### PR TITLE
Add Checkbox to Enable Metadata Push for Run Command

### DIFF
--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -247,6 +247,7 @@ function handleBruinValidateCurrentAsset() {
 const checkboxItems = ref([
   { name: "Full-Refresh", checked: false },
   { name: "Exclusive-End-Date", checked: true },
+  { name: "Push-Metadata", checked: false}
 ]);
 
 

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -39,12 +39,11 @@ export const concatCommandFlags = (
   if (isExclusiveChecked(checkboxItems)) {
     endDateFlag = " --end-date " + endDateExclusive;
   }
-
   const checkboxesFlags = checkboxItems
     .filter((item) => item.checked && item.name !== "Exclusive-End-Date")
     .map((item) => ` --${item.name.toLowerCase()}`);
 
-  const flags = [startDateFlag, endDateFlag, ...checkboxesFlags].join(" ");
+  const flags = [startDateFlag, endDateFlag, ...checkboxesFlags].join("");
   return flags;
 };
 


### PR DESCRIPTION
# PR Overview:

This update adds a new checkbox option to the main panel that allows users to toggle the inclusion of the --push-metadata flag when executing the run command. 

# Main Changes:

- Add a new checkbox to the UI enabling metadata push.
- Modified the run command logic to append the --push-metadata flag when the checkbox is checked.

**Push metadata checkbox**

![push-metadata-chackbox](https://github.com/user-attachments/assets/72949565-eaea-4e6a-800d-e2bf6db9fed7)
