### PR TITLE
Automatic Rerendering of SQL View on File Change and Error Message Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Bruin extension will be documented in this file.
 
+## [0.1.1] - [2024-03-13]
+
+## Fixed
+- Fixed the screenshots on the readme 
 
 ## [0.1.0] - [2024-03-13]
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 - **Syntax Coloring**: Applies YAML syntax coloring to Bruin code in SQL files (enclosed between `/* @bruin ... @bruin */`) and Python files (enclosed between `""" @bruin ... @bruin """`).
 
-    ![Screenshot of Syntaxe Coloring](./screenshots/syntaxe-coloring.png)
+    ![Screenshot of Syntaxe Coloring](https://github.com/bruin-data/bruin-vscode/blob/main/screenshots/syntaxe-coloring.png?raw=true)
 
 - **Folding Range Provider**: Allows folding and unfolding Bruin code regions in SQL and Python files for a cleaner workspace.
 - **Dynamic SQL Content Viewer**: Renders SQL content within a VS Code Webview, enabling content copying, and automatically refreshing on file updates.
 
-    ![Screenshot of Bruin Extension Features](./screenshots/bruin_extension_features.gif)
+    ![Screenshot of Bruin Extension Features](https://github.com/bruin-data/bruin-vscode/blob/main/screenshots/bruin_extension_features.gif?raw=true)
 
 - **Adapting to theme changes**: the SQL Content Viewer matches the vscode current theme (dark/light/Dark high contrast)
 
-    ![Screenshot of SQL viewer Theme Updates](./screenshots/theme-updates.gif)
+    ![Screenshot of SQL viewer Theme Updates](https://github.com/bruin-data/bruin-vscode/blob/main/screenshots/theme-updates.gif?raw=true)
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@vscode/webview-ui-toolkit": "^1.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "engines": {
     "vscode": "^1.87.0"
   },


### PR DESCRIPTION
# PR Overview

- This PR enables the automatic rerendering of the SQL content whenever the file is modified. This ensures that the SQL view stays up to date with the latest changes. 
- It also fixes an issue where error messages were incorrectly displayed in the view when encountering problems with the Bruin CLI command. 

![change-content-onfile-change](https://github.com/bruin-data/bruin-vscode/assets/25383275/0de82660-bd41-45f2-ba4f-4ecc95886e07)
