### PR TITLE
Implement Environment Selection Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 
-
- - Corrected the validation button behavior where "Validate All" and "Validate Current Pipeline" were erroneously swapped.
-
 ### Latest Release: v0.10.7
 ## Fixed
  - Corrected the validation button behavior where "Validate All" and "Validate Current Pipeline" were erroneously swapped.

--- a/src/bruin/bruinSelectEnv.ts
+++ b/src/bruin/bruinSelectEnv.ts
@@ -1,0 +1,47 @@
+import { BruinCommandOptions } from "../types";
+import { BruinCommand } from "./bruinCommand";
+import { BruinPanel } from "../panels/BruinPanel";
+
+/**
+ * Extends the BruinCommand class to implement the bruin select run environement command.
+ */
+
+export class BruinEnvList extends BruinCommand {
+  /**
+   * Specifies the Bruin command string.
+   *
+   * @returns {string} Returns the 'environments list -o json' command string.
+   */
+  protected bruinCommand(): string {
+    return "environments";
+  }
+
+  /**
+   * Return the environments List.
+   * Communicates the results of the execution or errors back to the BruinPanel.
+   *
+   * @param {BruinCommandOptions} [options={}] - Optional parameters for execution, including flags and errors.
+   * @returns {Promise<void>} A promise that resolves when the execution is complete or an error is caught.
+   */
+
+  public async getEnvironmentsList(
+    { flags = ["list", "-o", "json"], ignoresErrors = false }: BruinCommandOptions = {}
+  ): Promise<void> {
+    await this.run([...flags], { ignoresErrors })
+      .then(
+        (result) => {
+          this.postMessageToPanels("success", result);
+        },
+        (error) => {
+          this.postMessageToPanels("error", error);
+        }
+      )
+      .catch((err) => {
+        console.debug("environment list command error", err);
+      });
+  }
+
+  private postMessageToPanels(status: string, message: string | any) {
+    BruinPanel.postMessage("environments-list-message", { status, message });
+  }
+}

--- a/src/extension/commands/getEnvListCommand.ts
+++ b/src/extension/commands/getEnvListCommand.ts
@@ -1,0 +1,14 @@
+import { getDefaultBruinExecutablePath } from "../configuration";
+import { BruinEnvList } from "../../bruin/bruinSelectEnv";
+import { Uri } from "vscode";
+import { bruinWorkspaceDirectory } from "../../bruin";
+
+export const getEnvListCommand = async (lastRenderedDocumentUri:  Uri | undefined ) => {
+
+  const getList = new BruinEnvList(
+    getDefaultBruinExecutablePath(),
+    bruinWorkspaceDirectory(lastRenderedDocumentUri!.fsPath)!!
+  );
+  await getList.getEnvironmentsList();
+  };
+  

--- a/src/extension/commands/parseAssetCommand.ts
+++ b/src/extension/commands/parseAssetCommand.ts
@@ -1,5 +1,5 @@
 import { Uri } from "vscode";
-import { BruinLineage, bruinWorkspaceDirectory } from "../../bruin";
+import { bruinWorkspaceDirectory } from "../../bruin";
 import { getDefaultBruinExecutablePath } from "../configuration";
 import { BruinInternalParse } from "../../bruin/bruinInternalParse";
 

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -12,6 +12,8 @@ import * as vscode from "vscode";
 import { renderCommandWithFlags } from "../extension/commands/renderCommand";
 import { lineageCommand } from "../extension/commands/lineageCommand";
 import { parseAssetCommand } from "../extension/commands/parseAssetCommand";
