### PR TITLE
Fix GitHub Actions for Cross-Platform Extension Testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,10 @@ on: pull_request
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -15,6 +18,15 @@ jobs:
 
     - name: Install dependencies
       run: npm run install:all
+
+    - name: Run extension tests
+      if: runner.os == 'Linux'
+      run: xvfb-run -a npm run test
+
+    - name: Run extension tests
+      if: runner.os != 'Linux'
+      run: npm run test
+      
     - name: Run webview tests
       run: npm run test:webview
     

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -3,18 +3,18 @@ import * as vscode from "vscode";
 import * as os from "os";
 import { isFileExtensionSQL, isPythonBruinAsset, isBruinPipeline, isYamlBruinAsset, isBruinYaml, isBruinAsset, encodeHTML, removeAnsiColors, processLineageData, getDependsSectionOffsets, isChangeInDependsSection, getFileExtension } from '../utilities/helperUtils';
 import * as fs from 'fs';
+import path = require('path');
+
 suite("Extension Initialization", () => {
   test("should set default path separator based on platform", async () => {
-    const config = vscode.workspace.getConfiguration("bruin");
-  
     // Determine the expected path separator based on the current platform
-    const expectedPathSeparator = process.platform === "win32" ? "\\" : "/";
+    const expectedPathSeparator = path.sep;
   
     // Update the path separator setting
-    await config.update("pathSeparator", expectedPathSeparator, vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration("bruin").update("pathSeparator", expectedPathSeparator, vscode.ConfigurationTarget.Global);
   
     // Retrieve the updated setting
-    const pathSeparator = config.get<string>("pathSeparator");
+    const pathSeparator = vscode.workspace.getConfiguration("bruin").get<string>("pathSeparator");
   
     // Assert that the path separator matches the expected value
     assert.strictEqual(pathSeparator, expectedPathSeparator);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -6,16 +6,16 @@ import * as fs from 'fs';
 suite("Extension Initialization", () => {
   test("should set default path separator based on platform", async () => {
     const config = vscode.workspace.getConfiguration("bruin");
-
+  
     // Determine the expected path separator based on the current platform
-    const expectedPathSeparator = os.platform() === "win32" ? "\\" : "/";
-
+    const expectedPathSeparator = process.platform === "win32" ? "\\" : "/";
+  
     // Update the path separator setting
     await config.update("pathSeparator", expectedPathSeparator, vscode.ConfigurationTarget.Global);
-
+  
     // Retrieve the updated setting
     const pathSeparator = config.get<string>("pathSeparator");
-
+  
     // Assert that the path separator matches the expected value
     assert.strictEqual(pathSeparator, expectedPathSeparator);
   });


### PR DESCRIPTION
# PR Overview:

This pull request added a job to run the tests for the VS Code extension across multiple platforms (macOS, Ubuntu, and Windows). 

## Key changes:

- Set up a matrix strategy to run the tests on macOS, Ubuntu, and Windows.
- Use the `xvfb-run` command to run the extension tests on the Linux (Ubuntu) environment, as it requires a virtual X server to execute the GUI-based tests.
- Run the extension tests directly on the macOS and Windows environments, as they don't require the `xvfb` tool.