### PR TITLE
Update the Code Base to cover the old and new 'upstream' format from the CLI

### DIFF
--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -12,7 +12,7 @@
             <div v-if="data.type === 'asset'"
                  class=""
                  :class="[props.data.asset?.isFocusAsset ? 'ring-2 ring-offset-4 ring-indigo-300 outline-2 outline-dashed outline-offset-8 outline-indigo-300 w-56 rounded' : '',
-             data.highlight ? '' : 'opacity-50']"
+             data.highlight ? '' : '']"
             >
                 <div class="flex justify-between w-56" :class="status ? selectedStatusStyle : ''">
                     <div class="flex items-center px-2 font-mono text-sm font-semibold space-x-1">


### PR DESCRIPTION
#PR Overview:

Newer versions of Bruin CLI support a new type of upstream asset `external assets`, so, the returned JSON is updated to support this new format. However, the old format is still not deprecated. 

This PR updates the vscode extension to support the new `upstream` format while keeping the old one functioning. 

## Main changes:
- Updated the code base to support the new upstream format 
- Updated the opacity of the asset nodes in the lineage graph.

<img width="729" alt="Screenshot 2024-07-17 at 10 49 12" src="https://github.com/user-attachments/assets/f38c4659-2546-4817-90d9-b2bab20ef616">