+import { getEnvListCommand } from "../extension/commands/getEnvListCommand";
+import { Input, transformToEnvironmentsArray } from "../utilities/helperUtils";
 
 /**
  * This class manages the state and behavior of Bruin webview panels.
@@ -57,6 +59,7 @@ export class BruinPanel {
           renderCommandWithFlags(this._flags);
           lineageCommand(this._lastRenderedDocumentUri);
           parseAssetCommand(this._lastRenderedDocumentUri);
+          getEnvListCommand(this._lastRenderedDocumentUri);
           console.log("Document URI onDidChangeTextDocument", this._lastRenderedDocumentUri);
         }
       }),
@@ -71,6 +74,7 @@ export class BruinPanel {
           renderCommandWithFlags(this._flags);
           lineageCommand(this._lastRenderedDocumentUri);
           parseAssetCommand(this._lastRenderedDocumentUri);
+          getEnvListCommand(this._lastRenderedDocumentUri);
         }
       })
     );
@@ -87,6 +91,9 @@ export class BruinPanel {
 
     // Set an event listener to listen for messages passed from the webview context
     this._setWebviewMessageListener(this._panel.webview);
+
+
+  
   }
 
   public static postMessage(
@@ -101,6 +108,7 @@ export class BruinPanel {
       });
     }
   }
+
 
   /**
    * Renders the current webview panel if it exists otherwise a new webview panel
@@ -197,9 +205,7 @@ export class BruinPanel {
     this._panel.webview.postMessage({
       command: "init",
       panelType: "bruin",
-      payload: ["default", "Env1", "Env2", "Env3"]
-    },
-  );
+    });
 
     webview.onDidReceiveMessage(
       async (message: any) => {
@@ -311,7 +317,15 @@ export class BruinPanel {
             console.log("Loading asset data for:", this._lastRenderedDocumentUri);
             parseAssetCommand(this._lastRenderedDocumentUri);
             break;
+
+            case "bruin.getEnvironmentsList":
+              if (!this._lastRenderedDocumentUri) {
+                console.log("Loading asset data impossible without an active document.");
+                return;
+              }
+             getEnvListCommand(this._lastRenderedDocumentUri);
         }
+       
       },
       undefined,
       this._disposables

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -197,7 +197,9 @@ export class BruinPanel {
     this._panel.webview.postMessage({
       command: "init",
       panelType: "bruin",
-    });
+      payload: ["default", "Env1", "Env2", "Env3"]
+    },
+  );
 
     webview.onDidReceiveMessage(
       async (message: any) => {

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -3,6 +3,28 @@ import * as fs from "fs";
 import path = require("path");
 export const isEditorActive = (): boolean => !!vscode.window.activeTextEditor;
 
+
+export interface Environment {
+  name: string;
+}
+
+export interface Input {
+  selectedEnvironment: string;
+  environments: Environment[];
+}
+
+
+// Function to transform the input object to an array of environment names
+export function transformToEnvironmentsArray(input: string): string[] {
+  const envResult = JSON.parse(input);
+  if (!envResult || !envResult.environments) {
+    return [];
+  }
+
+  return envResult.environments.map((env: { name: string; }) => env.name);
+}
+
+
 export const isFileExtensionSQL = (fileName: string): boolean => {
   fileName = fileName.toLowerCase();
 

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -51,6 +51,7 @@ import { updateValue } from "./utilities/helper";
 import MessageAlert from "@/components/ui/alerts/AlertMessage.vue";
 import { getAssetDataset } from "@/components/lineage-flow/asset-lineage/useAssetLineage";
 import { ArrowPathIcon } from "@heroicons/vue/20/solid";
+import type { EnvironmentsList } from "./types";
 
 const panelType = ref("");
 const parseError = ref();
@@ -94,33 +95,25 @@ window.addEventListener("message", (event) => {
   }
 });
 
-interface Environment {
-  name: string;
-}
-
-interface EnvironmentsList {
-  selected_environment: string;
-  environments: Environment[];
-}
 
 const activeTab = ref(0);
 
  const environmentsList = computed(() => {
   if(!environments.value) return [];
-  return parseEnvironmentList(environments.value);
+  return parseEnvironmentList(environments.value)?.environments || [];
 }); 
+
+
+const selectedEnvironment = computed(() => {
+  if(!environments.value) return [];
+  return parseEnvironmentList(environments.value)?.selectedEnvironment || "something went wrong";
+});
 
 const assetDetailsProps = computed(() => {
   if (!data.value) return null;
   return parseAssetDetails(data.value);
 });
 
-
-/* const assetName = computed(() => {
-  if (!data.value) return null;
-  return parseAssetDetails(data.value)?.name;
-});
- */
 
 const tabs = ref([
   /* { label: "General", component: AssetGeneral, props: { name: assetName }, includeIn: ["bruin"] }, */
@@ -131,6 +124,7 @@ const tabs = ref([
     props: computed(() => ({
       ...assetDetailsProps.value,
       environments: environmentsList.value,
+      selectedEnvironment: selectedEnvironment.value,
     })),
   },
   { label: "Asset Lineage", component: AssetLineageText, includeIn: ["bruin"] },

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -54,7 +54,7 @@ import { ArrowPathIcon } from "@heroicons/vue/20/solid";
 
 const panelType = ref("");
 const parseError = ref();
-
+const environments = ref([]);
 const data = ref(
   JSON.stringify({
     asset: {
@@ -74,8 +74,9 @@ window.addEventListener("message", (event) => {
   switch (message.command) {
     case "init":
       panelType.value = message.panelType;
+      environments.value = message.payload;
       console.log("---------------------------\n");
-      console.log("Panel Type", message.panelType);
+      console.log("Environments", message.payload);
       break;
     case "parse-message":
       console.log("Parse Message", message);
@@ -110,7 +111,10 @@ const tabs = ref([
     label: "Asset Details",
     component: AssetDetails,
     includeIn: ["bruin"],
-    props: assetDetailsProps || null,
+    props: computed(() => ({
+      ...assetDetailsProps.value,
+      environments: environments.value,
+    })),
   },
   { label: "Asset Lineage", component: AssetLineageText, includeIn: ["bruin"] },
   {

--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -33,7 +33,7 @@
     <vscode-divider class="border-t border-editor-border opacity-20 my-4"></vscode-divider>
 
     <div class="w-full">
-      <AssetGeneral :schedule="scheduleExists ?  props.pipeline.schedule : ''"/>
+      <AssetGeneral :schedule="scheduleExists ?  props.pipeline.schedule : ''" :environments="environments"/>
     </div>
   </div>
 </template>
@@ -53,6 +53,7 @@ const props = defineProps<{
   owner: string;
   id: string;
   pipeline: any;
+  environments: string[]; 
 }>();
 
 const ownerExists = computed(() => {

--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -33,7 +33,7 @@
     <vscode-divider class="border-t border-editor-border opacity-20 my-4"></vscode-divider>
 
     <div class="w-full">
-      <AssetGeneral :schedule="scheduleExists ?  props.pipeline.schedule : ''" :environments="environments"/>
+      <AssetGeneral :schedule="scheduleExists ?  props.pipeline.schedule : ''" :environments="environments" :selectedEnvironment="selectedEnvironment"/>
     </div>
   </div>
 </template>
@@ -54,6 +54,7 @@ const props = defineProps<{
   id: string;
   pipeline: any;
   environments: string[]; 
+  selectedEnvironment: string;
 }>();
 
 const ownerExists = computed(() => {

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -23,7 +23,7 @@
           </div>
         </div>
         <div class="flex flex-wrap justify-between items-center"> 
-       <EnvSelectMenu :options="['default', 'env 1', 'env 2']" @selected-env="setSelectedEnv" /> 
+       <EnvSelectMenu :options="environments || ['default']" @selected-env="setSelectedEnv" /> 
         <div class="flex justify-end items-center space-x-2 sm:space-x-4 mt-2 sm:mt-0">
           <div class="inline-flex rounded-md shadow-sm">
             <button
@@ -214,7 +214,7 @@ const isNotAsset = computed(() => (renderAssetAlert.value ? true : false));
 
 const props = defineProps<{
   schedule: string;
-  environements?: string [];
+  environments: string [];
 }>();
 
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -23,7 +23,7 @@
           </div>
         </div>
         <div class="flex flex-wrap justify-between items-center"> 
-       <EnvSelectMenu :options="environments || ['default']" @selected-env="setSelectedEnv" /> 
+       <EnvSelectMenu :options="environments" @selected-env="setSelectedEnv" :selectedEnvironment="selectedEnvironment" /> 
         <div class="flex justify-end items-center space-x-2 sm:space-x-4 mt-2 sm:mt-0">
           <div class="inline-flex rounded-md shadow-sm">
             <button
@@ -215,7 +215,9 @@ const isNotAsset = computed(() => (renderAssetAlert.value ? true : false));
 const props = defineProps<{
   schedule: string;
   environments: string [];
+  selectedEnvironment: string;
 }>();
+
 
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 import { ChevronDownIcon, CheckCircleIcon, XCircleIcon } from "@heroicons/vue/24/solid";

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -248,6 +248,7 @@ const checkboxItems = ref([
 
 function runAssetOnly() {
   let payload = getCheckboxChangePayload();
+  payload = payload + " --environment " + selectedEnv.value;
   vscode.postMessage({
     command: "bruin.runSql",
     payload: payload,
@@ -256,7 +257,7 @@ function runAssetOnly() {
 
 function runAssetWithDownstream() {
   let payload = getCheckboxChangePayload();
-  payload = payload + " --downstream";
+  payload = payload + " --downstream" + " --environment " + selectedEnv.value;
   vscode.postMessage({
     command: "bruin.runSql",
     payload: payload,
@@ -265,6 +266,7 @@ function runAssetWithDownstream() {
 
 function runCurrentPipeline() {
   let payload = getCheckboxChangePayload();
+  payload = payload + " --downstream" + " --environment " + selectedEnv.value;
   vscode.postMessage({
     command: "bruin.runCurrentPipeline",
     payload: payload,

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -22,8 +22,8 @@
             <CheckboxGroup :checkboxItems="checkboxItems" />
           </div>
         </div>
-        <!-- <div class="flex flex-wrap justify-between items-center"> -->
-        <!-- <EnvSelectMenu :options="['default', 'env 1', 'env 2']" @selected-env="setSelectedEnv" /> -->
+        <div class="flex flex-wrap justify-between items-center"> 
+       <EnvSelectMenu :options="['default', 'env 1', 'env 2']" @selected-env="setSelectedEnv" /> 
         <div class="flex justify-end items-center space-x-2 sm:space-x-4 mt-2 sm:mt-0">
           <div class="inline-flex rounded-md shadow-sm">
             <button
@@ -180,8 +180,8 @@
             </Menu>
           </div>
         </div>
-        <!--         </div>
- -->
+             </div>
+ 
         <ErrorAlert v-if="isError" :errorMessage="errorMessage!" />
         <div v-if="language === 'sql'">
           <SqlEditor v-show="!isError" :code="code" :copied="false" :language="language" />
@@ -214,6 +214,7 @@ const isNotAsset = computed(() => (renderAssetAlert.value ? true : false));
 
 const props = defineProps<{
   schedule: string;
+  environements?: string [];
 }>();
 
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
@@ -267,6 +268,7 @@ function runCurrentPipeline() {
     payload: payload,
   });
 }
+
 const selectedEnv = ref<string>("default");
 
 function setSelectedEnv(env: string) {

--- a/webview-ui/src/components/ui/select-menu/EnvSelectMenu.vue
+++ b/webview-ui/src/components/ui/select-menu/EnvSelectMenu.vue
@@ -14,6 +14,9 @@
         </vscode-option>
       </vscode-dropdown>
     </div>
+    <div>
+      <span  class="text-sm font-semibold text-editor-fg"> {{selectedEnvironment}} </span>
+    </div>
   </div>
 </template>
 
@@ -22,6 +25,7 @@ import { defineProps, defineEmits } from 'vue';
 
 const props = defineProps<{
   options: string[];
+  selectedEnvironment: string;
 }>();
 
 const emit = defineEmits(['selectedEnv']);

--- a/webview-ui/src/components/ui/select-menu/EnvSelectMenu.vue
+++ b/webview-ui/src/components/ui/select-menu/EnvSelectMenu.vue
@@ -4,7 +4,7 @@
       <span class="text-sm font-semibold text-editor-fg"> Environment </span>
     </div>
     <div class="p-4">
-      <vscode-dropdown @change="handleSelect" >
+      <vscode-dropdown @change="handleSelect">
         <vscode-option 
           v-for="option in options" 
           :key="option" 
@@ -13,9 +13,6 @@
           {{ option }}
         </vscode-option>
       </vscode-dropdown>
-    </div>
-    <div>
-      <span  class="text-sm font-semibold text-editor-fg"> {{selectedEnvironment}} </span>
     </div>
   </div>
 </template>

--- a/webview-ui/src/components/ui/select-menu/EnvSelectMenu.vue
+++ b/webview-ui/src/components/ui/select-menu/EnvSelectMenu.vue
@@ -9,7 +9,6 @@
           v-for="option in options" 
           :key="option" 
           :value="option"
-          :disabled="option !== 'default'"
         >
           {{ option }}
         </vscode-option>

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -88,3 +88,13 @@ interface File {
   content: string;
   type: string;
 }
+
+
+interface Environment {
+  name: string;
+}
+
+export interface EnvironmentsList {
+  selectedEnvironment: string;
+  environments: Environment[];
+}

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -122,3 +122,14 @@ export const parseAssetDetails = (data: string) => {
 
   return assetDetails;
 };
+
+export const parseEnvironmentList = (data) => {
+  if (!data) return;
+
+  const parsedData = JSON.parse(data);
+
+  const environments = parsedData.environments.map((env) => env.name);
+
+  return environments;
+}
+  

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -127,8 +127,10 @@ export const parseEnvironmentList = (data) => {
   if (!data) return;
 
   const parsedData = JSON.parse(data);
-
-  const environments = parsedData.environments.map((env) => env.name);
+  const environments = {
+    selectedEnvironment: parsedData.selected_environment,
+    environments: parsedData.environments.map((env) => env.name)
+  };
 
   return environments;
 }


### PR DESCRIPTION
# PR Overview

This PR introduces a new feature for selecting environments within the extension. The following key changes have been made:

- Added a dropdown component to allow users to select an environment from a list.
- Integrated a Bruin command to retrieve the environment list from the CLI.
- Refactored the Vue component to handle the environments list provided by the VS Code extension.
- Ensures the environments are dynamically fetched and up-to-date.
- The default environment is pre-selected based on the provided selected_environment from the CLI.
- The selected environment is concatenated into the run command to ensure the command executes in the correct environment.


![select-env-for-run](https://github.com/bruin-data/bruin-vscode/assets/25383275/def47a2d-93d1-4c38-8063-7add1d6f6f00)

