### PR TITLE
Handle Spaces in Filenames for `run` and `validate` Commands

### DIFF
--- a/src/bruin/bruinUtils.ts
+++ b/src/bruin/bruinUtils.ts
@@ -110,7 +110,8 @@ export const runInIntegratedTerminal = async (
   assetPath?: string,
   flags?: string
 ) => {
-  const command = `bruin ${BRUIN_RUN_SQL_COMMAND} ${flags} ${assetPath?.replace(/ /g, "\\ ")}`;
+  const assetPathEscaped = assetPath?.replace(/ /g, "\\ ");
+  const command = `bruin ${BRUIN_RUN_SQL_COMMAND} ${flags} ${assetPathEscaped}`;
 
   const terminalName = "Bruin Terminal";
   let terminal = vscode.window.terminals.find((t) => t.name === terminalName);

--- a/src/bruin/bruinUtils.ts
+++ b/src/bruin/bruinUtils.ts
@@ -83,7 +83,7 @@ export const bruinWorkspaceDirectory = (
       const bruinWorkspace = path.join(dirname, fileName);
       try {
         fs.accessSync(bruinWorkspace, fs.constants.F_OK);
-        return dirname;
+        return dirname.replace(/\\/g, "/");
       } catch (err) {
         // do nothing
       }
@@ -110,7 +110,7 @@ export const runInIntegratedTerminal = async (
   assetPath?: string,
   flags?: string
 ) => {
-  const command = `bruin ${BRUIN_RUN_SQL_COMMAND} ${flags} ${assetPath}`;
+  const command = `bruin ${BRUIN_RUN_SQL_COMMAND} ${flags} ${assetPath?.replace(/ /g, "\\ ")}`;
 
   const terminalName = "Bruin Terminal";
   let terminal = vscode.window.terminals.find((t) => t.name === terminalName);

--- a/src/bruin/bruinUtils.ts
+++ b/src/bruin/bruinUtils.ts
@@ -94,6 +94,13 @@ export const bruinWorkspaceDirectory = (
   return undefined;
 };
 
+const escapeFilePath = (filePath: string): string => {
+  // Escape backslashes first (they need to be escaped as double backslashes)
+  // Then escape spaces (they need to be escaped with a backslash)
+  // Finally, wrap the path in quotes for safety
+  return `"${filePath.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+};
+
 export const getCurrentPipelinePath = (fsPath: string): string | undefined => {
   return bruinWorkspaceDirectory(fsPath, ["pipeline.yaml", "pipeline.yml"]);
 };
@@ -110,8 +117,8 @@ export const runInIntegratedTerminal = async (
   assetPath?: string,
   flags?: string
 ) => {
-  const assetPathEscaped = assetPath?.replace(/ /g, "\\ ");
-  const command = `bruin ${BRUIN_RUN_SQL_COMMAND} ${flags} ${assetPathEscaped}`;
+  const escapedAssetPath = assetPath ? escapeFilePath(assetPath) : '';
+  const command = `bruin ${BRUIN_RUN_SQL_COMMAND} ${flags} ${escapedAssetPath}`;
 
   const terminalName = "Bruin Terminal";
   let terminal = vscode.window.terminals.find((t) => t.name === terminalName);

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -246,7 +246,14 @@ export class BruinPanel {
               bruinWorkspaceDirectory(currAssetPath || "")!!
             );
 
-            await pipelineValidator.validate(currentPipelinePath);
+            try {
+            // if the promess is rejected, the error will be catched and logged
+              await pipelineValidator.validate(currentPipelinePath);
+            }
+            catch (error) {
+              console.error("Error validating pipeline:", currentPipelinePath, error);
+            }
+
             break;
 
           case "bruin.validate":


### PR DESCRIPTION
# PR Overview:
This PR handles spaces in filenames for Bruin commands.

## Key Changes: 
- Implemented support for handling filenames with spaces in the `run` and `validate` commands.
- Escaped spaces in file paths to ensure correct execution of commands.
