### PR TITLE
Fixed swapped behavior in Validate Button

### DIFF
--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -95,7 +95,7 @@
                             : 'bg-editor-button-bg',
                           'block w-full text-left px-4 py-2 text-sm',
                         ]"
-                        @click="handleBruinValidateAllPipelines"
+                        @click="handleBruinValidateCurrentPipeline"
                       >
                         Validate current pipeline
                       </button>
@@ -108,8 +108,8 @@
                             : 'bg-editor-button-bg',
                           'block w-full text-left px-4 py-2 text-sm',
                         ]"
-                        @click="handleBruinValidateCurrentPipeline"
-                      >
+                        @click="handleBruinValidateAllPipelines"
+                        >
                         Validate all pipelines
                       </button>
                     </MenuItem>


### PR DESCRIPTION
# PR Overview 

This PR corrected the misplacement of choices in the validate button functionality. The "Validate All" and "Validate Current Pipeline" options were inverted, causing the incorrect behavior where clicking "Validate All" validated only the current pipeline and vice versa.