### PR TITLE
Refactor Render Command to Support JSON Output and Handle Unsupported Flags

### DIFF
--- a/src/bruin/bruinRender.ts
+++ b/src/bruin/bruinRender.ts
@@ -1,3 +1,83 @@
+/* import { BruinPanel } from "../panels/BruinPanel";
+import { BruinCommand } from "./bruinCommand";
+import { BruinCommandOptions } from "../types";
+import {
+  isBruinAsset,
+  isBruinPipeline,
+  isBruinYaml,
+  isPythonBruinAsset,
+  isYamlBruinAsset,
+} from "../utilities/helperUtils";
+
+/**
+ * Extends the BruinCommand class to implement the rendering process specific to Bruin assets.
+ * It checks if the file is a Python or SQL Bruin asset and manages the rendering accordingly.
+ 
+export class BruinRender extends BruinCommand {
+  /**
+   * Specifies the Bruin command string.
+   *
+   * @returns {string} Returns the 'render' command string.
+   
+  protected bruinCommand(): string {
+    return "render";
+  }
+
+  /**
+   * Renders the content of the specified asset path, handles the display of results, and manages errors.
+   * Notifies users when a Python Bruin asset is detected.
+   *
+   * @param {string} filePath - The path of the asset to be rendered.
+   * @param {BruinCommandOptions} [options={}] - The optional parameters including flags and error handling preferences.
+   * @returns {Promise<void>} A promise that resolves when the rendering process completes or errors are handled.
+   
+
+  public async render(
+    filePath: string,
+    { flags = ['-o', 'json'], ignoresErrors = false }: BruinCommandOptions = {}
+  ): Promise<void> {
+    if (!isBruinAsset(filePath, ["py", "sql", "asset.yml"]) || (await isBruinYaml(filePath))) {
+      BruinPanel?.postMessage("render-message", {
+        status: "non-asset-alert",
+        message: "-- This is not a BRUIN asset --",
+      });
+      console.log("This is not a BRUIN asset");
+      return;
+    } else {
+      if (
+        (await isPythonBruinAsset(filePath)) ||
+        (await isYamlBruinAsset(filePath)) ||
+        (await isBruinPipeline(filePath))
+      ) {
+        BruinPanel?.postMessage("render-message", {
+          status: "bruin-asset-alert",
+          message: "-- Python or Yaml BRUIN asset detected --",
+        });
+        console.log("Python or Yaml BRUIN asset detected");
+        return;
+      }
+    }
+    await this.run([...flags, filePath], { ignoresErrors }).then(
+      (sqlRendered) => {
+        BruinPanel?.postMessage("render-message", {
+          status: "success",
+          message: JSON.parse(sqlRendered).query,
+        });
+        console.log("SQL rendered successfully");
+      },
+      (error) => {
+        BruinPanel?.postMessage("render-message", {
+          status: "error",
+          message: error,
+        });
+        console.error("Error rendering SQL asset", error);
+      }
+    );
+  }
+}
+ */
+
+
 import { BruinPanel } from "../panels/BruinPanel";
 import { BruinCommand } from "./bruinCommand";
 import { BruinCommandOptions } from "../types";
@@ -8,6 +88,7 @@ import {
   isPythonBruinAsset,
   isYamlBruinAsset,
 } from "../utilities/helperUtils";
