### PR TITLE
Bruin CLI commands 

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -36,8 +36,8 @@ function activate(context) {
 
 	let bruinRenderDisposable = vscode.commands.registerCommand(BRUIN_RENDER_COMMAND_ID, async () => {
 		const columnToShowIn = vscode.window.activeTextEditor
-        ? vscode.ViewColumn.Beside
-        : undefined;
+			? vscode.ViewColumn.Beside
+			: undefined;
 
 		if (isEditorActive() && isFileExtensionSQL()) {
 			const sqlAssetPath = vscode.window.activeTextEditor.document.fileName;
@@ -53,7 +53,7 @@ function activate(context) {
 					columnToShowIn || vscode.window.activeTextEditor.viewColumn, // Editor column to show the new webview panel in.
 					{} // Webview options. More on these later.
 				);
-				
+
 				panel.onDidDispose(
 					() => {
 						panel = undefined;
@@ -76,7 +76,7 @@ function activate(context) {
 }
 
 // This method is called when your extension is deactivated
-function deactivate() { 
+function deactivate() {
 	// Left empty intentionally
 }
 
@@ -129,7 +129,7 @@ function getWebviewContent(renderedSql, filePath) {
 
 /**
  * Checks if the Bruin executable is available.
- * @returns {Promise<boolean>}
+ * @returns {Boolean}
  */
 function checkBruinBinary() {
 	try {
@@ -139,14 +139,16 @@ function checkBruinBinary() {
 		}
 	} catch (error) {
 		console.error(error);
-		return;
+		return true;
 	}
+	return false;
 }
 
 module.exports = {
 	activate,
 	deactivate,
 	commandExcution,
-	checkBruinBinary
+	checkBruinBinary,
+	getWebviewContent
 }
 

--- a/extension.js
+++ b/extension.js
@@ -11,15 +11,10 @@ const vscode = require('vscode');
  */
 function activate(context) {
 	//
-	let bruinHelpDisposable = vscode.commands.registerCommand("bruin.help", () => {
-		exec("bruin --help", (error, stdout, stderr) => {
-			if (error) {
-				console.error(`exec error ${error}`);
-				return;
-			}
-			vscode.window.showInformationMessage(stdout);
-			vscode.window.showInformationMessage(stderr)
-		})
+	let bruinHelpDisposable = vscode.commands.registerCommand("bruin.help", async () => {
+		const outputCommand = await commandExcution("bruin --help");
+		vscode.window.showInformationMessage(outputCommand.stdout);
+		vscode.window.showErrorMessage(outputCommand.stderr)
 	})
 	context.subscriptions.push(bruinHelpDisposable);
 }
@@ -27,7 +22,20 @@ function activate(context) {
 // This method is called when your extension is deactivated
 function deactivate() { }
 
+
+function commandExcution(cliCommand) {
+	return new Promise((resolve) => {
+		exec(cliCommand, (error, stdout) => {
+			if (error) {
+				return resolve({ stderr: error.message });
+			}
+			return resolve({ stdout });
+		});
+	})
+}
+
 module.exports = {
 	activate,
-	deactivate
+	deactivate,
+	commandExcution
 }

--- a/extension.js
+++ b/extension.js
@@ -5,9 +5,13 @@ const vscode = require('vscode');
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
-const BRUIN_HELP_COMMAND_ID = "bruin.help"
+
 const BRUIN_WHICH_COMMAND = "which bruin"
+const BRUIN_HELP_COMMAND_ID = "bruin.help"
 const BRUIN_HELP_COMMAND = "bruin --help"
+const BRUIN_RENDER_COMMAND = "bruin render"
+const BRUIN_RENDER_COMMAND_ID = "bruin.renderSql"
+
 /**
  * @param {vscode.ExtensionContext} context
  */
@@ -17,12 +21,11 @@ function activate(context) {
 		return;
 	}
 
-	let bruinHelpDisposable = vscode.commands.registerCommand(BRUIN_HELP_COMMAND_ID, async () => {
-		let editor = vscode.window.activeTextEditor
-		let fileName = editor.document.fileName.toLocaleLowerCase();
-		let isFileExtensionSQL = fileName.substring(fileName.lastIndexOf(".") + 1, fileName.length)
 
-		if (editor && isFileExtensionSQL === "sql") {
+
+	let bruinHelpDisposable = vscode.commands.registerCommand(BRUIN_HELP_COMMAND_ID, async () => {
+
+		if (isEditorActive() && isFileExtensionSQL()) {
 			const outputCommand = await commandExcution(BRUIN_HELP_COMMAND);
 			vscode.window.showInformationMessage(outputCommand.stdout);
 			vscode.window.showErrorMessage(outputCommand.stderr)
@@ -31,14 +34,42 @@ function activate(context) {
 		}
 	})
 
+	let bruinRenderDisposable = vscode.commands.registerCommand(BRUIN_RENDER_COMMAND_ID, async () => {
+
+		if (isEditorActive() && isFileExtensionSQL()) {
+			const sqlAssetPath = vscode.window.activeTextEditor.document.fileName;
+			const outputCommand = await commandExcution(`${BRUIN_RENDER_COMMAND} ${sqlAssetPath}`);
+			const panel = vscode.window.createWebviewPanel(
+				'bruin', // Identifies the type of the webview. Used internally
+				'Render single SQL assset', // Title of the panel displayed to the user
+				vscode.ViewColumn.Beside, // Editor column to show the new webview panel in.
+				{} // Webview options. More on these later.
+			);
+			panel.webview.html = getWebviewContent(outputCommand.stdout, sqlAssetPath);
+
+			vscode.window.showErrorMessage(outputCommand.stderr)
+		} else {
+			vscode.window.showErrorMessage('Please trigger Bruin for SQL files');
+		}
+	});
+
 	context.subscriptions.push(bruinHelpDisposable);
+	context.subscriptions.push(bruinRenderDisposable);
 	console.log("Bruin extension successfully activated")
 }
 
 // This method is called when your extension is deactivated
 function deactivate() { }
 
+function isEditorActive() {
+	return vscode.window.activeTextEditor
+}
 
+function isFileExtensionSQL() {
+	let fileName = vscode.window.activeTextEditor.document.fileName.toLocaleLowerCase();
+	let fileExtension = fileName.substring(fileName.lastIndexOf(".") + 1, fileName.length)
+	if (fileExtension === 'sql') return true
+}
 function commandExcution(cliCommand) {
 	return new Promise((resolve) => {
 		child_process.exec(cliCommand, (error, stdout) => {
@@ -50,6 +81,32 @@ function commandExcution(cliCommand) {
 	})
 }
 
+function getWebviewContent(renderedSql, filePath) {
+	return `<!DOCTYPE html>
+	<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>Render SQL File</title>
+		<style>
+			pre {
+				border: solid 1px;
+				padding: 10px;
+			}
+			.sql-header {
+				text-align: center;
+				font-weight: bold;
+				margin-top: 20px;
+				margin-bottom: 10px;
+			}
+	  </style>
+  </head>
+  <body>
+	  <pre class="sql-header">SQL File: ${filePath}</pre>
+	  <pre>${renderedSql}</pre>
+  </body>
+  </html>`;
+}
 
 /**
  * Checks if the Bruin executable is available.
@@ -73,3 +130,4 @@ module.exports = {
 	commandExcution,
 	checkBruinBinary
 }
+

--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,6 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
+const { exec } = require('child_process');
 const vscode = require('vscode');
 
 // This method is called when your extension is activated
@@ -10,10 +11,21 @@ const vscode = require('vscode');
  */
 function activate(context) {
 	//
+	let bruinHelpDisposable = vscode.commands.registerCommand("bruin.help", () => {
+		exec("bruin --help", (error, stdout, stderr) => {
+			if (error) {
+				console.error(`exec error ${error}`);
+				return;
+			}
+			vscode.window.showInformationMessage(stdout);
+			vscode.window.showInformationMessage(stderr)
+		})
+	})
+	context.subscriptions.push(bruinHelpDisposable);
 }
 
 // This method is called when your extension is deactivated
-function deactivate() {}
+function deactivate() { }
 
 module.exports = {
 	activate,

--- a/extension.js
+++ b/extension.js
@@ -1,22 +1,38 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-const { exec } = require('child_process');
+const child_process = require('child_process');
 const vscode = require('vscode');
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
-
+const BRUIN_HELP_COMMAND_ID = "bruin.help"
+const BRUIN_WHICH_COMMAND = "which bruin"
+const BRUIN_HELP_COMMAND = "bruin --help"
 /**
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
-	//
-	let bruinHelpDisposable = vscode.commands.registerCommand("bruin.help", async () => {
-		const outputCommand = await commandExcution("bruin --help");
-		vscode.window.showInformationMessage(outputCommand.stdout);
-		vscode.window.showErrorMessage(outputCommand.stderr)
+	if (checkBruinBinary()) {
+		vscode.window.showErrorMessage('Bruin executable not found');
+		return;
+	}
+
+	let bruinHelpDisposable = vscode.commands.registerCommand(BRUIN_HELP_COMMAND_ID, async () => {
+		let editor = vscode.window.activeTextEditor
+		let fileName = editor.document.fileName.toLocaleLowerCase();
+		let isFileExtensionSQL = fileName.substring(fileName.lastIndexOf(".") + 1, fileName.length)
+
+		if (editor && isFileExtensionSQL === "sql") {
+			const outputCommand = await commandExcution(BRUIN_HELP_COMMAND);
+			vscode.window.showInformationMessage(outputCommand.stdout);
+			vscode.window.showErrorMessage(outputCommand.stderr)
+		} else {
+			vscode.window.showErrorMessage('Please trigger Bruin for SQL files');
+		}
 	})
+
 	context.subscriptions.push(bruinHelpDisposable);
+	console.log("Bruin extension successfully activated")
 }
 
 // This method is called when your extension is deactivated
@@ -25,7 +41,7 @@ function deactivate() { }
 
 function commandExcution(cliCommand) {
 	return new Promise((resolve) => {
-		exec(cliCommand, (error, stdout) => {
+		child_process.exec(cliCommand, (error, stdout) => {
 			if (error) {
 				return resolve({ stderr: error.message });
 			}
@@ -34,8 +50,26 @@ function commandExcution(cliCommand) {
 	})
 }
 
+
+/**
+ * Checks if the Bruin executable is available.
+ * @returns {Promise<boolean>}
+ */
+function checkBruinBinary() {
+	try {
+		let output = child_process.execSync(BRUIN_WHICH_COMMAND);
+		if (!output) {
+			throw new Error("Bruin does not exists")
+		}
+	} catch (error) {
+		console.error(error);
+		return;
+	}
+}
+
 module.exports = {
 	activate,
 	deactivate,
-	commandExcution
+	commandExcution,
+	checkBruinBinary
 }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,16 @@
       }
     ],
     "menus": {
-      "editor/title/run": [
+      "editor/title": [
         {
           "command": "bruin.help",
-          "when": "resourceExtname == .sql"
+          "when": "resourceExtname == .sql",
+          "group": "navigation"
+        },
+        {
+          "command": "bruin.renderSql",
+          "when": "resourceExtname == .sql",
+          "group": "navigation"
         }
       ]
     },
@@ -42,6 +48,13 @@
         "title": "Help",
         "category": "Bruin",
         "icon":"$(lightbulb)"
+      },
+      {
+        "command": "bruin.renderSql",
+        "title": "Render single SQL asset",
+        "shortTitle": "Render SQL",
+        "category": "Bruin",
+        "icon":"$(rocket)"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "vscode": "^1.83.0"
   },
   "categories": [
-    "Data Science", "Formatters" 
+    "Data Science",
+    "Formatters"
   ],
   "icon": "images/bruin-logo-sm128.png",
   "activationEvents": [],
@@ -26,6 +27,22 @@
           "source.sql"
         ]
       }
+    ],
+    "menus": {
+      "editor/title/run": [
+        {
+          "command": "bruin.help",
+          "when": "resourceExtname == .sql"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "bruin.help",
+        "title": "Help",
+        "category": "Bruin",
+        "icon":"$(lightbulb)"
+      }
     ]
   },
   "scripts": {
@@ -34,13 +51,16 @@
     "test": "node ./test/runTest.js"
   },
   "devDependencies": {
-    "@types/vscode": "^1.83.0",
     "@types/mocha": "^10.0.2",
     "@types/node": "18.x",
+    "@types/vscode": "^1.83.0",
+    "@vscode/test-electron": "^2.3.4",
     "eslint": "^8.50.0",
     "glob": "^10.3.3",
     "mocha": "^10.2.0",
-    "typescript": "^5.2.2",
-    "@vscode/test-electron": "^2.3.4"
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "bruin": "^0.1.4"
   }
 }

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const child_process = require('child_process');
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
@@ -27,5 +28,31 @@ suite('Bruin Test Suite', () => {
 	test('should return an error message if the command does not exist', async () => {
 		const errorCommand = await bruinExtension.commandExcution('command-not-found');
 		assert.ok(errorCommand.stderr.includes("command not found"));
-	})
+	});
+
+	test('should generate correct HTML content for webview', () => {
+		const renderedSql = 'SELECT 1 as one;';
+		const filePath = '/path/to/file.sql';
+		const htmlContent = bruinExtension.getWebviewContent(renderedSql, filePath);
+	  
+		assert.ok(htmlContent.includes('<pre class="sql-header">SQL File: /path/to/file.sql</pre>'));
+		assert.ok(htmlContent.includes(`<pre>${renderedSql}</pre>`));
+	});
+
+	  
+	  test('should return an error message if Bruin binary does not exist', () => {
+		// Mock the child_process.execSync to simulate the absence of Bruin binary
+		const originalExecSync = child_process.execSync;
+		child_process.execSync = () => { throw new Error('Bruin does not exists'); };
+	  
+		const bruinNotInPath = bruinExtension.checkBruinBinary();
+		
+		// Restore the original function after the test
+		child_process.execSync = originalExecSync;
+	  
+		assert.strictEqual(bruinNotInPath, true);
+	  });
+	  
+	  
+	  
 });

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -3,13 +3,29 @@ const assert = require('assert');
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 const vscode = require('vscode');
-// const myExtension = require('../extension');
+const bruinExtension = require('../../extension');
 
-suite('Extension Test Suite', () => {
+suite('Bruin Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+	test('should return an object with stdout property', async () => {
+	  const outputCommand = await bruinExtension.commandExcution('bruin --help');
+	  assert.ok(outputCommand.hasOwnProperty('stdout'));
 	});
+	
+	test('should return an object with stdout containing the output of the bruin --help command', async () => {
+	  const expectedOutput = `bruin - The CLI used for managing Bruin-powered data pipelines`;
+	  const outputCommand = await bruinExtension.commandExcution('bruin --help');
+	assert.ok(outputCommand.stdout.includes(expectedOutput));
+	});
+
+	test('should return an error message if the command fails', async () => {
+		const errorCommand = await bruinExtension.commandExcution('bruin render null');
+	  assert.ok(errorCommand.stderr.includes("Command failed"));
+	});
+
+	test('should return an error message if the command does not exist', async () => {
+		const errorCommand = await bruinExtension.commandExcution('command-not-found');
+		assert.ok(errorCommand.stderr.includes("command not found"));
+	})
 });


### PR DESCRIPTION
This PR enhances Bruin VS Code extension by adding buttons for `bruin --help` and `bruin render` commands