### PR TITLE
Add buttons with dropdown

### DIFF
--- a/src/bruin/bruinUtils.ts
+++ b/src/bruin/bruinUtils.ts
@@ -84,8 +84,8 @@ export const bruinWorkspaceDirectory = (fsPath: string): string | undefined => {
  */
 
 export const runInIntegratedTerminal = async (
-  assetPath: string,
   workingDir: string | undefined,
+  assetPath?: string,
   flags?: string
 ) => {
   const command = `bruin ${BRUIN_RUN_SQL_COMMAND} ${flags} ${assetPath}`;

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -217,9 +217,9 @@ export class BruinPanel {
               getDefaultBruinExecutablePath(),
               bruinWorkspaceDir!!
             );
-
+            const flags = message.payload;
             await validator.validate(filePath, {
-              flags: ["-o", "json"],
+              flags: ["-o", "json", flags],
             });
             break;
           case "bruin.runSql":
@@ -227,7 +227,7 @@ export class BruinPanel {
               return;
             }
             const fPath = this._lastRenderedDocumentUri?.fsPath;
-            runInIntegratedTerminal(fPath, bruinWorkspaceDirectory(fPath), message.payload);
+            runInIntegratedTerminal( bruinWorkspaceDirectory(fPath), fPath, message.payload);
 
             setTimeout(() => {
               this._panel.webview.postMessage({
@@ -236,6 +236,21 @@ export class BruinPanel {
               });
             }, 1500);
             break;
+            case "bruin.runAll":
+              const workspaceF = vscode.workspace.workspaceFolders?.[0];
+              if (!workspaceF) {
+                console.error("No workspace folder found.");
+                return;
+              }
+              runInIntegratedTerminal(bruinWorkspaceDirectory(workspaceF?.uri.fsPath), message.payload);
+  
+              setTimeout(() => {
+                this._panel.webview.postMessage({
+                  command: "runCompleted",
+                  message: "",
+                });
+              }, 1500);
+              break;
           case "checkboxChange":
             this._flags = message.payload;
             await renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -189,6 +189,21 @@ export class BruinPanel {
         const command = message.command;
 
         switch (command) {
+          case "bruin.validateAll":
+            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+            if (!workspaceFolder) {
+              console.error("No workspace folder found.");
+              return;
+            }
+            const validatorAll = new BruinValidate(
+              getDefaultBruinExecutablePath(),
+              workspaceFolder.uri.fsPath
+            );
+
+            await validatorAll.validate(workspaceFolder.uri.fsPath, {
+              flags: ["-o", "json"],
+            });
+          break;
           case "bruin.validate":
             if (!this._lastRenderedDocumentUri) {
               console.error("No active document to validate.");

--- a/webview-ui/src/components/AssetDetails.vue
+++ b/webview-ui/src/components/AssetDetails.vue
@@ -21,6 +21,7 @@
             BGColor="bg-blue-500"
             :status="validateButtonStatus"
             buttonLabel="Validate"
+            @exec-choice="execChoice"
           />
           <CommandButton
             :disabled="isError"
@@ -62,18 +63,33 @@ const props = defineProps<{
   assetName: string | null;
 }>();
 
-function handleBruinValidate() {
+function handleBruinValidate(all: boolean = false) {
+  if(all){
+    vscode.postMessage({
+      command: "bruin.validateAll",
+    });
+  }
+  else {
   vscode.postMessage({
     command: "bruin.validate",
   });
 }
+}
+
 
 const checkboxItems = ref([
-  { name: "Downstream", checked: false },
   { name: "Full-Refresh", checked: false },
   { name: "Exclusive-End-Date", checked: false },
 ]);
 
+function handleExecChoice(action: string) {
+  if(action === "Pipeline") {
+    handleBruinValidate(true);
+  }
+  console.log("Checkbox items", checkboxItems, action);
+}
+
+const execChoice = computed(() => handleExecChoice);
 function runSql() {
   const payload = getCheckboxChangePayload();
   vscode.postMessage({

--- a/webview-ui/src/components/AssetDetails.vue
+++ b/webview-ui/src/components/AssetDetails.vue
@@ -17,14 +17,17 @@
         <div class="flex justify-end space-x-4">
           <CommandButton
             :disabled="isError"
-            @click="handleBruinValidate"
+            :defaultAction="handleBruinValidate"
             BGColor="bg-blue-500"
             :status="validateButtonStatus"
-            >Validate</CommandButton
-          >
-          <CommandButton :disabled="isError" @click="runSql" BGColor="bg-green-500">
-            Run
-          </CommandButton>
+            buttonLabel="Validate"
+          />
+          <CommandButton
+            :disabled="isError"
+            :defaultAction="runSql"
+            BGColor="bg-green-500"
+            buttonLabel="Run"
+          />
         </div>
         <ErrorAlert v-if="isError" :errorMessage="errorMessage!" />
         <div v-if="language === 'sql'">
@@ -166,7 +169,7 @@ function receiveMessage(event: { data: any }) {
         validateButtonStatus.value
       );
       break;
-   
+
     case "render-message":
       renderSQLAssetSuccess.value = updateValue(envelope, "success");
       renderSQLAssetError.value = updateValue(envelope, "error");

--- a/webview-ui/src/components/ui/buttons/ActionButton.vue
+++ b/webview-ui/src/components/ui/buttons/ActionButton.vue
@@ -24,26 +24,15 @@
       class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
     >
       <div class="py-1">
-        <MenuItem v-slot="{ active }">
+        <MenuItem v-slot="{ active }" v-for="(item, index) in items" :key="index">
           <button
-            @click="selectAction('Downstream')"
+            @click="selectAction(item)"
             :class="[
               active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
               'block w-full text-left px-4 py-2 text-sm',
             ]"
           >
-            Downstream
-          </button>
-        </MenuItem>
-        <MenuItem v-slot="{ active }">
-          <button
-            @click="selectAction('Pipeline')"
-            :class="[
-              active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
-              'block w-full text-left px-4 py-2 text-sm',
-            ]"
-          >
-            Pipeline
+            {{ item }}
           </button>
         </MenuItem>
       </div>
@@ -61,6 +50,7 @@ const props = defineProps<{
   buttonLabel: string;
   BGColor: string | null;
   status?: "validated" | "failed" | "loading" | null;
+  items?: string[];
   defaultAction: () => void;
 }>();
 
@@ -101,3 +91,5 @@ function selectAction(action: string) {
   animation: spin 1s linear infinite;
 }
 </style>
+
+

--- a/webview-ui/src/components/ui/buttons/ActionButton.vue
+++ b/webview-ui/src/components/ui/buttons/ActionButton.vue
@@ -1,63 +1,84 @@
 <template>
+  <div :class="`flex items-center gap-x-1.5 rounded-md px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 
+          focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed
+          focus-visible:outline-indigo-600  ${BGColor}`">
+  <button
+    type="button"
+    class="inline-flex items-center gap-x-1.5 "
+    @click="handleDefaultClick"
+  >
+    <CheckCircleIcon v-if="status === 'validated'" class="-ml-0.5 h-5 w-5" aria-hidden="true" />
+    <XCircleIcon v-if="status === 'failed'" class="-ml-0.5 h-5 w-5" aria-hidden="true" />
+    <span v-if="status === 'loading'" class="-ml-0.5 h-5 w-5 spinner"></span>
+    {{ buttonLabel }}
+  </button>
   <Menu as="div" class="relative inline-block text-left">
     <div>
-      <button
-        type="button"
-        :class="`inline-flex items-center gap-x-1.5 
-          rounded-md px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 
-          focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed
-          focus-visible:outline-indigo-600 ${BGColor}`"
-          @click="handleDefaultClick"
-      >
-        <CheckCircleIcon v-if="status === 'validated'" class="-ml-0.5 h-5 w-5" aria-hidden="true" />
-        <XCircleIcon v-if="status === 'failed'" class="-ml-0.5 h-5 w-5" aria-hidden="true" />
-        <span v-if="status === 'loading'" class="-ml-0.5 h-5 w-5 spinner"></span>
-
-        <slot></slot>
-        <ChevronDownIcon class="-mr-1 h-5 w-5" aria-hidden="true" />
-      </button>
+      <MenuButton
+        as="button">
+        <ChevronDownIcon class="h-5 w-5 pt-1" aria-hidden="true" />
+      </MenuButton>
     </div>
-    <div>
-      <MenuItems
-        class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
-      >
-        <div class="py-1">
-          <MenuItem v-slot="{ active }">
-            <a
-              href="#"
-              :class="[
-                active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
-                'block px-4 py-2 text-sm',
-              ]"
-              >Downstream</a
-            >
-          </MenuItem>
-          <MenuItem v-slot="{ active }">
-            <a
-              href="#"
-              :class="[
-                active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
-                'block px-4 py-2 text-sm',
-              ]"
-              >Pipeline</a
-            >
-          </MenuItem>
-        </div>
-      </MenuItems>
-    </div>
+    <MenuItems
+      id="menu-items"
+      class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+    >
+      <div class="py-1">
+        <MenuItem v-slot="{ active }">
+          <button
+            @click="selectAction('Downstream')"
+            :class="[
+              active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+              'block w-full text-left px-4 py-2 text-sm',
+            ]"
+          >
+            Downstream
+          </button>
+        </MenuItem>
+        <MenuItem v-slot="{ active }">
+          <button
+            @click="selectAction('Pipeline')"
+            :class="[
+              active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+              'block w-full text-left px-4 py-2 text-sm',
+            ]"
+          >
+            Pipeline
+          </button>
+        </MenuItem>
+      </div>
+    </MenuItems>
   </Menu>
+</div>
 </template>
 
 <script setup lang="ts">
-import { defineProps } from "vue";
+import { defineProps, ref } from "vue";
 import { CheckCircleIcon, XCircleIcon, ChevronDownIcon } from "@heroicons/vue/20/solid";
-import { Menu, MenuItems, MenuItem} from "@headlessui/vue";
+import { Menu, MenuItems, MenuItem, MenuButton } from "@headlessui/vue";
 
 const props = defineProps<{
+  buttonLabel: string;
   BGColor: string | null;
   status?: "validated" | "failed" | "loading" | null;
-  handleDefaultClick?: () => void;
+  defaultAction: () => void;
 }>();
+
+const buttonLabel = ref(props.buttonLabel);
+
+function handleDefaultClick(event) {
+  // Prevent the dropdown from opening when clicking the button part
+  event.stopPropagation();
+  if (props.defaultAction) {
+    props.defaultAction();
+  }
+}
+
+function selectAction(action) {
+  buttonLabel.value = action;
+  console.log(`Action selected: ${action}`);
+  // Implement additional action handlers as needed
+}
 </script>
 
 <style scoped>
@@ -68,6 +89,9 @@ const props = defineProps<{
   100% {
     transform: rotate(360deg);
   }
+}
+#menu-items {
+  background-color: var(--vscode-foreground);
 }
 .spinner {
   border: 2px solid rgba(255, 255, 255, 0.3);

--- a/webview-ui/src/components/ui/buttons/ActionButton.vue
+++ b/webview-ui/src/components/ui/buttons/ActionButton.vue
@@ -1,34 +1,73 @@
 <template>
-  <button
-    type="button"
-    :class="`inline-flex items-center gap-x-1.5 
-    rounded-md px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 
-    focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed
-     focus-visible:outline-indigo-600 ${BGColor}`"
-  >
-    <CheckCircleIcon v-if="status === 'validated'" class="-ml-0.5 h-5 w-5" aria-hidden="true" />
-    <XCircleIcon v-if="status === 'failed'" class="-ml-0.5 h-5 w-5" aria-hidden="true" />
-    <span v-if="status === 'loading'" class="-ml-0.5 h-5 w-5 spinner"></span>
+  <Menu as="div" class="relative inline-block text-left">
+    <div>
+      <button
+        type="button"
+        :class="`inline-flex items-center gap-x-1.5 
+          rounded-md px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 
+          focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed
+          focus-visible:outline-indigo-600 ${BGColor}`"
+          @click="handleDefaultClick"
+      >
+        <CheckCircleIcon v-if="status === 'validated'" class="-ml-0.5 h-5 w-5" aria-hidden="true" />
+        <XCircleIcon v-if="status === 'failed'" class="-ml-0.5 h-5 w-5" aria-hidden="true" />
+        <span v-if="status === 'loading'" class="-ml-0.5 h-5 w-5 spinner"></span>
 
-    <slot></slot>
-  </button>
+        <slot></slot>
+        <ChevronDownIcon class="-mr-1 h-5 w-5" aria-hidden="true" />
+      </button>
+    </div>
+    <div>
+      <MenuItems
+        class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+      >
+        <div class="py-1">
+          <MenuItem v-slot="{ active }">
+            <a
+              href="#"
+              :class="[
+                active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+                'block px-4 py-2 text-sm',
+              ]"
+              >Downstream</a
+            >
+          </MenuItem>
+          <MenuItem v-slot="{ active }">
+            <a
+              href="#"
+              :class="[
+                active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+                'block px-4 py-2 text-sm',
+              ]"
+              >Pipeline</a
+            >
+          </MenuItem>
+        </div>
+      </MenuItems>
+    </div>
+  </Menu>
 </template>
 
 <script setup lang="ts">
 import { defineProps } from "vue";
-import { CheckCircleIcon, XCircleIcon } from "@heroicons/vue/20/solid";
+import { CheckCircleIcon, XCircleIcon, ChevronDownIcon } from "@heroicons/vue/20/solid";
+import { Menu, MenuItems, MenuItem} from "@headlessui/vue";
 
 const props = defineProps<{
   BGColor: string | null;
   status?: "validated" | "failed" | "loading" | null;
+  handleDefaultClick?: () => void;
 }>();
 </script>
 
 <style scoped>
-
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 .spinner {
   border: 2px solid rgba(255, 255, 255, 0.3);

--- a/webview-ui/src/components/ui/buttons/ActionButton.vue
+++ b/webview-ui/src/components/ui/buttons/ActionButton.vue
@@ -66,18 +66,17 @@ const props = defineProps<{
 
 const buttonLabel = ref(props.buttonLabel);
 
-function handleDefaultClick(event) {
+function handleDefaultClick(event: { stopPropagation: () => void; }) {
   // Prevent the dropdown from opening when clicking the button part
   event.stopPropagation();
   if (props.defaultAction) {
     props.defaultAction();
   }
 }
-
-function selectAction(action) {
-  buttonLabel.value = action;
+const emit = defineEmits(["execChoice"]);
+function selectAction(action: string) {
+  emit("execChoice", action);
   console.log(`Action selected: ${action}`);
-  // Implement additional action handlers as needed
 }
 </script>
 


### PR DESCRIPTION

# PR Overview:
This pull request introduces dropdown menus for the `run` and `validate` buttons, providing additional executable options.

## Main Changes

- **Validate Button:**
  - Integrated a dropdown menu into the `validate` button. This menu includes a new option titled "Pipeline". Selecting this option triggers the command `bruin validate .`.
  
  - The default click action on the `validate` button remains unchanged; it continues to validate the current asset as per existing functionality.

- **Run Button:**
  - A dropdown menu has been added to the `run` button, featuring the "Downstream" option. When selected, this initiates the command `bruin run --downstream [rest of the command]`.
  
  - Similar to the `validate` button, the default behavior of the `run` button persists, executing the standard run command upon a direct click.
  - 
![run-validate-with-options](https://github.com/bruin-data/bruin-vscode/assets/25383275/1a314909-9818-4d0d-9f75-554d4733cee6)