+import { error } from "console";
 
 /**
  * Extends the BruinCommand class to implement the rendering process specific to Bruin assets.
@@ -57,21 +138,52 @@ export class BruinRender extends BruinCommand {
         return;
       }
     }
+    
     await this.run([...flags, filePath], { ignoresErrors }).then(
-      (sqlRendered) => {
-        BruinPanel?.postMessage("render-message", {
+      (sqlRendered)=>{
+       BruinPanel?.postMessage("render-message", {
           status: "success",
-          message: sqlRendered,
+          message: JSON.parse(sqlRendered).query,
         });
         console.log("SQL rendered successfully");
       },
-      (error) => {
+      (error)=>{
         BruinPanel?.postMessage("render-message", {
           status: "error",
           message: error,
         });
         console.error("Error rendering SQL asset", error);
       }
-    );
+    )
+      .catch ((err) => {
+        if (err.toString().includes("Incorrect")) {
+          this.runWithoutJsonFlag(filePath, ignoresErrors);
+        } else {
+          BruinPanel?.postMessage("render-message", {
+            status: "error",
+            message: JSON.stringify({ error: err }),
+          });
+          console.error("Error rendering SQL asset", err);
+      }
+    });
   }
+
+
+  private async runWithoutJsonFlag(filePath: string, ignoresErrors: boolean) {
+      await this.run([filePath], { ignoresErrors }).then(
+        (result) => {
+      BruinPanel?.postMessage("render-message", {
+        status: "success",
+        message: result,
+      });
+      console.log("SQL rendered successfully without JSON", result);
+    },
+     (err) => {
+      BruinPanel?.postMessage("render-message", {
+        status: "error",
+        message: JSON.stringify({ error: err }), 
+      });
+      console.error("Error rendering SQL asset without JSON", err);
+    });
 }
+  }

--- a/src/extension/commands/renderCommand.ts
+++ b/src/extension/commands/renderCommand.ts
@@ -41,7 +41,7 @@ export const renderCommandWithFlags = async (flags: string, lastRenderedDocument
     );
 
     await bruinSqlRenderer.render(filePath, {
-      flags: flags.split(" ").filter((flag) => flag !== "" && flag !== "--downstream"),
+      flags: ['-o', 'json'].concat(flags.split(" ").filter((flag) => flag !== "" && flag !== "--downstream")),
     });
   }
 };

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -77,7 +77,7 @@ export class BruinPanel {
 
   public static postMessage(
     name: string,
-    data: string | { status: string; message: string },
+    data: string | { status: string; message: string | any  },
     panelType?: string
   ) {
     if (BruinPanel.currentPanel?._panel) {

--- a/webview-ui/src/components/ErrorAlert.vue
+++ b/webview-ui/src/components/ErrorAlert.vue
@@ -1,17 +1,20 @@
 <template>
   <div v-if="formattedErrorMessage" class="rounded-md bg-red-50 p-4 my-4">
-    <div class="flex overflow-scroll overflow-x-auto">
+    <div class="flex">
       <div class="flex-shrink-0">
         <XCircleIcon class="h-5 w-5 text-red-500" aria-hidden="true" />
       </div>
       <div class="ml-4">
-        <h3 class="text-lg font-medium text-red-800">
+        <h3 class="text-lg font-medium text-red-800" v-if="formattedErrorMessage.pipeline">
           Pipeline: {{ formattedErrorMessage.pipeline }}
         </h3>
         <div v-for="(issue, index) in formattedErrorMessage.issues" :key="index" class="mt-3">
-          <h4 class="text-md font-semibold text-gray-900">Asset: {{ issue.asset }}</h4>
+          <h4 class="text-md font-semibold text-gray-900" v-if="issue.asset">
+            Asset: {{ issue.asset }}
+          </h4>
           <p class="text-sm text-red-600">{{ issue.description }}</p>
           <div
+            v-if="issue.context.length"
             class="flex items-center space-x-1 mt-2 justify-end text-[color:var(--vscode-editor-background)]"
           >
             <span class="font-semibold"> Details </span>
@@ -37,16 +40,16 @@
           </div>
         </div>
       </div>
-   
     </div>
   </div>
 </template>
+
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { defineProps } from "vue";
 import { XCircleIcon, ChevronDownIcon, ChevronUpIcon } from "@heroicons/vue/20/solid";
-import type { ParsedErrorMessage } from "@/types";
+import type {ParsedValidationErrorMessage} from "@/types";
 
 const props = defineProps<{
   errorMessage: string | any | null;
@@ -59,25 +62,46 @@ const formattedIssueContext = (context) => {
 
 const formattedErrorMessage = computed(() => {
   if (!props.errorMessage) return null;
-      try {
-        const parsed = JSON.parse(props.errorMessage)[0] as ParsedErrorMessage;
-        return {
-          pipeline: parsed.pipeline,
-          issues: Object.entries(parsed.issues)
-            .map(([test, issues]) => {
-              return issues.map((issue) => ({
-                asset: issue.asset,
-                description: issue.description,
-                context: issue.context,
-                expanded: ref(false),
-              }));
-            })
-            .flat(),
-        };
-      } catch (e) {
-        console.error("Failed to parse error message:", e);
-        return null;
-      }
+
+  try {
+    const errorObject = JSON.parse(props.errorMessage) as ParsedValidationErrorMessage;
+
+    // Handling a simple error message
+    if (errorObject.error) {
+      console.log("Error message:", errorObject.error);
+      return {
+        pipeline: null, // Set to null or a default message
+        issues: [{
+          asset: null, // Asset can be null
+          description: errorObject.error, // Ensure description is always populated
+          context: [],
+          expanded: ref(false),
+        }]
+      };
+    }
+
+    // Handling structured error messages
+    if (errorObject.pipeline || errorObject.issues) {
+      return {
+        pipeline: errorObject.pipeline || null,
+        issues: Object.entries(errorObject.issues || {}) 
+          .map(([test, issues]) => {
+            return issues.map((issue) => ({
+              asset: issue.asset || null,
+              description: issue.description, // Description is expected to be always available
+              context: issue.context || [],
+              expanded: ref(false),
+            }));
+          })
+          .flat(),
+      };
+    }
+
+    return null;
+  } catch (e) {
+    console.error("Failed to parse error message:", e);
+    return null;
+  }
 });
 </script>
 

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -13,10 +13,12 @@ interface IssuesMap {
   [test: string]: Issue[];
 }
 
-export interface ParsedErrorMessage {
-  pipeline: string;
-  issues: IssuesMap;
+export interface ParsedValidationErrorMessage {
+  pipeline?: string;
+  issues?: IssuesMap;
+  error?: string;
 }
+
 
 export interface Asset {
   name: string;


### PR DESCRIPTION
# PR Overview
This PR refactors the render command's functionality to support JSON output and introduces a fallback mechanism for environments where the `-o json` flag is not supported. These changes ensure the SQL preview remains functional across various versions of the CLI.

## Main Changes
- **Refactored Render Command**: Updated the render command to support the `-o json` flag, to fix the error display.
- **Fallback Implementation**: Added a fallback process that checks if the `-o json` flag is supported. If an error indicating an unsupported flag is caught, the command reverts to standard output, preventing failures in older CLI versions.
