### PR TITLE
Fix the 'SQL Preview' visibility when the file isn't a bruin asset

### DIFF
--- a/src/bruin/bruinRender.ts
+++ b/src/bruin/bruinRender.ts
@@ -1,7 +1,7 @@
 import { BruinPanel } from "../panels/BruinPanel";
 import { BruinCommand } from "./bruinCommand";
 import { BruinCommandOptions } from "../types";
-import { isPythonBruinAsset } from "../utilities/helperUtils";
+import { isBruinAsset, isPythonBruinAsset } from "../utilities/helperUtils";
 
 /**
  * Extends the BruinCommand class to implement the rendering process specific to Bruin assets.
@@ -30,19 +30,20 @@ export class BruinRender extends BruinCommand {
     filePath: string,
     { flags = [], ignoresErrors = false }: BruinCommandOptions = {}
   ): Promise<void> {
-    if (!filePath.endsWith(".sql")) {
-      if (!isPythonBruinAsset(filePath)) {
+      if (!isBruinAsset(filePath, ["py", "sql"])) {
         BruinPanel.currentPanel?.postMessage("render-message", {
           status: "non-assset-alert",
           message: "-- This is not a BRUIN asset --",
         });
+        return;
       } else {
+        if (await isPythonBruinAsset(filePath)){
         BruinPanel.currentPanel?.postMessage("render-message", {
           status: "py-asset-alert",
           message: "-- Python BRUIN asset detected --",
         });
+        return;
       }
-      return;
     }
     await this.run([...flags, filePath], { ignoresErrors }).then(
       (sqlRendered) => {

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -30,6 +30,8 @@ export const isBruinAsset = async (
 
   const fileExtension = fileName.split(".").pop()?.toLowerCase() || "";
 
+  
+
   if (!validAssetExtentions.includes(fileExtension)) {
     return false;
   }
@@ -37,7 +39,7 @@ export const isBruinAsset = async (
   const bruinPattern = /(\"\"\"\s*@bruin\s*$)|(\/\*\s*@bruin\s*$)/m;
 
   try {
-    const assetContent = await fs.readFileSync(fileName, "utf8");
+    const assetContent = fs.readFileSync(fileName, "utf8");
     return bruinPattern.test(assetContent);
   } catch (err) {
     return false;

--- a/webview-ui/src/components/AssetDetails.vue
+++ b/webview-ui/src/components/AssetDetails.vue
@@ -84,6 +84,7 @@ const validationError = ref(null);
 const renderSQLAssetSuccess = ref(null);
 const renderPythonAsset = ref(null);
 const renderSQLAssetError = ref(null);
+const renderAssetAlert = ref(null);
 const validateButtonStatus = ref("" as "validated" | "failed" | "loading" | null);
 const tzoffset = new Date().getTimezoneOffset() * 60000; //offset in milliseconds
 //startDate := time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 0, 0, 0, 0, time.UTC)
@@ -170,7 +171,7 @@ function receiveMessage(event: { data: any }) {
       renderSQLAssetSuccess.value = updateValue(envelope, "success");
       renderSQLAssetError.value = updateValue(envelope, "error");
       renderPythonAsset.value = updateValue(envelope, "py-asset-alert");
-
+      renderAssetAlert.value = updateValue(envelope, "non-asset-alert");
       code.value = renderSQLAssetSuccess.value || renderPythonAsset.value;
       language.value = renderSQLAssetSuccess.value ? "sql" : "python";
 

--- a/webview-ui/src/components/AssetLineage.vue
+++ b/webview-ui/src/components/AssetLineage.vue
@@ -18,7 +18,6 @@
 
 <script setup lang="ts">
 
-import { vscode } from '@/utilities/vscode';
 import { onBeforeUnmount, onMounted, ref } from "vue";
 import ErrorAlert from "@/components/ErrorAlert.vue";
 import { updateValue } from "@/utilities/helper";


### PR DESCRIPTION
# PR Overview

- This PR addresses the issue of SQL Preview visibility in files that are not classified as Bruin assets.

## Key Changes
- SQL Preview is now exclusively available when the current file is identified as a SQL Bruin Asset.
- For files that are neither SQL nor Python files (e.g., .yml files), the SQL Preview will be hidden, and both the `validate` and `run` buttons will be disabled.
- When the current file is a Bruin Python Asset, SQL Preview will not be displayed, but the `validate` and `run` buttons will remain active and can be used.