### PR TITLE
Fix resetting environment list on document change

### DIFF
--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -13,7 +13,6 @@ import { renderCommandWithFlags } from "../extension/commands/renderCommand";
 import { lineageCommand } from "../extension/commands/lineageCommand";
 import { parseAssetCommand } from "../extension/commands/parseAssetCommand";
 import { getEnvListCommand } from "../extension/commands/getEnvListCommand";
-import { Input, transformToEnvironmentsArray } from "../utilities/helperUtils";
 
 /**
  * This class manages the state and behavior of Bruin webview panels.
@@ -51,6 +50,9 @@ export class BruinPanel {
 
     this._disposables.push(
       workspace.onDidChangeTextDocument((editor) => {
+        if(editor && editor.document.uri.fsPath.endsWith(".bruin.yml")) {
+          getEnvListCommand(this._lastRenderedDocumentUri);
+        }
         if (editor && editor.document.uri) {
           if (editor.document.uri.fsPath === "tasks") {
             return;
@@ -59,11 +61,11 @@ export class BruinPanel {
           renderCommandWithFlags(this._flags);
           lineageCommand(this._lastRenderedDocumentUri);
           parseAssetCommand(this._lastRenderedDocumentUri);
-          getEnvListCommand(this._lastRenderedDocumentUri);
           console.log("Document URI onDidChangeTextDocument", this._lastRenderedDocumentUri);
         }
       }),
       window.onDidChangeActiveTextEditor((editor) => {
+      
         if (editor && editor.document.uri) {
           if (editor.document.uri.fsPath === "tasks") {
             return;
@@ -74,7 +76,6 @@ export class BruinPanel {
           renderCommandWithFlags(this._flags);
           lineageCommand(this._lastRenderedDocumentUri);
           parseAssetCommand(this._lastRenderedDocumentUri);
-          getEnvListCommand(this._lastRenderedDocumentUri);
         }
       })
     );


### PR DESCRIPTION
# PR Overview:

This pull request addresses an issue where the environment list was being updated unnecessarily whenever a file was opened or updated. This malfunction was also causing the `run` command to be executed with old and wrong environment values. The update to the environment list should only occur when the content of the `.bruin.yml` file changes.

### Changes:
1. **Modified Event Listeners:**
   - Updated the `workspace.onDidChangeTextDocument` listener to check for content changes or opening of the specific file `.bruin.yml`  and trigger the `getEnvListCommand` only when this file is detected.
   - Removed the unnecessary call to `getEnvListCommand` in the `window.onDidChangeActiveTextEditor` listener.

2. **Refactored Logic:**
   - Ensured that the environment list update logic is only executed when the `.bruin.yml` file changes, reducing redundant updates and fixing the bug.

