### PR TITLE
SQL Rendering and Dynamic Content Refresh in Webview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,12 @@
     "": {
       "name": "bruin",
       "version": "0.0.1",
+      "dependencies": {
+        "@vscode/webview-ui-toolkit": "^1.4.0"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
-        "@types/node": "18.x",
+        "@types/node": "^18.19.22",
         "@types/vscode": "^1.87.0",
         "@typescript-eslint/eslint-plugin": "^7.0.2",
         "@typescript-eslint/parser": "^7.0.2",
@@ -248,6 +251,47 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@microsoft/fast-element": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
+      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA=="
+    },
+    "node_modules/@microsoft/fast-foundation": {
+      "version": "2.49.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.5.tgz",
+      "integrity": "sha512-3PpG1BNmZ5kUM1goYU3SsxjsM2H7Rk0ZmpDJ7mnRhWDgKiM5SzJ02KvALRUqDrJQoeDnkW0Q2Q+r9SkEd68Gpg==",
+      "dependencies": {
+        "@microsoft/fast-element": "^1.12.0",
+        "@microsoft/fast-web-utilities": "^5.4.1",
+        "tabbable": "^5.2.0",
+        "tslib": "^1.13.0"
+      }
+    },
+    "node_modules/@microsoft/fast-foundation/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@microsoft/fast-react-wrapper": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.23.tgz",
+      "integrity": "sha512-iuL+J2AFKJ1mwUBxSp+bqzt4X93kQwj1jpVgHgw2VRzCOTl7wzta6X+lvRIVg4eoyLfmeVSMkB+q3PD87T/MyQ==",
+      "dependencies": {
+        "@microsoft/fast-element": "^1.12.0",
+        "@microsoft/fast-foundation": "^2.49.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0"
+      }
+    },
+    "node_modules/@microsoft/fast-web-utilities": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
+      "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
+      "dependencies": {
+        "exenv-es6": "^1.1.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -321,9 +365,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.21.tgz",
-      "integrity": "sha512-2Q2NeB6BmiTFQi4DHBzncSoq/cJMLDdhPaAoJFnFCyD9a8VPZRf7a1GAwp1Edb7ROaZc5Jz/tnZyL6EsWMRaqw==",
+      "version": "18.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.22.tgz",
+      "integrity": "sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -570,6 +614,20 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@vscode/webview-ui-toolkit": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.4.0.tgz",
+      "integrity": "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==",
+      "dependencies": {
+        "@microsoft/fast-element": "^1.12.0",
+        "@microsoft/fast-foundation": "^2.49.4",
+        "@microsoft/fast-react-wrapper": "^0.3.22",
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0"
       }
     },
     "node_modules/acorn": {
@@ -1213,6 +1271,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exenv-es6": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
+      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1717,6 +1780,12 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1825,6 +1894,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -2298,6 +2379,18 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -2646,6 +2739,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tabbable": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -2740,6 +2838,11 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "command": "bruin.renderSQL",
         "title": "Render SQL",
         "category": "Bruin",
-        "icon": "$(notebook-execute)",
+        "icon": "$(rocket)",
         "description": "Render SQL to a Bruin data asset."
       }
     ]

--- a/package.json
+++ b/package.json
@@ -36,6 +36,24 @@
           "source.python"
         ]
       }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "bruin.renderSQL",
