### PR TITLE
Move Webview panel logic to a separate file

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,204 +3,30 @@
 import * as vscode from "vscode";
 import { bruinFoldingRangeProvider } from "./providers/bruinFoldingRangeProvider";
 import {
-  commandExecution,
-  encodeHTML,
   isBruinBinaryAvailable,
-  isFileExtensionSQL,
 } from "./utils/bruinUtils";
-import { BRUIN_RENDER_SQL_ID, BRUIN_RENDER_SQL_COMMAND } from "./constants";
-import * as path from "path";
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
+import { BruinMainPanel } from './panels/BruinMainPanel';
 
 export function activate(context: vscode.ExtensionContext) {
-  // if bruin is not installed, prompt a message to install and quit
-  if (!isBruinBinaryAvailable()) {
-    vscode.window.showErrorMessage("Bruin is not installed");
-    return;
-  }
-  // register the folding range provider
-  const foldingDisposable = vscode.languages.registerFoldingRangeProvider(
-    ["python", "sql"],
-    {
-      provideFoldingRanges: bruinFoldingRangeProvider,
+    if (!isBruinBinaryAvailable()) {
+        vscode.window.showErrorMessage("Bruin is not installed");
+        return;
     }
-  );
-
-  // create a webview panel to render the SQL
-
-  let panel: vscode.WebviewPanel | undefined = undefined;
-
-  // register the command to render SQL
-  const renderDisposable = vscode.commands.registerCommand(
-    BRUIN_RENDER_SQL_ID,
-    async () => {
-      // check if the active file is a SQL file
-      const activeEditor = vscode.window.activeTextEditor;
-
-      if (activeEditor) {
-        let fileName: string =
-          activeEditor.document.fileName.toLocaleLowerCase();
-
-        if (isFileExtensionSQL(fileName)) {
-          const columnToShowIn = vscode.window.activeTextEditor
-            ? vscode.ViewColumn.Beside
-            : undefined;
-          const sqlAssetPath = activeEditor.document.fileName;
-          const outputCommand = await commandExecution(
-            `${BRUIN_RENDER_SQL_COMMAND} ${sqlAssetPath}`
-          );
-
-          const iconPath = vscode.Uri.file(
-            path.join(context.extensionPath, "img", "bruin-logo-sm128.png")
-          );
-
-          if (panel) {
-            panel.reveal(columnToShowIn);
-          } else {
-            panel = vscode.window.createWebviewPanel(
-              "bruinSQL",
-              "Render single SQL asset", // Title of the panel
-              columnToShowIn || vscode.ViewColumn.Beside,
-              {
-                // Webview options
-                enableScripts: true,
-              }
-            );
-            panel.iconPath = {
-              light: iconPath,
-              dark: iconPath,
-            };
-            panel.onDidDispose(
-              () => {
-                // When the panel is closed, cancel any future updates to the webview content
-                panel = undefined;
-              },
-              null,
-              context.subscriptions
-            );
-          }
-          panel.webview.html = getWebviewContent(outputCommand.stdout || "Something wrong first", sqlAssetPath);
-
-          async function showWebviewContent(currentSqlAssetPath: string) {
-            if (!panel) {return;}
-          
-            const { stdout, stderr } = await commandExecution(`${BRUIN_RENDER_SQL_COMMAND} ${currentSqlAssetPath}`);
-          
-            if (stderr) {
-              console.error('Error executing Bruin CLI:', stderr);
-              panel.webview.html = `<html><body><p>Error: ${encodeHTML(stderr)}</p></body></html>`;
-              return;
-            }
-          
-            panel.webview.html = getWebviewContent(stdout as string, currentSqlAssetPath);
-          }
-    
-      // Listen for changes to the active editor's document
-      const changeDocumentDisposable = vscode.workspace.onDidChangeTextDocument(async event => {
-        if (panel && event.document.uri.fsPath === sqlAssetPath) {
-          await showWebviewContent(activeEditor.document.fileName);
-        }
-      });
-       // Listen for changes to the active editor's document
-       const changeFileDisposable = vscode.window.onDidChangeActiveTextEditor(async event => {
-        const activeEditor = vscode.window.activeTextEditor;
-        if (panel && activeEditor) {
-          await showWebviewContent(activeEditor.document.fileName);
-        }
-      });
-    
-      // Listen for theme changes
-      const changeThemeDisposable = vscode.window.onDidChangeActiveColorTheme(async () => {
-        if (panel) {
-          await showWebviewContent(activeEditor.document.fileName);
-        }
-      });
-
-		context.subscriptions.push(changeDocumentDisposable, changeThemeDisposable, changeFileDisposable);
-        }
-      } else {
-        vscode.window.showErrorMessage("Please trigger Bruin for SQL files");
+    const foldingDisposable = vscode.languages.registerFoldingRangeProvider(
+      ["python", "sql"],
+      {
+        provideFoldingRanges: bruinFoldingRangeProvider,
       }
-    }
-  );
-
-  context.subscriptions.push(foldingDisposable, renderDisposable);
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('bruin.renderSQL', () => {
+            BruinMainPanel.createOrShow(context.extensionUri, context);
+        }),
+        foldingDisposable
+    );
 }
 
-const getWebviewContent = (renderedSql: string, filePath: string) => { 
-	const themeKind = vscode.window.activeColorTheme.kind;
-    let themeCssUrl;
-
-	switch (themeKind) {
-        case vscode.ColorThemeKind.Light:
-            themeCssUrl = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css";
-            break;
-        case vscode.ColorThemeKind.Dark:
-            themeCssUrl = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/monokai.min.css";
-            break;
-        case vscode.ColorThemeKind.HighContrast:
-            themeCssUrl = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/darcula.min.css";
-            break;
-        default:
-            themeCssUrl = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css";
-            break;
-    }
-
-	return `
-	<!DOCTYPE html>
-	<html lang="en">
-	<head>
-		<meta charset="UTF-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<title>SQL Content</title>
-		<link rel="stylesheet" href="${themeCssUrl}">
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>
-		<script>hljs.highlightAll();</script>
-		<style>
-			.copy-button {
-				cursor: pointer;
-				padding: 5px;
-				border: 1px solid #ccc;
-				background-color: #f9f9f9;
-			}
-			#copyFeedback {
-				display: none;
-				color: var(--vscode-editor-foreground);
-			}
-		</style>
-	</head>
-	<body>
-		<pre><code class="sql">${encodeHTML(renderedSql)}</code></pre>
-			<div id="copyIcon" onclick="copyToClipboard()" style="cursor: pointer;">
-				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-					<path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/>
-				</svg>
-			</div>
-			<div id="copyFeedback">Copied!</div>
-		<script>
-			function copyToClipboard() {
-				navigator.clipboard.writeText(\`${encodeHTML(renderedSql)}\`).then(function() {
-					document.getElementById('copyIcon').style.display = 'none';
-					const copyFeedback = document.getElementById('copyFeedback');
-					copyFeedback.style.display = 'block';
-					
-					// Revert back to the icon after 2 seconds
-					setTimeout(() => {
-						copyFeedback.style.display = 'none';
-						document.getElementById('copyIcon').style.display = 'block';
-					}, 2000);
-				}, function(err) {
-					console.error('Could not copy text: ', err);
-				});
-			}
-		</script>
-	</body>
-	</html>
-	
-`;
-	};
 
 // This method is called when your extension is deactivated
 export function deactivate() {}

--- a/src/panels/BruinMainPanel.ts
+++ b/src/panels/BruinMainPanel.ts
@@ -1,0 +1,213 @@
+import * as vscode from "vscode";
+import {
+  commandExecution,
+  encodeHTML,
+  isFileExtensionSQL,
+} from "../utils/bruinUtils";
+import { BRUIN_RENDER_SQL_COMMAND } from "../constants";
+
+export class BruinMainPanel {
+  private static currentPanel: BruinMainPanel | undefined;
+  private readonly panel: vscode.WebviewPanel;
+  private readonly extensionUri: vscode.Uri;
+  private disposables: vscode.Disposable[] = [];
+
+  public static createOrShow(
+    extensionUri: vscode.Uri,
+    context: vscode.ExtensionContext
+  ) {
+    const columnToShowIn = vscode.window.activeTextEditor
+      ? vscode.ViewColumn.Beside
+      : undefined;
+
+    if (BruinMainPanel.currentPanel) {
+      BruinMainPanel.currentPanel.panel.reveal(columnToShowIn);
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      "bruinSQL",
+      "Render single SQL asset",
+      columnToShowIn || vscode.ViewColumn.Beside,
+      {
+        enableScripts: true,
+        localResourceRoots: [vscode.Uri.joinPath(extensionUri, "img")],
+        retainContextWhenHidden: true,
+      }
+    );
+
+    BruinMainPanel.currentPanel = new BruinMainPanel(
+      panel,
+      extensionUri,
+      context
+    );
+  }
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    extensionUri: vscode.Uri,
+    context: vscode.ExtensionContext
+  ) {
+    this.panel = panel;
+    this.extensionUri = extensionUri;
+
+    // Set the icon path
+    const iconPath = vscode.Uri.joinPath(
+      extensionUri,
+      "img",
+      "bruin-logo-sm128.png"
+    );
+    this.panel.iconPath = { light: iconPath, dark: iconPath };
+
+    // Update content when the panel is initially displayed
+    this.update();
+
+    // Listen for when the panel is disposed
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+
+    // React to content changes
+    const changeDocumentDisposable = vscode.workspace.onDidChangeTextDocument(
+      (event) => {
+        if (
+          event.document.uri.toString() ===
+          vscode.window.activeTextEditor?.document.uri.toString()
+        ) {
+          this.update();
+        }
+      }
+    );
+    // React to file changes
+
+    const changeFileDisposable = vscode.window.onDidChangeActiveTextEditor(
+      async (event) => {
+        const activeEditor = vscode.window.activeTextEditor;
+        if (panel && activeEditor) {
+          this.update();
+        }
+      }
+    );
+    
+    // React to theme changes
+    const changeThemeDisposable = vscode.window.onDidChangeActiveColorTheme(
+      () => {
+        this.update();
+      }
+    );
+
+    this.disposables.push(changeDocumentDisposable, changeThemeDisposable);
+  }
+
+  private update() {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (activeEditor && isFileExtensionSQL(activeEditor.document.fileName)) {
+      commandExecution(
+        `${BRUIN_RENDER_SQL_COMMAND} ${activeEditor.document.fileName}`
+      )
+        .then(({ stdout, stderr }) => {
+          this.panel.webview.html = stderr
+            ? this.getErrorContent(stderr)
+            : this.getWebviewContent(stdout as string);
+        })
+        .catch((err) => {
+          console.error(err);
+          this.panel.webview.html = this.getErrorContent(
+            "Failed to execute Bruin CLI command."
+          );
+        });
+    }
+  }
+
+  private getWebviewContent = (renderedSql: string) => {
+    const themeKind = vscode.window.activeColorTheme.kind;
+    let themeCssUrl;
+
+    switch (themeKind) {
+      case vscode.ColorThemeKind.Light:
+        themeCssUrl =
+          "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css";
+        break;
+      case vscode.ColorThemeKind.Dark:
+        themeCssUrl =
+          "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/monokai.min.css";
+        break;
+      case vscode.ColorThemeKind.HighContrast:
+        themeCssUrl =
+          "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/darcula.min.css";
+        break;
+      default:
+        themeCssUrl =
+          "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/styles/default.min.css";
+        break;
+    }
+
+    return `
+	<!DOCTYPE html>
+	<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>SQL Content</title>
+		<link rel="stylesheet" href="${themeCssUrl}">
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"></script>
+		<script>hljs.highlightAll();</script>
+		<style>
+			.copy-button {
+				cursor: pointer;
+				padding: 5px;
+				border: 1px solid #ccc;
+				background-color: #f9f9f9;
+			}
+			#copyFeedback {
+				display: none;
+				color: var(--vscode-editor-foreground);
+			}
+		</style>
+	</head>
+	<body>
+		<pre><code class="sql">${encodeHTML(renderedSql)}</code></pre>
+			<div id="copyIcon" onclick="copyToClipboard()" style="cursor: pointer;">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+					<path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/>
+				</svg>
+			</div>
+			<div id="copyFeedback">Copied!</div>
+		<script>
+			function copyToClipboard() {
+				navigator.clipboard.writeText(\`${encodeHTML(renderedSql)}\`).then(function() {
+					document.getElementById('copyIcon').style.display = 'none';
+					const copyFeedback = document.getElementById('copyFeedback');
+					copyFeedback.style.display = 'block';
+					
+					// Revert back to the icon after 2 seconds
+					setTimeout(() => {
+						copyFeedback.style.display = 'none';
+						document.getElementById('copyIcon').style.display = 'block';
+					}, 2000);
+				}, function(err) {
+					console.error('Could not copy text: ', err);
+				});
+			}
+		</script>
+	</body>
+	</html>
+	
+`;
+  };
+
+  private getErrorContent(errorMessage: string): string {
+    // Use encodeHTML for safe rendering
+    return `<!DOCTYPE html>...${encodeHTML(errorMessage)}`;
+  }
+
+  private dispose() {
+    BruinMainPanel.currentPanel = undefined;
+
+    // Dispose all disposables
+    while (this.disposables.length) {
+      const x = this.disposables.pop();
+      if (x) {
+        x.dispose();
+      }
+    }
+  }
+}


### PR DESCRIPTION
# PR Overview

- This PR refactors the Bruin VSCode extension's codebase, isolating the functionality into a separate panel component (`BruinMainPanel` class).
- The aim is to pave the way for adding more complex features to the extension.