### PR TITLE
Fix Loading State Handling for No Lineage Data

### DIFF
--- a/src/bruin/bruinLineage.ts
+++ b/src/bruin/bruinLineage.ts
@@ -32,7 +32,7 @@ export class BruinLineage extends BruinCommand {
           status: "success",
           message: lineageDisplayed,
         });
-        console.debug("lineage-success", lineageDisplayed);
+        //console.debug("lineage-success", lineageDisplayed);
       },
       (error) => {
         BruinPanel.postMessage("lineage-message", {

--- a/src/extension/commands/FlowLineageCommand.ts
+++ b/src/extension/commands/FlowLineageCommand.ts
@@ -11,7 +11,6 @@ export const flowLineageCommand = async (lastRenderedDocumentUri:  Uri | undefin
     getDefaultBruinExecutablePath(),
     bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath)!!
   );
-  console.log("flowLineageCommand", lastRenderedDocumentUri.fsPath);
   await flowLineage.parseAssetLineage(lastRenderedDocumentUri.fsPath);
   };
   

--- a/src/panels/LineagePanel.ts
+++ b/src/panels/LineagePanel.ts
@@ -64,9 +64,15 @@ export class LineagePanel implements vscode.WebviewViewProvider, vscode.Disposab
     context: vscode.WebviewViewResolveContext,
     _token: vscode.CancellationToken
   ) {
+    try {
     LineagePanel._view = webviewView;
     this.context = context;
     this.token = _token;
+
+    if (!webviewView.webview) {
+      throw new Error("Webview is undefined");
+    }
+
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [this._extensionUri],
@@ -87,6 +93,10 @@ export class LineagePanel implements vscode.WebviewViewProvider, vscode.Disposab
     });
 
     webviewView.webview.html = this._getWebviewContent(webviewView.webview);
+    }
+    catch (error) {
+      console.error("Error loading lineage data:", error);
+    }
   }
 
   private _getWebviewContent(webview: vscode.Webview) {

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -91,7 +91,7 @@ window.addEventListener("message", (event) => {
       console.log("Flow Lineage Data Message", message);
       lineageData.value = updateValue(message, "success");
       lineageError.value = updateValue(message, "error");
-      console.log("Lineage Data from webview", lineageData.value);
+      console.log("Lineage Data ERR from webview", lineageError.value);
       // Add this line to ensure the graph updates
       if (activeTab.value === tabs.value.findIndex((tab) => tab.label === "Lineage")) {
         nextTick(() => {
@@ -130,6 +130,10 @@ const pipeline = computed(() => {
   }
 });
 
+const lineageErr = computed(() => {
+  if(!lineageError.value) return null;
+  return lineageError.value;
+});
 const assetName = computed(() => {
   return lineageData.value?.name ?? null;
 });
@@ -162,6 +166,7 @@ const tabs = ref([
       assetDataset: computed(() => getAssetDataset(pipeline.value, assetId.value)),
       pipelineData: computed(() => pipeline.value),
       name: assetName.value,
+      LineageError: lineageErr.value,
     },
   },
   //{ label: "Pipeline Graph Lineage", component: PipelineLineage, includeIn: ["lineage"] },

--- a/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
+++ b/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
@@ -5,7 +5,6 @@
       <span class="ml-2">Loading lineage data...</span>
     </div>
     <div v-else-if="error" class="error-message">
-      <vscode-badge variant="error">Error</vscode-badge>
       <span class="ml-2">{{ error }}</span>
     </div>
     <VueFlow
@@ -55,9 +54,12 @@ const props = defineProps<{
   assetDataset?: AssetDataset;
   pipelineData: any;
   isLoading: boolean,  // Pass loading state
-
+  LineageError: string | null,  // Pass error state
 }>();
 
+console.log("=====================================\n");
+
+console.log("Lineage Error from webview ", props.LineageError);
 
 const nodeTypes: NodeTypesObject = {
   custom: CustomNode as any,
@@ -71,9 +73,9 @@ const onPaneReady = () => {
 const elk = new ELK();
 
 const isLoading = ref(true);
-const error = ref<string | null>(null);
+const error = ref<string | null>(props.LineageError);
 
-error.value = !props.assetDataset ? "No asset dataset provided" : "";
+error.value = !props.assetDataset ? "No Lineage Data Available" : null;
 
 
 
@@ -137,11 +139,12 @@ const updateLayout = async () => {
 // Function to process the asset properties and update nodes and edges
 const processProperties = () => {
   if (!props.assetDataset || !props.pipelineData) {
-    isLoading.value = true;
+
+    isLoading.value = error.value === null ? true : false;
     return;
   }
 
-  isLoading.value = true;
+  isLoading.value = error.value === null ? true : false;
   error.value = null;
 
  try {


### PR DESCRIPTION
#PR Overview 

This pull request addresses an issue with the loading state in the lineage panel when no lineage data is available. Previously, the panel did not properly handle scenarios where lineage data could not be provided, leading to an infinite loading state.

## Changes:

- Enhanced the logic to ensure that the panel transitions smoothly between different states (loading, no data, and data available)