### PR TITLE
Add folding settings to the extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,16 @@
   },
   "publisher": "bruin",
   "contributes": {
+    "configuration": {
+      "properties": {
+      "bruin.defaultFoldingState": {
+      "type": "string",
+      "enum": ["folded", "expanded"],
+      "default": "folded",
+      "description": "Sets the default folding state for custom Bruin foldable regions in Python and SQL files."
+      }
+      }
+      },
     "grammars": [
       {
         "path": "./syntaxes/bruin-sql-injection.json",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,32 +1,59 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
-import { bruinFoldingRangeProvider } from "./providers/bruinFoldingRangeProvider";
-import {
-  isBruinBinaryAvailable,
-} from "./utils/bruinUtils";
 
-import { BruinMainPanel } from './panels/BruinMainPanel';
+import { bruinFoldingRangeProvider } from "./providers/bruinFoldingRangeProvider";
+
+import { isBruinBinaryAvailable } from "./utils/bruinUtils";
+
+import { BruinMainPanel } from "./panels/BruinMainPanel";
 
 export function activate(context: vscode.ExtensionContext) {
-    if (!isBruinBinaryAvailable()) {
-        vscode.window.showErrorMessage("Bruin is not installed");
-        return;
+  if (!isBruinBinaryAvailable()) {
+    vscode.window.showErrorMessage("Bruin is not installed");
+
+    return;
+  }
+
+  const foldingDisposable = vscode.languages.registerFoldingRangeProvider(
+    ["python", "sql"],
+
+    {
+      provideFoldingRanges: bruinFoldingRangeProvider,
     }
-    const foldingDisposable = vscode.languages.registerFoldingRangeProvider(
-      ["python", "sql"],
-      {
-        provideFoldingRanges: bruinFoldingRangeProvider,
-      }
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand('bruin.renderSQL', () => {
-            BruinMainPanel.createOrShow(context.extensionUri, context);
-        }),
-        foldingDisposable
-    );
+  );
+
+  applyFoldingStateBasedOnConfiguration();
+
+  // Listen for configuration changes to apply folding state
+
+  vscode.workspace.onDidChangeConfiguration((e) => {
+    if (e.affectsConfiguration("bruin.defaultFoldingState")) {
+      applyFoldingStateBasedOnConfiguration();
+    }
+  });
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("bruin.renderSQL", () => {
+      BruinMainPanel.createOrShow(context.extensionUri, context);
+    }),
+
+    foldingDisposable,
+
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      applyFoldingStateBasedOnConfiguration();
+    })
+  );
 }
 
-
 // This method is called when your extension is deactivated
+
 export function deactivate() {}
+
+function applyFoldingStateBasedOnConfiguration() {
+  const config = vscode.workspace.getConfiguration();
+
+  const defaultFoldingState = config.get("bruin.defaultFoldingState", "folded");
+
+  if (defaultFoldingState === "folded" && vscode.window.activeTextEditor) {
+    vscode.commands.executeCommand("editor.foldAllMarkerRegions");
+  }
+}


### PR DESCRIPTION
# PR Overview:

- This PR adds settings to the VSCode extension.
- Users can choose whether they want the Bruin code regions to be folded or expanded by default. 

<img width="565" alt="bruin-settings" src="https://github.com/bruin-data/bruin-vscode/assets/25383275/e35c3bf2-0262-4873-985f-55f6946358a4">

- The code regions introduced by the Bruin extension are folded by default,

![auto-fold](https://github.com/bruin-data/bruin-vscode/assets/25383275/e15c4832-b8b3-4cbf-bd0f-5b38cd60cae1)

## Important to know:
- Currently, VSCode does not support folding specific custom regions, the setting will fold all regions identified as foldable, including those created by Bruin.