### PR TITLE
Implement Custom Folding Range Functionality 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,17 @@
 				"${workspaceFolder}/out/**/*.js"
 			],
 			"preLaunchTask": "${defaultBuildTask}"
-		}
+		},
+		{
+			"name": "Extension Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+			  "--extensionDevelopmentPath=${workspaceFolder}",
+			  "--extensionTestsPath=${workspaceFolder}/out/test/extension.test"
+			],
+			"outFiles": ["${workspaceFolder}/out/test/*.js"],
+			"preLaunchTask": "${defaultBuildTask}"
+		  }
 	]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,4 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+**/*.js.map

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "Data Science", "Formatters" 
   ],
   "icon": "img/bruin-logo-sm128.png",
-  "activationEvents": [],
+  "activationEvents": [
+    "onLanguage:python",
+    "onLanguage:sql"
+  ],
   "main": "./out/extension.js",
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,18 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { bruinFoldingRangeProvider } from './providers/bruinFoldingRangeProvider';
 
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+	const disposable = vscode.languages.registerFoldingRangeProvider(['python', 'sql'],
+	{
+		provideFoldingRanges: bruinFoldingRangeProvider,
+	});
+
+	context.subscriptions.push(disposable);
 }
 
 // This method is called when your extension is deactivated

--- a/src/providers/bruinFoldingRangeProvider.ts
+++ b/src/providers/bruinFoldingRangeProvider.ts
@@ -1,0 +1,26 @@
+import * as vscode from 'vscode';
+import { getLangageDelimiters } from '../utils/delimiters';
+
+
+export const bruinFoldingRangeProvider = (
+    document: vscode.TextDocument
+) => {
+
+    let ranges : vscode.FoldingRange[] = [];
+    
+    
+    let {startFoldingRegionDelimiter, endFoldingRegionDelimiter} = getLangageDelimiters(document.languageId);
+
+    let foldingRegionStart = -1;
+    for(let i=0; i< document.lineCount; i++){
+        let textLine : string = document.lineAt(i).text;
+        if(startFoldingRegionDelimiter.test(textLine) && foldingRegionStart === -1){
+            foldingRegionStart = i;
+        }
+        else if(endFoldingRegionDelimiter.test(textLine) && foldingRegionStart !== -1){
+            ranges.push(new vscode.FoldingRange(foldingRegionStart, i, vscode.FoldingRangeKind.Region));
+        }
+    }
+
+return ranges;
+};

--- a/src/providers/bruinFoldingRangeProvider.ts
+++ b/src/providers/bruinFoldingRangeProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { getLangageDelimiters } from '../utils/delimiters';
 
 
-export const bruinFoldingRangeProvider = (
+export const bruinFoldingRangeProvider  = (
     document: vscode.TextDocument
 ) => {
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -3,13 +3,77 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import { bruinFoldingRangeProvider } from '../providers/bruinFoldingRangeProvider';
+import { test } from 'mocha';
 
-suite('Extension Test Suite', () => {
+function createMockTextDocument(content: string[], languageId: string): any {
+    return {
+        lineAt: (lineNumber: number) => {
+            return { text: content[lineNumber] };
+        },
+        lineCount: content.length,
+        languageId
+    };
+}
+
+
+
+suite('Folding Range Provider Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
+    const tests = [
+        {
+            languageId: 'python',
+            content: [
+                '""" @bruin',
+                'name: dashboard.bookings',
+                'type: python',
+                ' depends:',
+                ' - raw.Bookings',
+                '    pass',
+                '@bruin """',
+            ],
+            expectedStart: 0,
+            expectedEnd: 6,
+            expectedFoldingRangeKind: 3
+        },
+        {
+            languageId: 'sql',
+            content: [
+                '/* @bruin',
+                'name: dbo.hello_ms',
+                'type: ms.sql',
+                'materialization:',
+                '   type: table',
+                'columns:',
+                '  - name: one',
+                '    type: integer',
+                '    description: \'Just a number\'',
+                '    checks:',
+                '        - name: unique',
+                '        - name: not_null',
+                '        - name: positive',
+                '        - name: accepted_values',
+                '          value: [1, 2]',
+                '@bruin */',
+            ],
+            expectedStart: 0,
+            expectedEnd: 15,
+            expectedFoldingRangeKind: 3
+        }
+    ];
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
-});
+
+        tests.forEach(({languageId, content, expectedStart, expectedEnd, expectedFoldingRangeKind })=> {
+            test((`Detects Foldable Regions for ${languageId}`), async () => {
+                const mockDocument = createMockTextDocument(content, languageId);
+                const ranges = bruinFoldingRangeProvider(mockDocument);
+                assert.strictEqual(ranges.length, 1, "Should detect one foldable region");
+                assert.strictEqual(ranges[0].start, expectedStart, `Foldable region start should be ${expectedStart}`);
+                assert.strictEqual(ranges[0].end, expectedEnd, `Foldable region end should be ${expectedEnd}`);
+                assert.strictEqual(ranges[0].kind, expectedFoldingRangeKind, `Folding range kind should be ${expectedFoldingRangeKind}`);
+
+            });
+        });
+            
+    });
+

--- a/src/utils/delimiters.ts
+++ b/src/utils/delimiters.ts
@@ -1,0 +1,31 @@
+type BruinDelimiters = {
+    pyStartDelimiter: RegExp;
+    pyEndDelimiter: RegExp;
+    sqlStartDelimiter: RegExp;
+    sqlEndDelimiter: RegExp;
+};
+
+const bruinDelimiterRegex : BruinDelimiters = {
+    pyStartDelimiter : new RegExp('(\"\"\"\\s*@bruin)\\s*$'),
+    pyEndDelimiter : new RegExp('(^\\s*@bruin\\s*\"\"\")'),
+    sqlStartDelimiter : new RegExp('(\\/\\*\\s*@bruin)\\s*$'),
+    sqlEndDelimiter : new RegExp('(@bruin\\s*\\*\/)$')
+};
+
+export const getLangageDelimiters = (languageId: string)  => {
+    let startFoldingRegionDelimiter : RegExp = /$^/;
+    let endFoldingRegionDelimiter : RegExp = /$^/;
+
+    if(languageId === 'python'){
+         startFoldingRegionDelimiter = bruinDelimiterRegex.pyStartDelimiter;
+         endFoldingRegionDelimiter = bruinDelimiterRegex.pyEndDelimiter;
+    }
+    else if(languageId === 'sql'){
+        startFoldingRegionDelimiter = bruinDelimiterRegex.sqlStartDelimiter;
+        endFoldingRegionDelimiter = bruinDelimiterRegex.sqlEndDelimiter;
+    }
+    return {
+        startFoldingRegionDelimiter, 
+        endFoldingRegionDelimiter
+        };
+};


### PR DESCRIPTION
**Description:**

This PR introduces custom code folding range functionality to the Bruin VSCode extension. This new feature enables users to expand and collapse "bruin" regions within Python and SQL files, which are defined by specific delimiters.

**Screenshot:** 

![folding_range](https://github.com/bruin-data/bruin-vscode/assets/25383275/0ace97bf-3a7a-4d4b-a256-76cb21eec660)
