### PR TITLE
Handle render error when output panel is clicked

### DIFF
--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -7,7 +7,6 @@ import * as vscode from "vscode";
 import { renderCommandWithFlags } from "../extension/commands/renderCommand";
 import { lineageCommand } from "../extension/commands/lineageCommand";
 import { parseAssetCommand } from "../extension/commands/parseAssetCommand";
-import { parse } from "path";
 
 /**
  * This class manages the state and behavior of Bruin webview panels.
@@ -57,7 +56,13 @@ export class BruinPanel {
       }),
       window.onDidChangeActiveTextEditor((editor) => {
         if (editor && editor.document.uri) {
-          this._lastRenderedDocumentUri = editor.document.uri;
+
+          if(editor.document.uri.fsPath === "tasks"){
+          return;
+        }
+        this._lastRenderedDocumentUri = editor.document.uri;
+          console.log("Document URI active text editor", this._lastRenderedDocumentUri);
+
           renderCommandWithFlags(this._flags);
           lineageCommand(this._lastRenderedDocumentUri);
           parseAssetCommand(this._lastRenderedDocumentUri);

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -90,23 +90,3 @@ export const processLineageData = (lineageString: { name: any }): any => {
   return lineageString.name;
 };
 
-/* {
-  "name": "test_dataset.test",
-  "upstream": [],
-  "downstream": [
-      {
-          "name": "test_dataset.test3",
-          "type": "bq.sql",
-          "executable_file": {
-              "name": "test3.sql",
-              "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test3.sql",
-              "content": ""
-          },
-          "definition_file": {
-              "name": "test3.sql",
-              "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test3.sql",
-              "type": "comment"
-          }
-      }
-  ]
-} */


### PR DESCRIPTION
# PR Overview
This PR addresses an issue where the extension would throw an error when the `output` panel is clicked. The specific error is "no such file or directory" (ENOENT), which was previously unhandled and interrupted the flow of the extension.

## Main Changes
- Added error handling for the "no such file or directory" (ENOENT) error.
- Ensured that the render process continues normally when this error occurs.
