### PR TITLE
Lineage: Fix Node Dragging Issue

### DIFF
--- a/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
+++ b/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
@@ -36,7 +36,7 @@ import CustomNode from "@/components/lineage-flow/custom-nodes/CustomNodes.vue";
 import { generateGraphFromJSON } from "@/utilities/graphGenerator";
 import type { AssetDataset } from "@/types";
 
-const props = defineProps<AssetDataset>();
+const graphProps = defineProps<AssetDataset>();
 
 const nodeTypes: NodeTypesObject = {
   custom: CustomNode as any,
@@ -48,7 +48,7 @@ const elk = new ELK();
 
 // Function to update node positions based on ELK layout
 const updateNodePositions = (layout: any) => {
-  const updatedNodes = nodes.value.map(node => {
+  const updatedNodes = nodes.value.map((node) => {
     const layoutNode = layout.children.find((child: any) => child.id === node.id);
     if (layoutNode) {
       return {
@@ -99,9 +99,9 @@ const updateLayout = async () => {
 
 // Function to process the asset properties and update nodes and edges
 const processProperties = () => {
-  if (!props) return;
-
-  const { nodes: generatedNodes, edges: generatedEdges } = generateGraphFromJSON(props);
+  if (!graphProps) return;
+  // on node click update the props and re-render the graph
+  const { nodes: generatedNodes, edges: generatedEdges } = generateGraphFromJSON(graphProps);
   addNodes(generatedNodes);
   addEdges(generatedEdges);
 
@@ -110,7 +110,7 @@ const processProperties = () => {
 
 // Watch for changes in props and update nodes and edges
 watch(
-  () => props,
+  () => graphProps,
   (newValue) => {
     if (newValue) {
       processProperties();
@@ -121,8 +121,8 @@ watch(
 
 // Handle node dragging
 const onNodesDragged = (draggedNodes: NodeDragEvent[]) => {
-  const updatedNodes = nodes.value.map(node => {
-    const draggedNode = draggedNodes.find(n => n.node.id === node.id);
+  const updatedNodes = nodes.value.map((node) => {
+    const draggedNode = draggedNodes.find((n) => n.node.id === node.id);
     if (draggedNode) {
       return { ...node, position: draggedNode.node.position as XYPosition };
     }

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -34,19 +34,11 @@
                     class="rounded-b font-mono py-1 text-left w-56 px-1 border border-white/20"
                     :class="[selectedStyle.main, status ? '' : 'rounded-tl']">
                     <div class="truncate">
-                        {{ label }}
+                       {{ label }}
                     </div>
                 </div>
             </div>
 
-            <div v-else-if="data.type === 'dot'"
-                 class="rounded border border-dashed border-gray-400 bg-gray-300 opacity-25 h-full w-full text-sm p-2 font-mono">
-                {{ label }}
-            </div>
-            <div v-else
-                 class="rounded border border-dashed border-gray-400 bg-gray-300 opacity-25 h-full w-full text-sm p-2 font-mono">
-                Project: {{ data?.project?.name }}
-            </div>
         </div>
         <div @click.stop="props.onNodeDoubleClick?.(nodeProps)"
              class="ml-1 border border-gray-700/20 hover:border-gray-700/50 rounded h-full py-2"

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -8,7 +8,7 @@ import {
   adjustEndDateForExclusive,
   getUpstreams,
 } from "../utilities/helper";
-import { parsePipelineData } from "../utilities/getPipelineLineage";
+import { getAssetDependencies, parsePipelineData } from "../utilities/getPipelineLineage";
 import * as pipelineData from "../utilities/pipeline.json";
 
 suite("testing webview", () => {
@@ -451,4 +451,67 @@ suite("testing webview", () => {
     const pipelineAssets = parsePipelineData(null);
     assert.deepStrictEqual(pipelineAssets.assets, []);
   });
+
+  test("test getAssetDependencies with valid assetId", () => {
+    const pipelineAssets = parsePipelineData(pipelineData).assets;
+    const expectedOutput = {
+      "name": "test_dataset.test3",
+      "upstreams": [
+        {
+          "name": "test_dataset.test",
+          "upstreams": [],
+          "downstreams": []
+        },
+        {
+          "name": "test_dataset.test2",
+          "upstreams": [
+            {
+              "name": "test_dataset.test5",
+              "upstreams": [],
+              "downstreams": []
+            }
+          ],
+          "downstreams": []
+        },
+        {
+          "name": "test_dataset.test4",
+          "upstreams": [
+            {
+              "name": "test_dataset.test6",
+              "upstreams": [],
+              "downstreams": []
+            },
+            {
+              "name": "bigquery://some-query",
+              "upstreams": [],
+              "downstreams": []
+            }
+          ],
+          "downstreams": []
+        },
+        {
+          "name": "asset_uri",
+          "upstreams": [],
+          "downstreams": []
+        }
+      ],
+      "downstreams": []
+  };
+
+    const assetId = "842395685364ad0d4d6903bbb5b9cf48a54945774187f169327559e1453a7612";
+    const assetDependencies = getAssetDependencies(assetId, pipelineAssets);
+    const assetName = pipelineAssets.filter((asset) => asset.id === assetId)[0].name;
+   // assert.deepStrictEqual(assetName, "test_dataset.test3");
+    assert.deepStrictEqual(assetDependencies, expectedOutput);
+  }
+);
+
+test("test getAssetDependencies with assetId that has downstreams and upstreams ", () => {
+  const pipelineAssets = parsePipelineData(pipelineData).assets;
+
+  const assetId = "04a0d75146552e5e3305db450e7c5b402bd4bb8f8de813263166466f9f901a6b";
+  const assetDependencies = getAssetDependencies(assetId, pipelineAssets);
+  //assert.deepStrictEqual(assetDependencies, []);
+}
+);
 });

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -8,7 +8,7 @@ import {
   adjustEndDateForExclusive,
   getUpstreams,
 } from "../utilities/helper";
-import { getAssetDependencies, parsePipelineData } from "../utilities/getPipelineLineage";
+import { getAssetDependencies, parsePipelineData, processAssetDependencies } from "../utilities/getPipelineLineage";
 import * as pipelineData from "../utilities/pipeline.json";
 
 suite("testing webview", () => {
@@ -512,6 +512,39 @@ test("test getAssetDependencies with assetId that has downstreams and upstreams 
   const assetId = "04a0d75146552e5e3305db450e7c5b402bd4bb8f8de813263166466f9f901a6b";
   const assetDependencies = getAssetDependencies(assetId, pipelineAssets);
   //assert.deepStrictEqual(assetDependencies, []);
-}
-);
+});
+
+test("test processAssetDependencies with assetId that has no downstreams and some upstreams ", () => {
+  const pipelineAssets = parsePipelineData(pipelineData).assets;
+  const expectedOutput = {
+    "name": "test_dataset.test3",
+      "upstreams": [
+        {
+          "name": "test_dataset.test",
+          "hasUpstreamForClicking": false,
+          "hasDownstreamForClicking": false
+        },
+        {
+          "name": "test_dataset.test2",
+          "hasUpstreamForClicking": true,
+          "hasDownstreamForClicking": false
+        },
+        {
+          "name": "test_dataset.test4",
+          "hasUpstreamForClicking": true,
+          "hasDownstreamForClicking": false
+        },
+        {
+          "name": "asset_uri",
+          "hasUpstreamForClicking": false,
+          "hasDownstreamForClicking": false
+        }
+      ],
+      "downstreams": []
+  };
+  const assetId = "842395685364ad0d4d6903bbb5b9cf48a54945774187f169327559e1453a7612";
+  const assetDependencies = processAssetDependencies(assetId, pipelineAssets);
+  assert.deepStrictEqual(assetDependencies, expectedOutput);
+});
+
 });

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -1,40 +1,48 @@
-import { suite, test, assert, beforeEach, afterEach } from 'vitest';
-import * as  cronParser from 'cron-parser';
-import { isValidCron, resetStartEndDate, scheduleToCron, getPreviousRun, adjustEndDateForExclusive, getUpstreams } from '../utilities/helper';
+import { suite, test, assert, beforeEach, afterEach } from "vitest";
+import * as cronParser from "cron-parser";
+import {
+  isValidCron,
+  resetStartEndDate,
+  scheduleToCron,
+  getPreviousRun,
+  adjustEndDateForExclusive,
+  getUpstreams,
+} from "../utilities/helper";
+import { parsePipelineData } from "../utilities/getPipelineLineage";
+import * as pipelineData from "../utilities/pipeline.json";
 
-
-suite('testing webview', () => {
-  const environments = ['dev', 'qa', 'prod'];
+suite("testing webview", () => {
+  const environments = ["dev", "qa", "prod"];
   let schedule: string, today, startDate, endDate, startTime, endTime, isExclusiveEndDate: boolean;
 
-    /**
+  /**
    * Before each test, initialize common variables.
    */
 
   beforeEach(() => {
-    schedule = '' ;
-    today = new Date('2024-07-08T05:23:00.000Z');
-    startDate = { value: '' };
-    endDate = { value: '' };
-    startTime = '';
-    endTime = '';
+    schedule = "";
+    today = new Date("2024-07-08T05:23:00.000Z");
+    startDate = { value: "" };
+    endDate = { value: "" };
+    startTime = "";
+    endTime = "";
     isExclusiveEndDate = false;
   });
 
-    /**
+  /**
    * Test suite for scheduleToCron function.
    */
-  test('test scheduleToCron', () => {
-    const hourly = '0 * * * *';
-    const daily = '0 0 * * *';
-    const weekly = '0 0 * * 1';
-    const monthly = '0 0 1 * *';
+  test("test scheduleToCron", () => {
+    const hourly = "0 * * * *";
+    const daily = "0 0 * * *";
+    const weekly = "0 0 * * 1";
+    const monthly = "0 0 1 * *";
 
-    const cronHourly = scheduleToCron('hourly');
-    const cronDaily = scheduleToCron('daily');
-    const cronWeekly = scheduleToCron('weekly');
-    const cronMonthly = scheduleToCron('monthly');
-    const cronInvalid = scheduleToCron('invalid');
+    const cronHourly = scheduleToCron("hourly");
+    const cronDaily = scheduleToCron("daily");
+    const cronWeekly = scheduleToCron("weekly");
+    const cronMonthly = scheduleToCron("monthly");
+    const cronInvalid = scheduleToCron("invalid");
 
     assert.deepStrictEqual(cronHourly, { cronSchedule: hourly, error: null });
     assert.deepStrictEqual(cronDaily, { cronSchedule: daily, error: null });
@@ -45,11 +53,11 @@ suite('testing webview', () => {
     assert.match(cronInvalid.error as string, /^Invalid schedule: invalid\. .*$/);
   });
 
- /**
+  /**
    * Test if selected environment is correctly initialized with default.
    */
-  test('initializes selectedEnv with default environment', () => {
-    const selectedEnvironment = 'qa';
+  test("initializes selectedEnv with default environment", () => {
+    const selectedEnvironment = "qa";
     const wrapper = {
       vm: {
         selectedEnv: null as string | null,
@@ -59,10 +67,10 @@ suite('testing webview', () => {
     assert.strictEqual(wrapper.vm.selectedEnv, selectedEnvironment);
   });
 
-    /**
+  /**
    * Test handling of null selectedEnvironment.
    */
-  test('handles edge case of null selectedEnvironment', () => {
+  test("handles edge case of null selectedEnvironment", () => {
     const wrapper = {
       vm: {
         selectedEnv: null,
@@ -74,8 +82,8 @@ suite('testing webview', () => {
   /**
    * Test handling when selectedEnv is not in the list of environments.
    */
-  test('handles edge case when selectedEnv is not in the list of environments', () => {
-    const selectedEnvironment = 'staging';
+  test("handles edge case when selectedEnv is not in the list of environments", () => {
+    const selectedEnvironment = "staging";
     const wrapper = {
       vm: {
         selectedEnv: null as string | null,
@@ -93,22 +101,22 @@ suite('testing webview', () => {
   /**
    * Test suite for cron parser.
    */
-  test('test cron parser', () => {
-    const fixedDate = new Date('2023-06-15T12:00:00.000Z');
-    const interval = cronParser.parseExpression('0 0 1 * *', { currentDate: fixedDate, tz: 'UTC' });
+  test("test cron parser", () => {
+    const fixedDate = new Date("2023-06-15T12:00:00.000Z");
+    const interval = cronParser.parseExpression("0 0 1 * *", { currentDate: fixedDate, tz: "UTC" });
 
     const next = interval.next().toDate();
     const expectedNextDate = new Date(Date.UTC(2023, 6, 1, 0, 0, 0, 0));
 
     assert.strictEqual(next.toISOString(), expectedNextDate.toISOString());
   });
- 
-    /**
+
+  /**
    * Test suite for isValidCron function.
    */
-  test('test is valid cron ', () => {
-    const cron = '0 0 1 * *';
-    const invalidCron = '0 0 1 * * *';
+  test("test is valid cron ", () => {
+    const cron = "0 0 1 * *";
+    const invalidCron = "0 0 1 * * *";
 
     const isValid = isValidCron(cron);
     const isInvalid = isValidCron(invalidCron);
@@ -117,278 +125,330 @@ suite('testing webview', () => {
     assert.strictEqual(isInvalid, true);
   });
 
-   /**
+  /**
    * Test suite for getPreviousRun function with "hourly" schedule.
    */
 
   test('test get previous run for "hourly" schedule', () => {
-    schedule = 'hourly';
+    schedule = "hourly";
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2024-07-08T04:00:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2024-07-08T05:00:00.000Z').getTime());
+    assert.strictEqual(startTime, new Date("2024-07-08T04:00:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-07-08T05:00:00.000Z").getTime());
   });
 
-
-   /**
+  /**
    * Test suite for getPreviousRun function with "daily" schedule.
    */
   test('test get previous run for "daily" schedule', () => {
-    schedule = 'daily';
+    schedule = "daily";
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2024-07-07T00:00:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2024-07-08T00:00:00.000Z').getTime());
+    assert.strictEqual(startTime, new Date("2024-07-07T00:00:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-07-08T00:00:00.000Z").getTime());
   });
-   /**
+  /**
    * Test suite for getPreviousRun function with "weekly" schedule.
    */
-  
+
   test('test get previous run for "weekly" schedule', () => {
-    schedule = 'weekly';
+    schedule = "weekly";
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2024-07-01T00:00:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2024-07-08T00:00:00.000Z').getTime()); 
-});
-   /**
+    assert.strictEqual(startTime, new Date("2024-07-01T00:00:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-07-08T00:00:00.000Z").getTime());
+  });
+  /**
    * Test suite for getPreviousRun function with "monthly" schedule.
    */
   test('test get previous run for "monthly" schedule', () => {
-    schedule = 'monthly';
+    schedule = "monthly";
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2024-06-01T00:00:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2024-07-01T00:00:00.000Z').getTime());
+    assert.strictEqual(startTime, new Date("2024-06-01T00:00:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-07-01T00:00:00.000Z").getTime());
   });
 
   /**
    * Test suite for getPreviousRun function with specific cron expressions.
    */
   test('test get previous run for "2 17 * * *"', () => {
-    schedule = '2 17 * * *';
+    schedule = "2 17 * * *";
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2024-07-06T17:02:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2024-07-07T17:02:00.000Z').getTime());
+    assert.strictEqual(startTime, new Date("2024-07-06T17:02:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-07-07T17:02:00.000Z").getTime());
   });
 
   test('test get previous run for "30 17 * * *"', () => {
-    schedule = '30 17 * * *';
+    schedule = "30 17 * * *";
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2024-07-06T17:30:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2024-07-07T17:30:00.000Z').getTime());
+    assert.strictEqual(startTime, new Date("2024-07-06T17:30:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-07-07T17:30:00.000Z").getTime());
   });
 
   test('test get previous run for "0 18 * * *"', () => {
-    schedule = '0 18 * * *';
+    schedule = "0 18 * * *";
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2024-07-06T18:00:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2024-07-07T18:00:00.000Z').getTime());
+    assert.strictEqual(startTime, new Date("2024-07-06T18:00:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-07-07T18:00:00.000Z").getTime());
   });
-    test('test get previous run for "0 19 * 6 *"', () => {
-    schedule = '0 19 * 6 *'; // June
+  test('test get previous run for "0 19 * 6 *"', () => {
+    schedule = "0 19 * 6 *"; // June
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2024-06-29T19:00:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2024-06-30T19:00:00.000Z').getTime());
+    assert.strictEqual(startTime, new Date("2024-06-29T19:00:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-06-30T19:00:00.000Z").getTime());
   });
 
   test('test get previous run for "0 20 * * 1-5"', () => {
-    schedule = '0 20 * * 1-5'; // Weekdays (Monday to Friday)
+    schedule = "0 20 * * 1-5"; // Weekdays (Monday to Friday)
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2024-07-04T20:00:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2024-07-05T20:00:00.000Z').getTime());
+    assert.strictEqual(startTime, new Date("2024-07-04T20:00:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-07-05T20:00:00.000Z").getTime());
   });
 
   test('test get previous run for "0 20 * * 6,7"', () => {
-    schedule = '0 20 * * 6,7'; // Saturday and Sunday
+    schedule = "0 20 * * 6,7"; // Saturday and Sunday
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2024-07-06T20:00:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2024-07-07T20:00:00.000Z').getTime());
+    assert.strictEqual(startTime, new Date("2024-07-06T20:00:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-07-07T20:00:00.000Z").getTime());
   });
 
   test('test get previous run for "0 20 10 7 *"', () => {
-    schedule = '0 20 10 7 *'; // July 10th
+    schedule = "0 20 10 7 *"; // July 10th
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date('2022-07-10T20:00:00.000Z').getTime());
-    assert.strictEqual(endTime, new Date('2023-07-10T20:00:00.000Z').getTime());
+    assert.strictEqual(startTime, new Date("2022-07-10T20:00:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2023-07-10T20:00:00.000Z").getTime());
   });
-  
-    /**
+
+  /**
    * Test suite for resetStartEndDate function.
    */
-  test ('test reset Start End Date for "hourly" schedule', () => {
-    schedule = 'hourly';
+  test('test reset Start End Date for "hourly" schedule', () => {
+    schedule = "hourly";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-07-08T04:00:00.000');
-    assert.strictEqual(endDate.value, '2024-07-08T05:00:00.000');
+    assert.strictEqual(startDate.value, "2024-07-08T04:00:00.000");
+    assert.strictEqual(endDate.value, "2024-07-08T05:00:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-07-08T04:59:59.999999999Z');
+    assert.strictEqual(endDateExclusive, "2024-07-08T04:59:59.999999999Z");
   });
   test('test reset Start End Date for "daily" schedule', () => {
-    schedule = 'daily';
+    schedule = "daily";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-07-07T00:00:00.000');
-    assert.strictEqual(endDate.value, '2024-07-08T00:00:00.000');
-
+    assert.strictEqual(startDate.value, "2024-07-07T00:00:00.000");
+    assert.strictEqual(endDate.value, "2024-07-08T00:00:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-07-07T23:59:59.999999999Z');
+    assert.strictEqual(endDateExclusive, "2024-07-07T23:59:59.999999999Z");
   });
 
   test('test reset Start End Date for "weekly" schedule', () => {
-    schedule = 'weekly';
+    schedule = "weekly";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-07-01T00:00:00.000');
-    assert.strictEqual(endDate.value, '2024-07-08T00:00:00.000');
+    assert.strictEqual(startDate.value, "2024-07-01T00:00:00.000");
+    assert.strictEqual(endDate.value, "2024-07-08T00:00:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-07-07T23:59:59.999999999Z');
+    assert.strictEqual(endDateExclusive, "2024-07-07T23:59:59.999999999Z");
   });
 
   test('test reset Start End Date for "monthly" schedule', () => {
-    schedule = 'monthly';
+    schedule = "monthly";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-06-01T00:00:00.000');
-    assert.strictEqual(endDate.value, '2024-07-01T00:00:00.000');
+    assert.strictEqual(startDate.value, "2024-06-01T00:00:00.000");
+    assert.strictEqual(endDate.value, "2024-07-01T00:00:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-06-30T23:59:59.999999999Z');
+    assert.strictEqual(endDateExclusive, "2024-06-30T23:59:59.999999999Z");
   });
 
   test('test reset Start End Date for "2 17 * * *"', () => {
-    schedule = '2 17 * * *';
+    schedule = "2 17 * * *";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-07-06T17:02:00.000');
-    assert.strictEqual(endDate.value, '2024-07-07T17:02:00.000');
+    assert.strictEqual(startDate.value, "2024-07-06T17:02:00.000");
+    assert.strictEqual(endDate.value, "2024-07-07T17:02:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-07-07T17:01:59.999999999Z');
+    assert.strictEqual(endDateExclusive, "2024-07-07T17:01:59.999999999Z");
   });
 
   test('test reset Start End Date for "30 17 * * *"', () => {
-    schedule = '30 17 * * *';
+    schedule = "30 17 * * *";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-07-06T17:30:00.000');
-    assert.strictEqual(endDate.value, '2024-07-07T17:30:00.000');
+    assert.strictEqual(startDate.value, "2024-07-06T17:30:00.000");
+    assert.strictEqual(endDate.value, "2024-07-07T17:30:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-07-07T17:29:59.999999999Z');
-    
+    assert.strictEqual(endDateExclusive, "2024-07-07T17:29:59.999999999Z");
   });
 
   test('test reset Start End Date for "0 18 * * *"', () => {
-    schedule = '0 18 * * *';
+    schedule = "0 18 * * *";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-07-06T18:00:00.000');
-    assert.strictEqual(endDate.value, '2024-07-07T18:00:00.000');
+    assert.strictEqual(startDate.value, "2024-07-06T18:00:00.000");
+    assert.strictEqual(endDate.value, "2024-07-07T18:00:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-07-07T17:59:59.999999999Z');
+    assert.strictEqual(endDateExclusive, "2024-07-07T17:59:59.999999999Z");
   });
 
   test('test reset Start End Date for "2 * * * *"', () => {
-    schedule = '2 * * * *';
+    schedule = "2 * * * *";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-07-08T04:02:00.000');
-    assert.strictEqual(endDate.value, '2024-07-08T05:02:00.000');
+    assert.strictEqual(startDate.value, "2024-07-08T04:02:00.000");
+    assert.strictEqual(endDate.value, "2024-07-08T05:02:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-07-08T05:01:59.999999999Z');
+    assert.strictEqual(endDateExclusive, "2024-07-08T05:01:59.999999999Z");
   });
 
   test('test reset Start End Date for "0 19 * 6 *"', () => {
-    schedule = '0 19 * 6 *'; // June
+    schedule = "0 19 * 6 *"; // June
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-06-29T19:00:00.000');
-    assert.strictEqual(endDate.value, '2024-06-30T19:00:00.000');
+    assert.strictEqual(startDate.value, "2024-06-29T19:00:00.000");
+    assert.strictEqual(endDate.value, "2024-06-30T19:00:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-06-30T18:59:59.999999999Z');
-    
+    assert.strictEqual(endDateExclusive, "2024-06-30T18:59:59.999999999Z");
   });
 
   test('test reset Start End Date for "0 20 * * 1-5"', () => {
-    schedule = '0 20 * * 1-5'; // Weekdays (Monday to Friday)
+    schedule = "0 20 * * 1-5"; // Weekdays (Monday to Friday)
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-07-04T20:00:00.000');
-    assert.strictEqual(endDate.value, '2024-07-05T20:00:00.000');
+    assert.strictEqual(startDate.value, "2024-07-04T20:00:00.000");
+    assert.strictEqual(endDate.value, "2024-07-05T20:00:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-07-05T19:59:59.999999999Z');
+    assert.strictEqual(endDateExclusive, "2024-07-05T19:59:59.999999999Z");
   });
 
   test('test reset Start End Date for "0 20 * * 6,7"', () => {
-    schedule = '0 20 * * 6,7'; // Saturday and Sunday
+    schedule = "0 20 * * 6,7"; // Saturday and Sunday
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2024-07-06T20:00:00.000');
-    assert.strictEqual(endDate.value, '2024-07-07T20:00:00.000');
+    assert.strictEqual(startDate.value, "2024-07-06T20:00:00.000");
+    assert.strictEqual(endDate.value, "2024-07-07T20:00:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2024-07-07T19:59:59.999999999Z');
+    assert.strictEqual(endDateExclusive, "2024-07-07T19:59:59.999999999Z");
   });
 
   test('test reset Start End Date for "0 20 10 7 *"', () => {
-    schedule = '0 20 10 7 *'; // July 10th
+    schedule = "0 20 10 7 *"; // July 10th
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, '2022-07-10T20:00:00.000');
-    assert.strictEqual(endDate.value, '2023-07-10T20:00:00.000');
+    assert.strictEqual(startDate.value, "2022-07-10T20:00:00.000");
+    assert.strictEqual(endDate.value, "2023-07-10T20:00:00.000");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, '2023-07-10T19:59:59.999999999Z');
+    assert.strictEqual(endDateExclusive, "2023-07-10T19:59:59.999999999Z");
   });
 
- 
-  test ('test get previous run for invalid schedule', () => {
-    schedule = 'invalid';
+  test("test get previous run for invalid schedule", () => {
+    schedule = "invalid";
     try {
       const { startTime, endTime } = getPreviousRun(schedule, today);
-      assert.fail('Expected an error to be thrown');
+      assert.fail("Expected an error to be thrown");
     } catch (error: any) {
-      assert.deepStrictEqual(error.message, `Invalid schedule: ${schedule}. Please provide a valid cron expression or use 'hourly', 'daily', 'weekly', or 'monthly'.`);
+      assert.deepStrictEqual(
+        error.message,
+        `Invalid schedule: ${schedule}. Please provide a valid cron expression or use 'hourly', 'daily', 'weekly', or 'monthly'.`
+      );
     }
-  }
-  );
+  });
 
-  test('test get lineage text for old and new upstream format', () => {
-
-    const oldFormatasset ={
-      name:"asset1",
-      type:"python",
+  test("test get lineage text for old and new upstream format", () => {
+    const oldFormatasset = {
+      name: "asset1",
+      type: "python",
       upstream: [
         {
-          name:"asset2",
-          type:"python",
+          name: "asset2",
+          type: "python",
           executable_file: {
-            name:"asset2.py",
+            name: "asset2.py",
           },
           definition_file: {
-            name:"asset2.yml",
-          }
-        }
-      ]
-    }
-    const newFormatasset ={
-      name:"asset1",
-      type:"python",
+            name: "asset2.yml",
+          },
+        },
+      ],
+    };
+    const newFormatasset = {
+      name: "asset1",
+      type: "python",
       upstreams: [
         {
-          name:"asset2",
-          type:"python",
+          name: "asset2",
+          type: "python",
           executable_file: {
-            name:"asset2.py",
+            name: "asset2.py",
           },
           definition_file: {
-            name:"asset2.yml",
-          }
+            name: "asset2.yml",
+          },
         },
         {
-          name:"asset2",
+          name: "asset2",
           external: true,
-        }
-      ]
-    }
-  
+        },
+      ],
+    };
+
     const oldUpstream = getUpstreams(oldFormatasset);
     const newUpstream = getUpstreams(newFormatasset);
     assert.deepStrictEqual(oldUpstream, oldFormatasset.upstream);
     assert.deepStrictEqual(newUpstream, newFormatasset.upstreams);
-});
+  });
 
+  // test for parsePiplineData function using mock data from pipeline.json
+  test("test parsePiplineData", () => {
+    const pipelineAssets = parsePipelineData(pipelineData);
+
+    const assetTest2 = pipelineAssets.assets.find((asset) => asset.name === "test_dataset.test2");
+    const assetTest3 = pipelineAssets.assets.find((asset) => asset.name === "test_dataset.test3");
+    const assetTest4 = pipelineAssets.assets.find((asset) => asset.name === "test_dataset.test4");
+    assert.deepStrictEqual(assetTest3 && assetTest3.upstreams, [
+      "test_dataset.test",
+      "test_dataset.test2",
+      "test_dataset.test4",
+      "asset_uri",
+    ]);
+    assert.deepStrictEqual(assetTest3 && assetTest3.downstreams, []);
+    assert.deepStrictEqual(assetTest4 && assetTest4.upstreams, [
+      "test_dataset.test6",
+      "bigquery://some-query",
+    ]);
+    assert.deepStrictEqual(assetTest4 && assetTest4.downstreams, ["test_dataset.test3"]);
+    assert.deepStrictEqual(assetTest2 && assetTest2.upstreams, ["test_dataset.test5"]);
+    assert.deepStrictEqual(assetTest2 && assetTest2.downstreams, ["test_dataset.test3"]);
+  });
+
+  const pipelineDataNoUpstreamsDownstreams = {
+    assets: [
+      {
+        name: "test_dataset.test7",
+        upstreams: [],
+        downstreams: [],
+      },
+    ],
+  };
+
+  test("test parsePipelineData with no upstreams or downstreams", () => {
+    const pipelineAssets = parsePipelineData(pipelineDataNoUpstreamsDownstreams);
+
+    const assetTest7 = pipelineAssets.assets.find((asset) => asset.name === "test_dataset.test7");
+
+    assert.deepStrictEqual(assetTest7 && assetTest7.upstreams, []);
+    assert.deepStrictEqual(assetTest7 && assetTest7.downstreams, []);
+  });
+
+  test("test parsePipelineData with no assets", () => {
+    const pipelineAssets = parsePipelineData({ assets: [] });
+    assert.deepStrictEqual(pipelineAssets.assets, []);
+  });
+
+  test("test parsePipelineData with empty object", () => {
+    const pipelineAssets = parsePipelineData({});
+    assert.deepStrictEqual(pipelineAssets.assets, []);
+  });
+
+  test("test parsePipelineData with null", () => {
+    const pipelineAssets = parsePipelineData(null);
+    assert.deepStrictEqual(pipelineAssets.assets, []);
+  });
 });

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -106,6 +106,7 @@ export interface PipelineAssets {
 }
 
 export interface SimpleAsset {
+  id: string;
   name: string;
   type: string;
   upstreams: string[];

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -100,3 +100,17 @@ export interface EnvironmentsList {
   selectedEnvironment: string;
   environments: Environment[];
 }
+
+export interface PipelineAssets {
+  assets: SimpleAsset[];
+}
+
+export interface SimpleAsset {
+  name: string;
+  type: string;
+  upstreams: string[];
+  downstreams: string[];
+  hasUpstreamForClicking?: boolean;
+  hasDownstreamForClicking?: boolean;
+  isFocusAsset?: boolean;
+}

--- a/webview-ui/src/utilities/getPipelineLineage.ts
+++ b/webview-ui/src/utilities/getPipelineLineage.ts
@@ -1,0 +1,54 @@
+import type { PipelineAssets, SimpleAsset } from "@/types";
+
+/**
+ * Parses the pipeline data from the JSON object.
+ *
+ * @param pipelineJson The pipeline JSON object.
+ *
+ * @returns The pipeline assets.
+ *
+ */
+
+export const parsePipelineData = (pipelineJson): PipelineAssets => {
+  if (!pipelineJson) {
+    return { assets: [] };
+  }
+
+  if (!pipelineJson.assets || pipelineJson.assets.length === 0) {
+    return { assets: [] };
+  }
+  const assets = pipelineJson.assets.map((asset) => {
+    return {
+      id: asset.id,
+      name: asset.name,
+      type: asset.type,
+      upstreams: [],
+      downstreams: [],
+    };
+  });
+
+  const assetMap: { [name: string]: SimpleAsset } = {};
+  assets.forEach((asset) => {
+    assetMap[asset.name] = asset;
+  });
+
+  // Populate upstreams
+  pipelineJson.assets.forEach((asset) => {
+    if (asset.upstreams) {
+      const upstreamNames = asset.upstreams.map((upstream) => upstream.value);
+      assetMap[asset.name].upstreams = upstreamNames;
+    }
+  });
+
+  // Populate downstreams
+  pipelineJson.assets.forEach((asset) => {
+    if (asset.upstreams) {
+      asset.upstreams.forEach((upstream) => {
+        if (assetMap[upstream.value]) {
+          assetMap[upstream.value].downstreams.push(asset.name);
+        }
+      });
+    }
+  });
+  return { assets };
+};

--- a/webview-ui/src/utilities/getPipelineLineage.ts
+++ b/webview-ui/src/utilities/getPipelineLineage.ts
@@ -101,4 +101,31 @@ export const getAssetDependencies = (assetId: string, pipelineAssets: SimpleAsse
   return buildDependencyTree(assetId);
 };
 
+// function that process the asset dependencies and return the dependencies that can be clicked
 
+export const processAssetDependencies = (assetId: string, pipelineAssets: SimpleAsset[]): any => {
+  const assetDependencies = getAssetDependencies(assetId, pipelineAssets);
+  if (!assetDependencies) {
+    return null;
+  }
+
+  const processDependency = (dependency) => {
+    const hasUpstreamForClicking = dependency.upstreams.length > 0;
+    const hasDownstreamForClicking = dependency.downstreams.length > 0;
+    return {
+      name: dependency.name,
+      hasUpstreamForClicking,
+      hasDownstreamForClicking,
+    };
+  };
+
+  const processDependencies = (dependencies) => {
+    return dependencies.map(processDependency);
+  };
+
+  return {
+    name: assetDependencies.name,
+    upstreams: processDependencies(assetDependencies.upstreams),
+    downstreams: processDependencies(assetDependencies.downstreams),
+  };
+}

--- a/webview-ui/src/utilities/pipeline.json
+++ b/webview-ui/src/utilities/pipeline.json
@@ -1,0 +1,576 @@
+{
+    "legacy_id": "",
+    "name": "bruin-init",
+    "schedule": "2 17 * * *",
+    "start_date": "",
+    "definition_file": {
+      "name": "pipeline.yml",
+      "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/pipeline.yml"
+    },
+    "default_parameters": {},
+    "default_connections": {
+      "google_cloud_platform": "djamila-dev"
+    },
+    "assets": [
+      {
+        "id": "fbb7b5bf4ca348eeeebf8cc3660712859a5a1fbf18e83217a57ce203fb51d5c2",
+        "uri": "",
+        "name": "basic",
+        "description": "",
+        "type": "python",
+        "executable_file": {
+          "name": "asset.py",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/asset.py",
+          "content": ""
+        },
+        "definition_file": {
+          "name": "asset.py",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/asset.py",
+          "type": "comment"
+        },
+        "parameters": {},
+        "connection": "",
+        "secrets": [],
+        "materialization": null,
+        "columns": [],
+        "custom_checks": [],
+        "image": "",
+        "instance": "",
+        "owner": "",
+        "metadata": {},
+        "tags": [],
+        "snowflake": null,
+        "upstreams": [],
+        "upstream": []
+      },
+      {
+        "id": "3ada037570e5da866bb214bae5880da26f2220b9659a4c28799b504ff28ab4b4",
+        "uri": "",
+        "name": "public.ingestr_destiny",
+        "description": "",
+        "type": "ingestr",
+        "executable_file": {
+          "name": "",
+          "path": "",
+          "content": ""
+        },
+        "definition_file": {
+          "name": "asset_names.asset.yaml",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/asset_names.asset.yaml",
+          "type": "yaml"
+        },
+        "parameters": {
+          "destination": "postgres",
+          "source_connection": "neon",
+          "source_table": "public.test_merge"
+        },
+        "connection": "local",
+        "secrets": [],
+        "materialization": null,
+        "columns": [
+          {
+            "entity_attribute": null,
+            "name": "id",
+            "type": "integer",
+            "description": "Just a number",
+            "checks": [
+              {
+                "id": "484ee52bdd9e49dcde77e12618b799d2897f1894626573a5eff65391d112e8f8",
+                "name": "not_null",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "471cbd2380364e9bd7cbf5582483dc3ac399d7e5db09a19c525ef8ae30662748",
+                "name": "positive",
+                "value": null,
+                "blocking": true
+              }
+            ],
+            "primary_key": false,
+            "update_on_merge": false
+          }
+        ],
+        "custom_checks": [
+          {
+            "id": "379a9e0bad82b577bdb8ff893f4ab9112eb9c87b0c717078fdbb1f09213269a8",
+            "name": "This is a custom check name",
+            "description": "",
+            "query": "select count(*) from public.ingestr_destiny",
+            "value": 6,
+            "blocking": true
+          }
+        ],
+        "image": "",
+        "instance": "",
+        "owner": "",
+        "metadata": {},
+        "tags": [],
+        "snowflake": null,
+        "upstreams": [],
+        "upstream": []
+      },
+      {
+        "id": "0dcd4af9110c57d830557f390a423529739ce7d105e37e0733329f42479cddb9",
+        "uri": "",
+        "name": "test_dataset.test",
+        "description": "",
+        "type": "bq.sql",
+        "executable_file": {
+          "name": "test.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test.sql",
+          "content": ""
+        },
+        "definition_file": {
+          "name": "test.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test.sql",
+          "type": "comment"
+        },
+        "parameters": {},
+        "connection": "",
+        "secrets": [],
+        "materialization": {
+          "type": "table",
+          "strategy": "",
+          "partition_by": "",
+          "cluster_by": null,
+          "incremental_key": ""
+        },
+        "columns": [
+          {
+            "entity_attribute": null,
+            "name": "one",
+            "type": "integer",
+            "description": "Just a number",
+            "checks": [
+              {
+                "id": "202bdb6cea4132a3ca87aa2cdd3fc422092d5c4c71847bc834a77fdf8f049065",
+                "name": "unique",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "c1735029eb1ea93da2f0fbe4dd172ac8412bf9a65e50a3da22096e864f245614",
+                "name": "not_null",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "902bfe1959d1cb045a96b4683d1523e3f7e5e228fd141e32e07e427c1d380dfa",
+                "name": "negative",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "685192c8265e4ffd4378af05fe628be96869254d3866f79dbc145f8223b41f0a",
+                "name": "accepted_values",
+                "value": [
+                  1,
+                  2
+                ],
+                "blocking": true
+              }
+            ],
+            "primary_key": false,
+            "update_on_merge": false
+          }
+        ],
+        "custom_checks": [
+          {
+            "id": "11202db75f03682c83cbc3d33bd736b2467e2b43a2da8a1cc587ab1b7b460dcd",
+            "name": "This is a custom check name here",
+            "description": "",
+            "query": "select count(*) from test_dataset.test",
+            "value": 2,
+            "blocking": true
+          }
+        ],
+        "image": "",
+        "instance": "",
+        "owner": "",
+        "metadata": {},
+        "tags": [],
+        "snowflake": null,
+        "upstreams": [],
+        "upstream": []
+      },
+      {
+        "id": "49048325f91f37ede0c77e6187cd1ba8ac6bdcc7aac323bd4721bd4b6e92ac93",
+        "uri": "",
+        "name": "test_dataset.test2",
+        "description": "",
+        "type": "bq.sql",
+        "executable_file": {
+          "name": "test2.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test2.sql",
+          "content": ""
+        },
+        "definition_file": {
+          "name": "test2.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test2.sql",
+          "type": "comment"
+        },
+        "parameters": {},
+        "connection": "",
+        "secrets": [],
+        "materialization": {
+          "type": "table",
+          "strategy": "",
+          "partition_by": "",
+          "cluster_by": null,
+          "incremental_key": ""
+        },
+        "columns": [
+          {
+            "entity_attribute": null,
+            "name": "one",
+            "type": "integer",
+            "description": "Just a number",
+            "checks": [
+              {
+                "id": "4ad3d8d19d19b6dc3867a500a5a9343baf5523c7c915bbb1e05caab28bfec735",
+                "name": "unique",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "db7fe959cc791b1e05afa2602d7bec382f642f9024fabf21a83a779c955663fa",
+                "name": "not_null",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "65e868fec7269644000d2a913e8a68ec517edcb65cb05c52963cd1a8506a565d",
+                "name": "negative",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "f509a4173bfc02f7e889b6724220d8ffa2462a3d9ffb5834d03772b97450d2ad",
+                "name": "accepted_values",
+                "value": [
+                  1,
+                  2
+                ],
+                "blocking": true
+              }
+            ],
+            "primary_key": false,
+            "update_on_merge": false
+          }
+        ],
+        "custom_checks": [
+          {
+            "id": "c86f611eaa5c91a6f8acd3c94206be23839ef986264b1250e0afdff24067f0a1",
+            "name": "This is a custom check name here",
+            "description": "",
+            "query": "select count(*) from test_dataset.test",
+            "value": 2,
+            "blocking": true
+          }
+        ],
+        "image": "",
+        "instance": "",
+        "owner": "",
+        "metadata": {},
+        "tags": [],
+        "snowflake": null,
+        "upstreams": [
+          {
+            "type": "asset",
+            "value": "test_dataset.test5"
+          }
+        ],
+        "upstream": [
+          "test_dataset.test5"
+        ]
+      },
+      {
+        "id": "842395685364ad0d4d6903bbb5b9cf48a54945774187f169327559e1453a7612",
+        "uri": "",
+        "name": "test_dataset.test3",
+        "description": "",
+        "type": "bq.sql",
+        "executable_file": {
+          "name": "test3.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test3.sql",
+          "content": ""
+        },
+        "definition_file": {
+          "name": "test3.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test3.sql",
+          "type": "comment"
+        },
+        "parameters": {},
+        "connection": "",
+        "secrets": [],
+        "materialization": {
+          "type": "table",
+          "strategy": "",
+          "partition_by": "",
+          "cluster_by": null,
+          "incremental_key": ""
+        },
+        "columns": [],
+        "custom_checks": [],
+        "image": "",
+        "instance": "",
+        "owner": "",
+        "metadata": {},
+        "tags": [],
+        "snowflake": null,
+        "upstreams": [
+          {
+            "type": "asset",
+            "value": "test_dataset.test"
+          },
+          {
+            "type": "asset",
+            "value": "test_dataset.test2"
+          },
+          {
+            "type": "asset",
+            "value": "test_dataset.test4"
+          },
+          {
+            "type": "uri",
+            "value": "asset_uri"
+          }
+        ],
+        "upstream": [
+          "test_dataset.test",
+          "test_dataset.test2",
+          "test_dataset.test4"
+        ]
+      },
+      {
+        "id": "04a0d75146552e5e3305db450e7c5b402bd4bb8f8de813263166466f9f901a6b",
+        "uri": "",
+        "name": "test_dataset.test4",
+        "description": "",
+        "type": "bq.sql",
+        "executable_file": {
+          "name": "test4.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test4.sql",
+          "content": ""
+        },
+        "definition_file": {
+          "name": "test4.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test4.sql",
+          "type": "comment"
+        },
+        "parameters": {},
+        "connection": "",
+        "secrets": [],
+        "materialization": {
+          "type": "table",
+          "strategy": "",
+          "partition_by": "",
+          "cluster_by": null,
+          "incremental_key": ""
+        },
+        "columns": [
+          {
+            "entity_attribute": null,
+            "name": "column_name",
+            "type": "integer",
+            "description": "column_description",
+            "checks": [
+              {
+                "id": "f9ffcec05b2820e0affc47d53b78fbfa24025e4fa186aa52354321d81abbf731",
+                "name": "unique",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "8ee5038ce5ba790c8f0cc9edc70cfade753c1eb47320c24e7d114d8de16fff46",
+                "name": "accepted_values",
+                "value": [
+                  "val1",
+                  "val2"
+                ],
+                "blocking": true
+              }
+            ],
+            "primary_key": false,
+            "update_on_merge": false
+          }
+        ],
+        "custom_checks": [],
+        "image": "",
+        "instance": "",
+        "owner": "",
+        "metadata": {},
+        "tags": [],
+        "snowflake": null,
+        "upstreams": [
+          {
+            "type": "asset",
+            "value": "test_dataset.test6"
+          },
+          {
+            "type": "uri",
+            "value": "bigquery://some-query"
+          }
+        ],
+        "upstream": [
+          "test_dataset.test6"
+        ]
+      },
+      {
+        "id": "0846e19dafdf994dcc866608c38b5516207266f3289b9dafd20413fe0b6a5678",
+        "uri": "",
+        "name": "test_dataset.test5",
+        "description": "",
+        "type": "python",
+        "executable_file": {
+          "name": "test5.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test5.sql",
+          "content": ""
+        },
+        "definition_file": {
+          "name": "test5.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test5.sql",
+          "type": "comment"
+        },
+        "parameters": {},
+        "connection": "",
+        "secrets": [],
+        "materialization": {
+          "type": "table",
+          "strategy": "",
+          "partition_by": "",
+          "cluster_by": null,
+          "incremental_key": ""
+        },
+        "columns": [
+          {
+            "entity_attribute": null,
+            "name": "one",
+            "type": "integer",
+            "description": "Just another number",
+            "checks": [
+              {
+                "id": "f41936eb414a20b62b9c36a6350c2a5586515407dd63b0f4f9530ae94dd3f838",
+                "name": "unique",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "9d6699ee7a8fb34ec62bd8214c9bbfa7ecbb9b720747c0cb758232d1c9f35d30",
+                "name": "not_null",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "4fb94e0bf55a19f28a96f25cf76ea8c4e2bd511c9b0ce7a140c730365027d701",
+                "name": "negative",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "f9214b401710dbdc31938b578dd47ef45e3a74aa51a44e6f21a43533bf259202",
+                "name": "accepted_values",
+                "value": [
+                  1,
+                  2
+                ],
+                "blocking": true
+              }
+            ],
+            "primary_key": false,
+            "update_on_merge": false
+          }
+        ],
+        "custom_checks": [],
+        "image": "",
+        "instance": "",
+        "owner": "",
+        "metadata": {},
+        "tags": [],
+        "snowflake": null,
+        "upstreams": [],
+        "upstream": []
+      },
+      {
+        "id": "9669f46513643c48836a192c2f99882a51472c613f00919b81573f7cb77ef02a",
+        "uri": "",
+        "name": "test_dataset.test6",
+        "description": "",
+        "type": "python",
+        "executable_file": {
+          "name": "test6.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test6.sql",
+          "content": ""
+        },
+        "definition_file": {
+          "name": "test6.sql",
+          "path": "/Users/djamilabaroudi/Desktop/bruin-test/pipeline-one/assets/test6.sql",
+          "type": "comment"
+        },
+        "parameters": {},
+        "connection": "",
+        "secrets": [],
+        "materialization": {
+          "type": "table",
+          "strategy": "",
+          "partition_by": "",
+          "cluster_by": null,
+          "incremental_key": ""
+        },
+        "columns": [
+          {
+            "entity_attribute": null,
+            "name": "one",
+            "type": "integer",
+            "description": "Just another number",
+            "checks": [
+              {
+                "id": "b1f5150c59be07de452902f514befcce893eddc5baa56cafd65b8593af95da73",
+                "name": "unique",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "3ac27b41c7498bd460136fb5fe7e1a15c69a8f9c6c3aa8104def01b902d62281",
+                "name": "not_null",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "cd19c730076001d138b00d0d6e59829b1037ecffaea4a14e9b1542c37628cb05",
+                "name": "negative",
+                "value": null,
+                "blocking": true
+              },
+              {
+                "id": "dfa86a12e705a7ac3ed78520c02da74974dbbbff7ebe05f1941e88ea19af580a",
+                "name": "accepted_values",
+                "value": [
+                  1,
+                  2
+                ],
+                "blocking": true
+              }
+            ],
+            "primary_key": false,
+            "update_on_merge": false
+          }
+        ],
+        "custom_checks": [],
+        "image": "",
+        "instance": "",
+        "owner": "",
+        "metadata": {},
+        "tags": [],
+        "snowflake": null,
+        "upstreams": [],
+        "upstream": []
+      }
+    ],
+    "notifications": {
+      "slack": []
+    },
+    "catchup": false,
+    "retries": 0
+  }


### PR DESCRIPTION
# PR Overview

This PR addresses the issue of dragging nodes in the lineage graph. Previously, the node positions were overridden by ELK, preventing them from being dragged. With this fix, nodes can now be dragged freely, and clicking the refresh button will return them to their initial positions.

![lineage-dragging-nodes](https://github.com/user-attachments/assets/cdf2703b-1b3a-42d2-a5b3-1270d737e975)