+          "when": "resourceLangId == sql",
+          "group": "navigation"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "bruin.renderSQL",
+        "title": "Render SQL",
+        "category": "Bruin",
+        "icon": "$(notebook-execute)",
+        "description": "Render SQL to a Bruin data asset."
+      }
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "vscode": "^1.87.0"
   },
   "categories": [
-    "Data Science", "Formatters" 
+    "Data Science",
+    "Formatters"
   ],
   "icon": "img/bruin-logo-sm128.png",
   "activationEvents": [
@@ -30,8 +31,8 @@
         ]
       },
       {
-        "path":"./syntaxes/bruin-python-injection.json",
-        "scopeName":"python.docstring.block",
+        "path": "./syntaxes/bruin-python-injection.json",
+        "scopeName": "python.docstring.block",
         "injectTo": [
           "source.python"
         ]
@@ -65,14 +66,17 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.87.0",
     "@types/mocha": "^10.0.6",
-    "@types/node": "18.x",
+    "@types/node": "^18.19.22",
+    "@types/vscode": "^1.87.0",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
-    "eslint": "^8.56.0",
-    "typescript": "^5.3.3",
     "@vscode/test-cli": "^0.0.6",
-    "@vscode/test-electron": "^2.3.9"
+    "@vscode/test-electron": "^2.3.9",
+    "eslint": "^8.56.0",
+    "typescript": "^5.3.3"
+  },
+  "dependencies": {
+    "@vscode/webview-ui-toolkit": "^1.4.0"
   }
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,24 @@
+import { BruinDelimiters } from "../types";
+
+const bruinDelimiterRegex : BruinDelimiters = {
+    pyStartDelimiter : new RegExp('(\"\"\"\\s*@bruin)\\s*$'),
+    pyEndDelimiter : new RegExp('(^\\s*@bruin\\s*\"\"\")'),
+    sqlStartDelimiter : new RegExp('(\\/\\*\\s*@bruin)\\s*$'),
+    sqlEndDelimiter : new RegExp('(@bruin\\s*\\*\/)$')
+};
+
+const BRUIN_WHICH_COMMAND= 'which bruin';
+const BRUIN_RENDER_SQL_ID = 'bruin.renderSQL';
+const BRUIN_RENDER_SQL_COMMAND = 'bruin render';
+const BRUIN_HELP_COMMAND = 'bruin --help';
+const BRUIN_HELP_ID = 'bruin.help';
+
+
+export { 
+    bruinDelimiterRegex, 
+    BRUIN_WHICH_COMMAND, 
+    BRUIN_RENDER_SQL_ID, 
+    BRUIN_RENDER_SQL_COMMAND, 
+    BRUIN_HELP_COMMAND, 
+    BRUIN_HELP_ID 
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,69 +1,178 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode';
-import { bruinFoldingRangeProvider } from './providers/bruinFoldingRangeProvider';
-import { commandExecution, isBruinBinaryAvailable, isFileExtensionSQL } from './utils/bruinUtils';
-import { BRUIN_RENDER_SQL_ID, BRUIN_RENDER_SQL_COMMAND } from './constants';
-
+import * as vscode from "vscode";
+import { bruinFoldingRangeProvider } from "./providers/bruinFoldingRangeProvider";
+import {
+  commandExecution,
+  isBruinBinaryAvailable,
+  isFileExtensionSQL,
+} from "./utils/bruinUtils";
+import { BRUIN_RENDER_SQL_ID, BRUIN_RENDER_SQL_COMMAND } from "./constants";
+import * as path from "path";
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 
 export function activate(context: vscode.ExtensionContext) {
-	// if bruin is not installed, prompt a message to install and quit
-	if(!isBruinBinaryAvailable()){
-		vscode.window.showErrorMessage('Bruin is not installed');
-		return;
-	}
-	// register the folding range provider
-	const foldingDisposable = vscode.languages.registerFoldingRangeProvider(['python', 'sql'],
-	{
-		provideFoldingRanges: bruinFoldingRangeProvider,
-	});
+  // if bruin is not installed, prompt a message to install and quit
+  if (!isBruinBinaryAvailable()) {
+    vscode.window.showErrorMessage("Bruin is not installed");
+    return;
+  }
+  // register the folding range provider
+  const foldingDisposable = vscode.languages.registerFoldingRangeProvider(
+    ["python", "sql"],
+    {
+      provideFoldingRanges: bruinFoldingRangeProvider,
+    }
+  );
 
-	// create a webview panel to render the SQL
+  // create a webview panel to render the SQL
 
-	let panel: vscode.WebviewPanel | undefined = undefined;
-	let fileName : string = vscode.window.activeTextEditor?.document.fileName.toLocaleLowerCase() || '';
+  let panel: vscode.WebviewPanel | undefined = undefined;
 
-	
-	// register the command to render SQL
-	const renderDisposable = vscode.commands.registerCommand(BRUIN_RENDER_SQL_ID, async () => {
-		// check if the active file is a SQL file
+  // register the command to render SQL
+  const renderDisposable = vscode.commands.registerCommand(
+    BRUIN_RENDER_SQL_ID,
+    async () => {
+      // check if the active file is a SQL file
+      const activeEditor = vscode.window.activeTextEditor;
 
-		if(vscode.window.activeTextEditor && isFileExtensionSQL(fileName)){
-			const columnToShowIn = vscode.window.activeTextEditor ? vscode.ViewColumn.Beside : undefined;
-			const sqlAssetPath = vscode.window.activeTextEditor.document.fileName;
-			const outputCommand = await commandExecution(`${BRUIN_RENDER_SQL_COMMAND} ${sqlAssetPath}`);
+      if (activeEditor) {
+        let fileName: string =
+          activeEditor.document.fileName.toLocaleLowerCase();
 
-			if(panel) {
-				panel.reveal(columnToShowIn);
-			} else {
-				panel = vscode.window.createWebviewPanel(
-					'bruinSQL',
-					'Render single SQL asset', // Title of the panel 
-					columnToShowIn || vscode.ViewColumn.Beside,
-					{ // Webview options
-						enableScripts: true
-					}
-				);
-				panel.onDidDispose(
-					() => {
-					// When the panel is closed, cancel any future updates to the webview content
-					panel = undefined;
-					},
-					null,
-					context.subscriptions
-				);
+        if (isFileExtensionSQL(fileName)) {
+          const columnToShowIn = vscode.window.activeTextEditor
+            ? vscode.ViewColumn.Beside
+            : undefined;
+          const sqlAssetPath = activeEditor.document.fileName;
+          const outputCommand = await commandExecution(
+            `${BRUIN_RENDER_SQL_COMMAND} ${sqlAssetPath}`
+          );
+
+          const iconPath = vscode.Uri.file(
+            path.join(context.extensionPath, "img", "bruin-logo-sm128.png")
+          );
+
+          if (panel) {
+            panel.reveal(columnToShowIn);
+          } else {
+            panel = vscode.window.createWebviewPanel(
+              "bruinSQL",
+              "Render single SQL asset", // Title of the panel
+              columnToShowIn || vscode.ViewColumn.Beside,
+              {
+                // Webview options
+                enableScripts: true,
+              }
+            );
+            panel.iconPath = {
+              light: iconPath,
+              dark: iconPath,
+            };
+            panel.onDidDispose(
+              () => {
+                // When the panel is closed, cancel any future updates to the webview content
+                panel = undefined;
+              },
+              null,
+              context.subscriptions
+            );
+          }
+          panel.webview.html = getWebviewContent(outputCommand.stdout || "Something wrong", sqlAssetPath);
+		   // Listen for changes to the active editor's document
+		   const changeDocumentDisposable = vscode.workspace.onDidChangeTextDocument(async event => {
+			if (event.document.uri.toString() === activeEditor.document.uri.toString()) {
+				// Reload the webview content when the SQL document is modified
+				const modifiedOutputCommand =  await commandExecution(`${BRUIN_RENDER_SQL_COMMAND} ${sqlAssetPath}`);
+				panel && (panel.webview.html = getWebviewContent( modifiedOutputCommand.stdout || "Something wrong", sqlAssetPath));
+				vscode.window.showInformationMessage("SQL content has been modified");
 			}
-			panel.webview.html = "<h1>SQL</h1>";
-	}  else {
-		vscode.window.showErrorMessage('Please trigger Bruin for SQL files');
-	}
-	});
+		});
+		context.subscriptions.push(changeDocumentDisposable);
+        }
+      } else {
+        vscode.window.showErrorMessage("Please trigger Bruin for SQL files");
+      }
+    }
+  );
 
-	context.subscriptions.push(foldingDisposable, renderDisposable);
+  context.subscriptions.push(foldingDisposable, renderDisposable);
 }
+
+const getWebviewContent = (renderedSql: string, filePath: string) => { 
+	const themeKind = vscode.window.activeColorTheme.kind;
+    let themeCssUrl;
+
+	switch (themeKind) {
+        case vscode.ColorThemeKind.Light:
+            themeCssUrl = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css";
+            break;
+        case vscode.ColorThemeKind.Dark:
+            themeCssUrl = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/monokai.min.css";
+            break;
+        case vscode.ColorThemeKind.HighContrast:
+            themeCssUrl = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/darcula.min.css";
+            break;
+        default:
+            themeCssUrl = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css";
+            break;
+    }
+
+	return `
+	<!DOCTYPE html>
+	<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>SQL Content</title>
+		<link rel="stylesheet" href="${themeCssUrl}">
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>
+		<script>hljs.highlightAll();</script>
+		<style>
+			.copy-button {
+				cursor: pointer;
+				padding: 5px;
+				border: 1px solid #ccc;
+				background-color: #f9f9f9;
+			}
+			#copyFeedback {
+				display: none;
+				color: var(--vscode-editor-foreground);
+			}
+		</style>
+	</head>
+	<body>
+		<pre><code class="sql">${renderedSql /* Make sure this is safely encoded to prevent XSS */}</code></pre>
+			<div id="copyIcon" onclick="copyToClipboard()" style="cursor: pointer;">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+					<path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/>
+				</svg>
+			</div>
+			<div id="copyFeedback">Copied!</div>
+		<script>
+			function copyToClipboard() {
+				navigator.clipboard.writeText(\`${renderedSql /* Make sure this is safely encoded to prevent XSS */}\`).then(function() {
+					document.getElementById('copyIcon').style.display = 'none';
+					const copyFeedback = document.getElementById('copyFeedback');
+					copyFeedback.style.display = 'block';
+					
+					// Revert back to the icon after 2 seconds
+					setTimeout(() => {
+						copyFeedback.style.display = 'none';
+						document.getElementById('copyIcon').style.display = 'block';
+					}, 2000);
+				}, function(err) {
+					console.error('Could not copy text: ', err);
+				});
+			}
+		</script>
+	</body>
+	</html>
+	
+`;
+	};
 
 // This method is called when your extension is deactivated
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,17 +2,49 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import { bruinFoldingRangeProvider } from './providers/bruinFoldingRangeProvider';
+import { isBruinBinaryAvailable, isFileExtensionSQL } from './utils/bruinUtils';
 
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
+
 export function activate(context: vscode.ExtensionContext) {
-	const disposable = vscode.languages.registerFoldingRangeProvider(['python', 'sql'],
+	// if bruin is not installed, prompt a message to install and quit
+	if(!isBruinBinaryAvailable()){
+		vscode.window.showErrorMessage('Bruin is not installed');
+		return;
+	}
+	// register the folding range provider
+	const foldingDisposable = vscode.languages.registerFoldingRangeProvider(['python', 'sql'],
 	{
 		provideFoldingRanges: bruinFoldingRangeProvider,
 	});
 
-	context.subscriptions.push(disposable);
+	// create a webview panel to render the SQL
+
+	let panel: vscode.WebviewPanel | undefined = undefined;
+	let fileName : string = vscode.window.activeTextEditor?.document.fileName.toLocaleLowerCase() || '';
+
+	
+	// register the command to render SQL
+	const renderDisposable = vscode.commands.registerCommand('bruin.renderSQL', () => {
+		// check if the active file is a SQL file
+		if(isFileExtensionSQL(fileName)){
+			panel = vscode.window.createWebviewPanel(
+				'bruinSQL',
+				'Render single SQL asset',
+				vscode.ViewColumn.Beside,
+				{
+					enableScripts: true
+				}
+			);
+			panel.webview.html = "<h1>SQL</h1>";
+	}
+		vscode.window.showInformationMessage('Render SQL');
+	});
+
+	context.subscriptions.push(foldingDisposable);
+	context.subscriptions.push(renderDisposable);
 }
 
 // This method is called when your extension is deactivated

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,7 @@
+export type BruinDelimiters = {
+    pyStartDelimiter: RegExp;
+    pyEndDelimiter: RegExp;
+    sqlStartDelimiter: RegExp;
+    sqlEndDelimiter: RegExp;
+};
+

--- a/src/utils/bruinUtils.ts
+++ b/src/utils/bruinUtils.ts
@@ -1,0 +1,40 @@
+import { BRUIN_WHICH_COMMAND } from "../constants";
+import * as vscode from 'vscode';
+const { execSync } = require('child_process');
+
+const isBruinBinaryAvailable = () : boolean =>{
+    // check if bruin is installed
+    // if not, prompt  a message to install    
+    try {
+        let output = execSync(BRUIN_WHICH_COMMAND);
+        console.log(output.toString());
+
+        if(!output){
+            throw new Error('Bruin is not installed');
+        }
+        
+    } catch(e){
+        console.log(e);
+        return false;
+    }
+    return true;
+};
+
+// check if there is an active editor
+const isEditorActive = () : boolean => {
+    // insure that the function always returns a boolean, hence the double negation
+    return !!vscode.window.activeTextEditor;
+};
+
+const isFileExtensionSQL = (fileName: string) : boolean => {
+    fileName = fileName.toLowerCase();
+    let fileExtension = fileName.split('.').pop();
+
+    if(fileExtension === "sql"){
+        return true;
+    }
+    return false;
+};
+
+
+export { isBruinBinaryAvailable, isEditorActive, isFileExtensionSQL };

--- a/src/utils/bruinUtils.ts
+++ b/src/utils/bruinUtils.ts
@@ -1,6 +1,8 @@
 import { BRUIN_WHICH_COMMAND } from "../constants";
 import * as vscode from 'vscode';
 const { execSync } = require('child_process');
+// eslint-disable-next-line @typescript-eslint/naming-convention
+import * as child_process from 'child_process';
 
 const isBruinBinaryAvailable = () : boolean =>{
     // check if bruin is installed
@@ -37,4 +39,16 @@ const isFileExtensionSQL = (fileName: string) : boolean => {
 };
 
 
-export { isBruinBinaryAvailable, isEditorActive, isFileExtensionSQL };
+const commandExecution = (cliCommand: string): Promise<{ stderr?: string; stdout?: string }> => {
+    return new Promise((resolve) => {
+        child_process.exec(cliCommand, (error: child_process.ExecException | null, stdout: string) => {
+            if (error) {
+                return resolve({ stderr: error.message });
+            }
+            return resolve({ stdout });
+        });
+    });
+};
+
+
+export { isBruinBinaryAvailable, isEditorActive, isFileExtensionSQL, commandExecution };

--- a/src/utils/delimiters.ts
+++ b/src/utils/delimiters.ts
@@ -1,16 +1,5 @@
-type BruinDelimiters = {
-    pyStartDelimiter: RegExp;
-    pyEndDelimiter: RegExp;
-    sqlStartDelimiter: RegExp;
-    sqlEndDelimiter: RegExp;
-};
+import { bruinDelimiterRegex } from "../constants";
 
-const bruinDelimiterRegex : BruinDelimiters = {
-    pyStartDelimiter : new RegExp('(\"\"\"\\s*@bruin)\\s*$'),
-    pyEndDelimiter : new RegExp('(^\\s*@bruin\\s*\"\"\")'),
-    sqlStartDelimiter : new RegExp('(\\/\\*\\s*@bruin)\\s*$'),
-    sqlEndDelimiter : new RegExp('(@bruin\\s*\\*\/)$')
-};
 
 export const getLangageDelimiters = (languageId: string)  => {
     let startFoldingRegionDelimiter : RegExp = /$^/;


### PR DESCRIPTION
###  PR Overview

- This PR introduces the functionality for rendering SQL content within a dedicated Webview. This feature is activated via a specific command (click the "Rocket" button).

![Render SQL](https://github.com/bruin-data/bruin-vscode/assets/25383275/cce6ace5-5003-40ae-bd4e-ad6f38ba8e43)


- Introduced a user-friendly copy-to-clipboard feature, represented by an intuitive icon within the Webview that makes it easier for users to copy the rendered SQL content with a simple click.


![Copy rendered SQL](https://github.com/bruin-data/bruin-vscode/assets/25383275/df956ea5-eef1-4665-9e3d-b7d440151334)

- The Webview dynamically matches the VS Code's active theme. Whether users prefer light, dark, or high-contrast themes, the Webview content adapts accordingly.


![Theme Matching](https://github.com/bruin-data/bruin-vscode/assets/25383275/f41d1ae4-7783-4f96-b1dc-5d9377261fc5)

- Implemented a live refresh feature to automatically refresh the Webview content whenever the underlying SQL file is updated. 

![automatic refresh ](https://github.com/bruin-data/bruin-vscode/assets/25383275/bd4c620d-3771-4391-8859-b26f42a9d40d)
