### PR TITLE
Fix the bruin exe command on windows

### DIFF
--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -14,19 +14,12 @@ export function getDefaultBruinExecutablePath(): string {
   const bruinConfig = vscode.workspace.getConfiguration("bruin");
   const bruinExecutable = bruinConfig.get<string>("executable") || "";
   if (bruinExecutable.length === 0) {
-    return _defaultBruinExecutablePath();
+    return "bruin";
   }
   return bruinExecutable;
 }
 
-function _defaultBruinExecutablePath(): string {
-  switch (process.platform) {
-    case "win32":
-      return "cmd.exe /c bruin.exe";
-    default:
-      return "bruin";
-  }
-}
+
 
 let documentInitState = new Map();
 


### PR DESCRIPTION
# PR Overview:

This PR addresses and resolves the functionality issues with the VSCode extension on Windows platforms. Previously, the extension was failing to display the rendered SQL and lineage data. Additionally, the 'Validate' and 'Run' buttons were not functioning correctly. This update ensures all features operate as intended across Windows environments.