### PR TITLE
Enhance Error Messages with Detailed Phases While Keeping SQL Editor Visible

### DIFF
--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -181,9 +181,9 @@
         </div>
              </div>
  
-        <ErrorAlert v-if="isError" :errorMessage="errorMessage!" />
-        <div v-if="language === 'sql'">
-          <SqlEditor v-show="!isError" :code="code" :copied="false" :language="language" />
+        <ErrorAlert v-if="isError" :errorMessage="errorMessage!" class="mb-4"/>
+        <div v-if="language === 'sql'" class="mt-4">
+          <SqlEditor :code="code" :copied="false" :language="language" />
         </div>
         <div v-else class="overflow-hidden w-full h-20">
           <pre class="white-space"></pre>
@@ -381,10 +381,6 @@ function receiveMessage(event: { data: any }) {
       validationSuccess.value = updateValue(envelope, "success");
       validationError.value = updateValue(envelope, "error");
       validateButtonStatus.value = updateValue(envelope, "loading");
-      console.debug(
-        "-------------------------Validation result------------------------",
-        validationSuccess.value
-      );
       validateButtonStatus.value = determineValidationStatus(
         validationSuccess.value,
         validationError.value,

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -181,7 +181,7 @@
         </div>
              </div>
  
-        <ErrorAlert v-if="isError" :errorMessage="errorMessage!" class="mb-4"/>
+        <ErrorAlert v-if="isError" :errorMessage="errorMessage!" class="mb-4" :errorPhase="errorPhase"  @close="handleClose"/>
         <div v-if="language === 'sql'" class="mt-4">
           <SqlEditor :code="code" :copied="false" :language="language" />
         </div>
@@ -209,7 +209,11 @@ import { updateValue, resetStates, determineValidationStatus } from "@/utilities
 const errorState = computed(() => handleError(validationError.value, renderSQLAssetError.value));
 const isError = computed(() => errorState.value?.errorCaptured);
 const errorMessage = computed(() => errorState.value?.errorMessage);
+const handleClose = () => {
+  resetStates([validationError, renderSQLAssetError]);
+};
 const isNotAsset = computed(() => (renderAssetAlert.value ? true : false));
+const errorPhase = ref<"Validation" | "Rendering" | "Unknown">("Unknown");
 
 const props = defineProps<{
   schedule: string;
@@ -386,6 +390,7 @@ function receiveMessage(event: { data: any }) {
         validationError.value,
         validateButtonStatus.value
       );
+      errorPhase.value = validationError.value ? "Validation" : "Unknown";
       break;
 
     case "render-message":
@@ -395,6 +400,7 @@ function receiveMessage(event: { data: any }) {
       renderAssetAlert.value = updateValue(envelope, "non-asset-alert");
       code.value = renderSQLAssetSuccess.value || renderPythonAsset.value;
       language.value = renderSQLAssetSuccess.value ? "sql" : "python";
+      errorPhase.value = renderSQLAssetError.value ? "Rendering" : "Unknown";
 
       resetStates([validationError, validationSuccess, validateButtonStatus]);
       break;

--- a/webview-ui/src/components/ui/alerts/ErrorAlert.vue
+++ b/webview-ui/src/components/ui/alerts/ErrorAlert.vue
@@ -1,42 +1,60 @@
+Updated Error Display Component
+
 <template>
-  <div v-if="formattedErrorMessages.length" class="rounded-md bg-red-50 p-4 my-4 max-h-64 overflow-y-auto">
-    <div class="flex">
-      <div class="flex-shrink-0">
-        <XCircleIcon class="h-5 w-5 text-red-500" aria-hidden="true" />
+  <div
+    v-if="formattedErrorMessages.length"
+    class="rounded-md bg-red-50 p-4 my-4 overflow-hidden transition-all duration-300"
+    :class="{ 'h-16': !isExpanded, 'max-h-64': isExpanded }"
+  >
+    <div class="flex justify-between items-center">
+      <div class="flex items-center flex-grow">
+        <XCircleIcon class="h-5 w-5 text-red-500 mr-2" aria-hidden="true" />
+        <h3 class="text-lg font-medium text-red-800">{{ errorPhase }} Error</h3>
       </div>
-      <div class="ml-4">
-        <div v-for="(errorMessage, index) in formattedErrorMessages" :key="index" class="mb-4">
-          <h3 class="text-lg font-medium text-red-800" v-if="errorMessage.pipeline">
-            Pipeline: {{ errorMessage.pipeline }}
-          </h3>
-          <div v-for="(issue, issueIndex) in errorMessage.issues" :key="issueIndex" class="mt-3">
-            <h4 class="text-md font-semibold text-gray-900" v-if="issue.asset">
+      <div class="flex items-center">
+        <button @click="toggleOverallExpansion" class="text-red-500 mr-2">
+          <ChevronDownIcon v-if="!isExpanded" class="h-5 w-5" aria-hidden="true" />
+          <ChevronUpIcon v-else class="h-5 w-5" aria-hidden="true" />
+        </button>
+        <button @click="$emit('close')" class="text-red-700">
+          <XMarkIcon class="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+    <div v-if="isExpanded" class="mt-4 overflow-y-auto" style="max-height: 200px">
+      <div v-for="(errorMessage, index) in formattedErrorMessages" :key="index">
+        <div v-if="errorPhase === 'Validation'" class="mt-4">
+          <div @click="toggleExpansion(index)" class="flex items-center cursor-pointer">
+            <ChevronRightIcon
+              v-if="!errorMessage.expanded"
+              class="h-5 w-5 text-red-500"
+              aria-hidden="true"
+            />
+            <ChevronDownIcon v-else class="h-5 w-5 text-red-500" aria-hidden="true" />
+            <span class="ml-2 text-red-700">Pipeline: {{ errorMessage.pipeline }}</span>
+          </div>
+        </div>
+        <div v-if="errorMessage.expanded || errorPhase === 'Rendering'" class="ml-5 mt-2">
+          <div v-for="(issue, issueIndex) in errorMessage.issues" :key="issueIndex" class="mb-2">
+            <h4 v-if="issue.asset" class="text-md font-semibold text-gray-900">
               Asset: {{ issue.asset }}
             </h4>
             <p class="text-sm text-red-600">{{ issue.description }}</p>
-            <div
-              v-if="issue.context.length"
-              class="flex items-center space-x-1 mt-2 justify-end text-[color:var(--vscode-editor-background)]"
-            >
-              <span class="font-semibold">Details</span>
-              <transition name="fade">
-                <ChevronUpIcon
-                  v-if="issue.expanded.value"
-                  class="h-5 w-5"
-                  aria-hidden="true"
-                  @click="issue.expanded.value = !issue.expanded.value"
-                />
-                <ChevronDownIcon
-                  v-else
-                  class="h-5 w-5"
-                  aria-hidden="true"
-                  @click="issue.expanded.value = !issue.expanded.value"
-                />
-              </transition>
+            <div v-if="issue.context.length" class="flex items-center space-x-1 mt-2 justify-end">
+              <button
+                @click="toggleIssueExpansion(index, issueIndex)"
+                class="text-xs text-red-700 flex items-center"
+              >
+                <span class="mr-1">Details</span>
+                <ChevronUpIcon v-if="issue.expanded" class="h-4 w-4" aria-hidden="true" />
+                <ChevronDownIcon v-else class="h-4 w-4" aria-hidden="true" />
+              </button>
             </div>
-            <div class="text-sm text-gray-700 ml-1 mt-1 w-full" v-show="issue.expanded.value"> 
-            <pre class="whitespace-pre-wrap bg-red-100 rounded p-2">{{ formattedIssueContext(issue.context) }}</pre>
-          </div>
+            <div v-if="issue.expanded" class="text-sm text-gray-700 ml-1 mt-1 w-full">
+              <pre class="whitespace-pre-wrap bg-red-100 rounded p-2">{{
+                formattedIssueContext(issue.context)
+              }}</pre>
+            </div>
           </div>
         </div>
       </div>
@@ -44,96 +62,110 @@
   </div>
 </template>
 
-
 <script setup lang="ts">
-import { computed, ref } from "vue";
-import { defineProps } from "vue";
-import { XCircleIcon, ChevronDownIcon, ChevronUpIcon } from "@heroicons/vue/20/solid";
+import { ref, computed } from "vue";
+import {
+  XCircleIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  XMarkIcon,
+} from "@heroicons/vue/20/solid";
 import type { FormattedErrorMessage, ParsedValidationErrorMessage } from "@/types";
-
-// Define the types explicitly
 
 
 const props = defineProps<{
   errorMessage: string | any | null;
+  errorPhase: "Validation" | "Rendering" | "Unknown";
 }>();
 
-// Helper function to format issue context
+defineEmits(["close"]);
+
 const formattedIssueContext = (context: string[]) => context.join("\n");
 
-const formattedErrorMessages = computed<FormattedErrorMessage[]>(() => {
+const formattedErrorMessages = ref<FormattedErrorMessage[]>([]);
+
+const isExpanded = ref(false);
+
+const parseErrorMessage = () => {
   if (!props.errorMessage) return [];
 
   try {
     const errorObject = JSON.parse(props.errorMessage);
 
-    // Handling a simple error message from render command
     if (errorObject.error) {
       return [
         {
-          pipeline: null,
+          pipeline: "Unknown",
+          expanded: false,
           issues: [
             {
               asset: null,
               description: errorObject.error,
               context: [],
-              expanded: ref(false),
+              expanded: false,
             },
           ],
         },
       ];
     }
 
-    // Handling validation errors
     if (Array.isArray(errorObject) && errorObject.length > 0) {
-      return errorObject.map((validationError: ParsedValidationErrorMessage) => ({
-        pipeline: validationError.pipeline || null,
-        issues: Object.entries(validationError.issues || {})
-          .flatMap(([test, issues]) =>
-            issues.map(issue => ({
-              asset: issue.asset || null,
-              description: issue.description,
-              context: issue.context || [],
-              expanded: ref(false),
-            }))
-          ),
+      return errorObject.map((validationError: ParsedValidationErrorMessage, index) => ({
+        pipeline: validationError.pipeline || `Pipeline ${index + 1}`,
+        expanded: index === 0, // Only expand the first pipeline by default
+        issues: Object.entries(validationError.issues || {}).flatMap(([test, issues]) =>
+          issues.map((issue) => ({
+            asset: issue.asset || null,
+            description: issue.description,
+            context: issue.context || [],
+            expanded: false,
+          }))
+        ),
       }));
     }
-    
+
     return [];
   } catch (e) {
     console.error("Failed to parse error message:", e);
     return [
+      {
+        pipeline: "Error",
+        expanded: true,
+        issues: [
           {
-            pipeline: null,
-            issues: [
-              {
-                asset: null,
-                description: props.errorMessage,
-                context: [],
-                expanded: ref(false),
-              },
-            ],
+            asset: null,
+            description: props.errorMessage,
+            context: [],
+            expanded: false,
           },
-        ];;
+        ],
+      },
+    ];
   }
-});
+};
+
+// Initialize formattedErrorMessages
+formattedErrorMessages.value = parseErrorMessage();
+
+const toggleOverallExpansion = () => {
+  isExpanded.value = !isExpanded.value;
+};
+
+const toggleExpansion = (index: number) => {
+  formattedErrorMessages.value[index].expanded = !formattedErrorMessages.value[index].expanded;
+};
+
+const toggleIssueExpansion = (pipelineIndex: number, issueIndex: number) => {
+  formattedErrorMessages.value[pipelineIndex].issues[issueIndex].expanded =
+    !formattedErrorMessages.value[pipelineIndex].issues[issueIndex].expanded;
+};
 </script>
-
-
 
 <style scoped>
 pre {
   white-space: pre-wrap;
   word-wrap: break-word;
   line-height: 1.5;
-}
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0s;
-}
-.fade-enter,
-.fade-leave-to {
-  opacity: 0;
 }
 </style>

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -26,6 +26,7 @@ export interface FormattedIssue {
 export interface FormattedErrorMessage {
   pipeline: string | null;
   issues: FormattedIssue[];
+  expanded?: boolean;
 }
 
 export interface Asset {
@@ -118,3 +119,5 @@ export interface SimpleAsset {
   hasDownstreamForClicking?: boolean;
   isFocusAsset?: boolean;
 }
+
+export type ErrorPhase = "Validating" | "Rednering";


### PR DESCRIPTION
# PR Overview:

This update improves error messaging by adding detailed phases for rendering and validation errors. It ensures that the SQL Preview remains visible.

## Key Changes:

**Detailed Error Phases**: Distinguish between `render` and `validate` errors for clearer feedback.
**Editor Visibility**: Keeps the SQL Preview visible when validation error occurs.

_Rendering Error_
![rendering-error](https://github.com/user-attachments/assets/e738fe48-ad9f-4620-ad97-5969fa324878)

_Validation Error_
![validation-error](https://github.com/user-attachments/assets/1209a966-820b-4523-91b2-aad6427d32c7)
