### PR TITLE
Add Bruin Python and SQL Snippets with Snowflake and BigQuery Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,12 +64,16 @@
     },
     "snippets": [
       {
-        "fileTypes": ["sql"],
+        "language": "sql",
+        "path": "./snippets/bruin-sql.code-snippets"
+      },
+      {
+        "language": "snowflake-sql",
         "path": "./snippets/bruin-sql.code-snippets"
       },
       {
         "language": "python",
-        "path": "./snippets/bruin-python.json"
+        "path": "./snippets/bruin-python.code-snippets"
       }
     ],
     "grammars": [

--- a/package.json
+++ b/package.json
@@ -62,6 +62,16 @@
         }
       }
     },
+    "snippets": [
+      {
+        "fileTypes": ["sql"],
+        "path": "./snippets/bruin-sql.code-snippets"
+      },
+      {
+        "language": "python",
+        "path": "./snippets/bruin-python.json"
+      }
+    ],
     "grammars": [
       {
         "path": "./syntaxes/bruin-sql-injection.json",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
         "path": "./snippets/bruin-sql.code-snippets"
       },
       {
+        "language": "sql-bigquery",
+        "path": "./snippets/bruin-sql.code-snippets"
+      },
+      {
         "language": "snowflake-sql",
         "path": "./snippets/bruin-sql.code-snippets"
       },

--- a/snippets/bruin-python.code-snippets
+++ b/snippets/bruin-python.code-snippets
@@ -1,6 +1,6 @@
 {
     "Bruin Python Section": {
-      "prefix": "bruin",
+      "prefix": "bruinasset",
       "body": [
         "\"\"\"@bruin",
         "name: ${1:asset_name}",

--- a/snippets/bruin-python.json
+++ b/snippets/bruin-python.json
@@ -1,0 +1,29 @@
+{
+    "Bruin Python Section": {
+      "prefix": "bruin",
+      "body": [
+        "\"\"\"@bruin",
+        "name: ${1:asset_name}",
+        "type: python",
+        "",
+        "depends: ",
+        "  - ${2:dependency1}",
+        "  - ${3:dependency2}",
+        "",
+        "materialization:",
+        "   type: ${4|table,view,incremental|}",
+        "",
+        "columns:",
+        "  - name: ${5:column_name}",
+        "    type: ${6|integer,string,float,boolean,date,timestamp|}",
+        "    description: \"${7:column_description}\"",
+        "    checks:",
+        "        - name: ${8|unique,not_null,accepted_values|}",
+        "        ${9:- name: accepted_values}",
+        "          ${10:value: [\"val1\", \"val2\"]}",
+        "@bruin\"\"\"",
+        "$0"
+      ],
+      "description": "Insert a Bruin section for Python files"
+    }
+  }

--- a/snippets/bruin-sql.code-snippets
+++ b/snippets/bruin-sql.code-snippets
@@ -1,6 +1,6 @@
 {
     "Bruin SQL Section": {
-      "prefix": "bruin",
+      "prefix": "bruinasset",
       "body": [
         "/* @bruin",
         "name: ${1:asset_name}",

--- a/snippets/bruin-sql.code-snippets
+++ b/snippets/bruin-sql.code-snippets
@@ -1,0 +1,29 @@
+{
+    "Bruin SQL Section": {
+      "prefix": "bruin",
+      "body": [
+        "/* @bruin",
+        "name: ${1:asset_name}",
+        "type: bq.sql",
+        "",
+        "depends: ",
+        "  - ${2:dependency1}",
+        "  - ${3:dependency2}",
+        "",
+        "materialization:",
+        "   type: ${4|table,view,incremental|}",
+        "",
+        "columns:",
+        "  - name: ${5:column_name}",
+        "    type: ${6|integer,string,float,boolean,date,timestamp|}",
+        "    description: \"${7:column_description}\"",
+        "    checks:",
+        "        - name: ${8|unique,not_null,accepted_values|}",
+        "        ${9:- name: accepted_values}",
+        "          ${10:value:  [\"val1\", \"val2\"]}",
+        "@bruin */",
+        "$0"
+      ],
+      "description": "Insert a Bruin section for SQL files"
+    }
+  }


### PR DESCRIPTION
# PR Overview:

This PR enhances the development experience by introducing snippets for Bruin Python and SQL assets, supporting both Snowflake and BigQuery environments. Users can now generate standardized asset templates directly in the Vscode extension.

## Main Changes
- Implemented new snippets for creating Bruin Python and SQL asset templates within VS Code.
- Added support for Snowflake and BigQuery.

![bruin-snippet](https://github.com/bruin-data/bruin-vscode/assets/25383275/c424688d-ab44-4c30-b3fa-dc3a225af9e3)
