### PR TITLE
Fix the extension activation on sql (snowflake, and bigQuery)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
       "editor/title": [
         {
           "command": "bruin.renderSQL",
-          "when": "resourceLangId == sql || resourceLangId == python",
           "group": "navigation"
         }
       ]


### PR DESCRIPTION
#PR Overview

- This PR fixes the problem of the extension activation on SQL files. Before, it was activated only on "resourceLangId = 'sql' or 'py'". Now, it's activated on every language as a temporary fix.