### PR TITLE
Handle missing badge types by falling back to default style

### DIFF
--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -73,10 +73,13 @@ const markdownDescription = computed(() => {
 const badgeClass = computed(() => {
   const commonStyle =
     "inline-flex items-center rounded-md px-1 py-0.5 text-xs font-medium ring-1 ring-inset";
+  
+    const styleForType = badgeStyles[props.type] || defaultBadgeStyle;
+
   return {
     commonStyle: commonStyle,
     grayBadge: `${commonStyle} ${defaultBadgeStyle.main}`,
-    badgeStyle: `${commonStyle} ${badgeStyles[props.type].main}`,
+    badgeStyle: `${commonStyle} ${styleForType.main}`,
   };
 });
 </script>


### PR DESCRIPTION
# PR Overview

This PR addresses an issue where the UI would disappear when encountering an unknown badge type. To fix it, a fallback logic in the badgeClass computed property was added.
