### PR TITLE
Add Reset Button for Start and End Dates Based on Pipeline Schedule

### DIFF
--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -41,7 +41,6 @@
 </template>
 
 <script setup lang="ts">
-import AssetGeneral from "@/components/asset/AssetGeneral.vue";
 import AssetDetails from "@/components/asset/AssetDetails.vue";
 import AssetLineageText from "@/components/lineage-text/AssetLineageText.vue";
 import AssetLineageFlow from "@/components/lineage-flow/asset-lineage/AssetLineage.vue";

--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -33,7 +33,7 @@
     <vscode-divider class="border-t border-editor-border opacity-20 my-4"></vscode-divider>
 
     <div class="w-full">
-      <AssetGeneral />
+      <AssetGeneral :schedule="scheduleExists ?  props.pipeline.schedule : ''"/>
     </div>
   </div>
 </template>
@@ -50,7 +50,6 @@ const props = defineProps<{
   name: string;
   description: string;
   type: string;
-  schedule: string;
   owner: string;
   id: string;
   pipeline: any;
@@ -60,6 +59,9 @@ const ownerExists = computed(() => {
   return props.owner !== "" && props.owner !== "undefined" && props.owner !== null && props.owner !== undefined;
 });
 
+const scheduleExists = computed(() => {
+  return props.pipeline.schedule !== "" && props.pipeline.schedule !== "undefined" && props.pipeline.schedule !== null && props.pipeline.schedule !== undefined;
+});
 const md = new MarkdownIt();
 const markdownDescription = computed(() => {
   if (!props.description) {

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -11,7 +11,8 @@
                 type="button"
                 class="rounded-md bg-editor-button-bg  p-2 mt-6 text-editor-button-fg hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed"
                 @click="resetStartEndDate"
-                :disabled="isNotAsset || isError"
+                :title="isCron ? `Schedule not supported yet`: `Reset Start and End Date`"
+                :disabled="isCron"
               >
                 <ArrowPathRoundedSquareIcon class="sm:h-5 sm:w-5 h-4 w-4" aria-hidden="true" />
               </button>
@@ -271,6 +272,7 @@ const selectedEnv = ref<string>("default");
 function setSelectedEnv(env: string) {
   selectedEnv.value = env;
 }
+const isCron = ref(false);
 const validationSuccess = ref(null);
 const validationError = ref(null);
 const renderSQLAssetSuccess = ref(null);
@@ -349,6 +351,8 @@ function resetStartEndDate() {
       startDate.value = firstDayOfLastMonth.toISOString().slice(0, -1);
       endDate.value = lastDayOfLastMonth.toISOString().slice(0, -1);
       break;
+      default:
+      isCron.value = true;
   }
 }
 function getCheckboxChangePayload() {

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -22,8 +22,8 @@
             <CheckboxGroup :checkboxItems="checkboxItems" />
           </div>
         </div>
-        <div class="flex flex-wrap justify-between items-center">
-          <EnvSelectMenu :options="['default', 'env 1', 'env 2']" @selected-env="setSelectedEnv" />
+        <!-- <div class="flex flex-wrap justify-between items-center"> -->
+          <!-- <EnvSelectMenu :options="['default', 'env 1', 'env 2']" @selected-env="setSelectedEnv" /> -->
           <div class="flex justify-end items-center space-x-2 sm:space-x-4 mt-2 sm:mt-0">
             <div class="inline-flex rounded-md shadow-sm">
               <button
@@ -180,8 +180,8 @@
               </Menu>
             </div>
           </div>
-        </div>
-
+<!--         </div>
+ -->
         <ErrorAlert v-if="isError" :errorMessage="errorMessage!" />
         <div v-if="language === 'sql'">
           <SqlEditor v-show="!isError" :code="code" :copied="false" :language="language" />

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -4,23 +4,17 @@
       <div class="flex flex-col space-y-4">
         <div class="flex flex-col space-y-3">
           <div>
-            <div class="flex justify-end">
+            <div class="flex space-x-2 items-center">
+              <DateInput class="w-2/5" label="Start Date" v-model="startDate" />
+              <DateInput class="w-2/5" label="End Date" v-model="endDate" />
               <button
                 type="button"
-                class="relative inline-flex items-center rounded-md bg-editor-button-bg px-3 py-2 mb-2 text-sm font-medium text-editor-button-fg ring-1 ring-inset ring-editor-button-border hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed focus:z-10"
-                @click="resetStartEndDate('daily')"
+                class="rounded-md bg-editor-button-bg  p-2 mt-6 text-editor-button-fg hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed"
+                @click="resetStartEndDate"
                 :disabled="isNotAsset || isError"
               >
-                <ArrowPathRoundedSquareIcon
-                  v-if="!validateButtonStatus"
-                  class="h-4 w-4 mr-1"
-                ></ArrowPathRoundedSquareIcon>
-                Reset date
+                <ArrowPathRoundedSquareIcon class="sm:h-5 sm:w-5 h-4 w-4" aria-hidden="true" />
               </button>
-            </div>
-            <div class="flex space-x-2">
-              <DateInput class="w-1/2" label="Start Date" v-model="startDate" />
-              <DateInput class="w-1/2" label="End Date" v-model="endDate" />
             </div>
           </div>
           <div>
@@ -217,6 +211,10 @@ const isError = computed(() => errorState.value?.errorCaptured);
 const errorMessage = computed(() => errorState.value?.errorMessage);
 const isNotAsset = computed(() => (renderAssetAlert.value ? true : false));
 
+const props = defineProps<{
+  schedule: string;
+}>();
+
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 import { ChevronDownIcon, CheckCircleIcon, XCircleIcon } from "@heroicons/vue/24/solid";
 import { SparklesIcon, PlayIcon, ArrowPathRoundedSquareIcon } from "@heroicons/vue/24/outline";
@@ -307,8 +305,8 @@ watch(
   { immediate: true }
 );
 
-function resetStartEndDate(schedule: string) {
-  switch (schedule) {
+function resetStartEndDate() {
+  switch (props.schedule) {
     case "daily":
       startDate.value = new Date(
         Date.UTC(today.getFullYear(), today.getMonth(), today.getDate() - 1, 0, 0, 0, 0)
@@ -326,7 +324,7 @@ function resetStartEndDate(schedule: string) {
       const lastMonday = new Date(
         Date.UTC(today.getFullYear(), today.getMonth(), today.getDate() - dayOfWeek - 6, 0, 0, 0, 0)
       );
-      
+
       const thisMonday = new Date(
         Date.UTC(
           today.getFullYear(),

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -3,9 +3,25 @@
     <div class="">
       <div class="flex flex-col space-y-4">
         <div class="flex flex-col space-y-3">
-          <div class="flex space-x-2">
-            <DateInput class="w-1/2" label="Start Date" v-model="startDate" />
-            <DateInput class="w-1/2" label="End Date" v-model="endDate" />
+          <div>
+            <div class="flex justify-end">
+              <button
+                type="button"
+                class="relative inline-flex items-center rounded-md bg-editor-button-bg px-3 py-2 mb-2 text-sm font-medium text-editor-button-fg ring-1 ring-inset ring-editor-button-border hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed focus:z-10"
+                @click="resetStartEndDate('daily')"
+                :disabled="isNotAsset || isError"
+              >
+                <ArrowPathRoundedSquareIcon
+                  v-if="!validateButtonStatus"
+                  class="h-4 w-4 mr-1"
+                ></ArrowPathRoundedSquareIcon>
+                Reset date
+              </button>
+            </div>
+            <div class="flex space-x-2">
+              <DateInput class="w-1/2" label="Start Date" v-model="startDate" />
+              <DateInput class="w-1/2" label="End Date" v-model="endDate" />
+            </div>
           </div>
           <div>
             <CheckboxGroup :checkboxItems="checkboxItems" />
@@ -203,7 +219,7 @@ const isNotAsset = computed(() => (renderAssetAlert.value ? true : false));
 
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 import { ChevronDownIcon, CheckCircleIcon, XCircleIcon } from "@heroicons/vue/24/solid";
-import { SparklesIcon, PlayIcon } from "@heroicons/vue/24/outline";
+import { SparklesIcon, PlayIcon, ArrowPathRoundedSquareIcon } from "@heroicons/vue/24/outline";
 
 function handleBruinValidateAllPipelines() {
   vscode.postMessage({
@@ -291,6 +307,52 @@ watch(
   { immediate: true }
 );
 
+function resetStartEndDate(schedule: string) {
+  switch (schedule) {
+    case "daily":
+      startDate.value = new Date(
+        Date.UTC(today.getFullYear(), today.getMonth(), today.getDate() - 1, 0, 0, 0, 0)
+      )
+        .toISOString()
+        .slice(0, -1);
+      endDate.value = new Date(
+        Date.UTC(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0)
+      )
+        .toISOString()
+        .slice(0, -1);
+      break;
+    case "weekly":
+      const dayOfWeek = today.getUTCDay();
+      const lastMonday = new Date(
+        Date.UTC(today.getFullYear(), today.getMonth(), today.getDate() - dayOfWeek - 6, 0, 0, 0, 0)
+      );
+      
+      const thisMonday = new Date(
+        Date.UTC(
+          today.getFullYear(),
+          today.getMonth(),
+          today.getDate() - (dayOfWeek === 0 ? 6 : dayOfWeek - 1),
+          0,
+          0,
+          0,
+          0
+        )
+      );
+      startDate.value = lastMonday.toISOString().slice(0, -1);
+      endDate.value = thisMonday.toISOString().slice(0, -1);
+      break;
+    case "monthly":
+      const firstDayOfLastMonth = new Date(
+        Date.UTC(today.getFullYear(), today.getMonth() - 1, 1, 0, 0, 0, 0)
+      );
+      const lastDayOfLastMonth = new Date(
+        Date.UTC(today.getFullYear(), today.getMonth(), 0, 0, 0, 0, 0)
+      );
+      startDate.value = firstDayOfLastMonth.toISOString().slice(0, -1);
+      endDate.value = lastDayOfLastMonth.toISOString().slice(0, -1);
+      break;
+  }
+}
 function getCheckboxChangePayload() {
   console.log("start date", startDate.value);
   console.log("end date", endDate.value);

--- a/webview-ui/src/components/ui/date-inputs/DateInput.vue
+++ b/webview-ui/src/components/ui/date-inputs/DateInput.vue
@@ -6,7 +6,7 @@
     <input
       id="datetime-picker"
       type="datetime-local"
-      class="p-2 block  max-w-sm rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+      class="p-2 block  max-w-sm rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
       :value="value" 
       @input="updateValue(($event.target as HTMLInputElement).value)"
       />


### PR DESCRIPTION
# PR Overview:
This PR implements a reset button to reset start and end dates according to the pipeline schedule.

## Main changes: 
- Add the reset button 
- Updated date calculations for schedule alignment.
- Implemented logic to retrieve schedule data.
- Handled cron schedules and added a button tooltip. The cron schedule isn't supported yet, so the button is disabled when a cron schedule is found.
- Temporarily removed environment dropdown for release.
![reset-dates](https://github.com/bruin-data/bruin-vscode/assets/25383275/a0a28dec-f538-4bb7-85ff-1e2c5ab67198)
