### PR TITLE
Decrease Vertical Node Spacing in Lineage Graph

### DIFF
--- a/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
+++ b/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
@@ -65,7 +65,7 @@ const updateLayout = async () => {
       "elk.layered.spacing.nodeNodeBetweenLayers": "150",
       "elk.layered.nodePlacement.bk.fixedAlignment": "BALANCED",
       "elk.direction": "RIGHT",
-      "elk.spacing.componentComponent": "200",
+      "elk.spacing.nodeNode": "0.0",
       "elk.layered.unnecessaryBendpoints": "true",
     },
     children: nodes.value.map((node) => ({


### PR DESCRIPTION
# PR Overview

This PR adjusts the vertical spacing between nodes in the lineage graph to improve layout visualization. 



![decrease_vertical_spcaing](https://github.com/user-attachments/assets/364ab4a4-d431-4ad4-b42e-9bd204ec5ef4)
