### PR TITLE
Display render icon on ingestr assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
       "editor/title": [
         {
           "command": "bruin.renderSQL",
-          "when": "resourceExtname == .sql || resourceExtname == .py  || resourceExtname == .yml",
+          "when": "resourceExtname == .sql || resourceExtname == .py  || resourceExtname == .yml || resourceExtname == .yaml",
           "group": "navigation"
         }
       ]

--- a/src/bruin/bruinRender.ts
+++ b/src/bruin/bruinRender.ts
@@ -69,7 +69,7 @@ export class BruinRender extends BruinCommand {
       });
   }
   private async isValidAsset(filePath: string): Promise<boolean> {
-    if (!isBruinAsset(filePath, ["py", "sql", "asset.yml"]) || (await isBruinYaml(filePath))) {
+    if (!isBruinAsset(filePath, ["py", "sql", "asset.yml", "asset.yaml"]) || (await isBruinYaml(filePath))) {
       BruinPanel?.postMessage("render-message", {
         status: "non-asset-alert",
         message: "-- This is not a BRUIN asset --",

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -55,7 +55,7 @@ export const isBruinPipeline = async (fileName: string): Promise<boolean> => {
   return path.basename(fileName) === "pipeline.yml" ? true : false;
 };
 export const isYamlBruinAsset = async (fileName: string): Promise<boolean> =>
-  isBruinAsset(fileName, ["asset.yml"]);
+  isBruinAsset(fileName, ["asset.yml", "asset.yaml"]);
 
 export const isBruinYaml = async (fileName: string): Promise<boolean> => {
   return getFileExtension(fileName) === "bruin.yml" ? true : false;
@@ -79,7 +79,7 @@ export const isBruinAsset = async (
 
   try {
     const assetContent = fs.readFileSync(fileName, "utf8");
-    const bruinAsset = bruinPattern.test(assetContent) || fileExtension === "asset.yml";
+    const bruinAsset = bruinPattern.test(assetContent) || fileExtension === "asset.yml" || fileExtension === "asset.yaml";
     console.log("============================================");
     console.log("this file" + fileName + "is bruin asset " + bruinAsset);
     return bruinAsset;


### PR DESCRIPTION
# PR Overview

This pull request addresses the issue where the rocket icon doesn't display for ingestr asset YAML files. The problem was due to the use of the .yaml extension instead of .yml.  With this fix, the rocket icon will correctly display for ingestr asset files with both .yaml and .yml extensions.

## Changes:

- Updated the code to include the .yaml extension for ingestr asset files.
- Ensured the rocket icon was displayed for both .yaml and .yml files.

