### PR TITLE
Show Asset Details on Node Click

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: tests
 
-on: pull_request
+on: 
+  pull_request:
+  push:
+    branches:
+      - main
+  
+
 
 jobs:
   test:

--- a/src/bruin/bruinFlowLineage.ts
+++ b/src/bruin/bruinFlowLineage.ts
@@ -35,8 +35,10 @@ export class BruinLineageInternalParse extends BruinCommand {
       .then(
         (result) => {
           const pipelineData = JSON.parse(result);
-          const asset = pipelineData.assets.find((asset: any) => asset.definition_file.path === filePath);
-          
+          const asset = pipelineData.assets.find(
+            (asset: any) => asset.definition_file.path === filePath
+          );
+
           if (asset) {
             LineagePanel.postMessage("flow-lineage-message", {
               status: "success",
@@ -51,8 +53,9 @@ export class BruinLineageInternalParse extends BruinCommand {
           }
         },
         (error) => {
-          if(error.includes("No help topic for")) {
-            error = "Bruin CLI is not installed or is outdated. Please install or update Bruin CLI to use this feature.";
+          if (error.includes("No help topic for")) {
+            error =
+              "Bruin CLI is not installed or is outdated. Please install or update Bruin CLI to use this feature.";
             vscode.window.showErrorMessage(error);
           }
           LineagePanel.postMessage("flow-lineage-message", {

--- a/src/bruin/bruinRender.ts
+++ b/src/bruin/bruinRender.ts
@@ -40,7 +40,7 @@ export class BruinRender extends BruinCommand {
     let isBruinAsset = false;
     let isBruinPipeline = false;
     let isBruinYaml = false;
-  
+
     try {
       isValidAsset = await this.isValidAsset(filePath);
       isBruinAsset = await this.detectBruinAsset(filePath);
@@ -50,7 +50,7 @@ export class BruinRender extends BruinCommand {
       console.error("Error checking file type:", error);
       return;
     }
-  
+
     if (!isValidAsset) {
       BruinPanel?.postMessage("render-message", {
         status: "non-asset-alert",
@@ -59,7 +59,7 @@ export class BruinRender extends BruinCommand {
       console.log("This is not a BRUIN asset");
       return;
     }
-  
+
     if (isBruinAsset || isBruinPipeline || isBruinYaml) {
       BruinPanel?.postMessage("render-message", {
         status: "bruin-asset-alert",
@@ -68,7 +68,7 @@ export class BruinRender extends BruinCommand {
       console.log("Python, Yaml, or Pipeline BRUIN asset detected");
       return;
     }
-  
+
     await this.run([...flags, filePath], { ignoresErrors })
       .then(
         (sqlRendered) => {
@@ -93,23 +93,30 @@ export class BruinRender extends BruinCommand {
         }
       });
   }
-  
 
-  
-
-  
   private async isBruinPipeline(filePath: string): Promise<boolean> {
     return await isBruinPipeline(filePath);
   }
-  
+
   private async isBruinYaml(filePath: string): Promise<boolean> {
     return await isBruinYaml(filePath);
   }
 
-  private readonly relevantFileExtensions = ["sql", "py", "asset.yml", "asset.yaml", "pipeline.yml", "pipeline.yaml"];
-    
+  private readonly relevantFileExtensions = [
+    "sql",
+    "py",
+    "asset.yml",
+    "asset.yaml",
+    "pipeline.yml",
+    "pipeline.yaml",
+  ];
+
   private async isValidAsset(filePath: string): Promise<boolean> {
-    if (!isBruinAsset(filePath, this.relevantFileExtensions) || (await isBruinYaml(filePath)) || !this.relevantFileExtensions.some(ext => filePath.endsWith(ext))) {
+    if (
+      !isBruinAsset(filePath, this.relevantFileExtensions) ||
+      (await isBruinYaml(filePath)) ||
+      !this.relevantFileExtensions.some((ext) => filePath.endsWith(ext))
+    ) {
       BruinPanel?.postMessage("render-message", {
         status: "non-asset-alert",
         message: "-- This is not a BRUIN asset --",

--- a/src/bruin/bruinSelectEnv.ts
+++ b/src/bruin/bruinSelectEnv.ts
@@ -24,9 +24,10 @@ export class BruinEnvList extends BruinCommand {
    * @returns {Promise<void>} A promise that resolves when the execution is complete or an error is caught.
    */
 
-  public async getEnvironmentsList(
-    { flags = ["list", "-o", "json"], ignoresErrors = false }: BruinCommandOptions = {}
-  ): Promise<void> {
+  public async getEnvironmentsList({
+    flags = ["list", "-o", "json"],
+    ignoresErrors = false,
+  }: BruinCommandOptions = {}): Promise<void> {
     await this.run([...flags], { ignoresErrors })
       .then(
         (result) => {

--- a/src/bruin/bruinUtils.ts
+++ b/src/bruin/bruinUtils.ts
@@ -117,7 +117,7 @@ export const runInIntegratedTerminal = async (
   assetPath?: string,
   flags?: string
 ) => {
-  const escapedAssetPath = assetPath ? escapeFilePath(assetPath) : '';
+  const escapedAssetPath = assetPath ? escapeFilePath(assetPath) : "";
   const command = `bruin ${BRUIN_RUN_SQL_COMMAND} ${flags} ${escapedAssetPath}`;
 
   const terminalName = "Bruin Terminal";

--- a/src/bruin/bruinValidate.ts
+++ b/src/bruin/bruinValidate.ts
@@ -33,14 +33,14 @@ export class BruinValidate extends BruinCommand {
       status: "loading",
       message: "Validating asset...",
     });
-  
+
     try {
       const result = await this.run([...flags, filePath], { ignoresErrors });
       const validationResults = JSON.parse(result);
-  
+
       let hasErrors = false;
       const pipelinesWithIssues = [];
-  
+
       for (const validationData of validationResults) {
         if (
           validationData.issues &&
@@ -51,7 +51,7 @@ export class BruinValidate extends BruinCommand {
           pipelinesWithIssues.push(validationData);
         }
       }
-  
+
       if (hasErrors) {
         BruinPanel.postMessage("validation-message", {
           status: "error",
@@ -74,5 +74,4 @@ export class BruinValidate extends BruinCommand {
       this.isLoading = false; // Reset loading state when validation completes or fails
     }
   }
-  
 }

--- a/src/panels/LineagePanel.ts
+++ b/src/panels/LineagePanel.ts
@@ -6,7 +6,8 @@ import { flowLineageCommand } from "../extension/commands/FlowLineageCommand";
 export class LineagePanel implements vscode.WebviewViewProvider, vscode.Disposable {
   public static readonly viewId = "lineageView";
   public static _view?: vscode.WebviewView | undefined;
-  private _lastRenderedDocumentUri: vscode.Uri | undefined = vscode.window.activeTextEditor?.document.uri;
+  private _lastRenderedDocumentUri: vscode.Uri | undefined =
+    vscode.window.activeTextEditor?.document.uri;
   private context: vscode.WebviewViewResolveContext<unknown> | undefined;
   private token: vscode.CancellationToken | undefined;
 
@@ -16,32 +17,29 @@ export class LineagePanel implements vscode.WebviewViewProvider, vscode.Disposab
   private async loadAndSendLineageData() {
     if (this._lastRenderedDocumentUri) {
       try {
-       await flowLineageCommand(this._lastRenderedDocumentUri);
+        await flowLineageCommand(this._lastRenderedDocumentUri);
       } catch (error) {
         console.error("Error loading lineage data:", error);
       }
     }
   }
 
-  private refresh = ((event: vscode.TextEditor) => {
+  private refresh = (event: vscode.TextEditor) => {
     if (event.document.uri === this._lastRenderedDocumentUri && !this.isRefreshing) {
       this.isRefreshing = true;
-      this.initPanel(event)
-        .then(() => {
-          this.isRefreshing = false;
-        });
+      this.initPanel(event).then(() => {
+        this.isRefreshing = false;
+      });
     }
-  });
+  };
 
   constructor(private readonly _extensionUri: vscode.Uri) {
-
     this.disposables.push(
       vscode.window.onDidChangeActiveTextEditor((event: vscode.TextEditor | undefined) => {
         this._lastRenderedDocumentUri = event?.document.uri;
         flowLineageCommand(this._lastRenderedDocumentUri);
         this.initPanel(event);
-      }),
-      
+      })
     );
   }
 
@@ -57,7 +55,6 @@ export class LineagePanel implements vscode.WebviewViewProvider, vscode.Disposab
   private init = async () => {
     await this.resolveWebviewView(LineagePanel._view!, this.context!, this.token!);
   };
-  
 
   public resolveWebviewView(
     webviewView: vscode.WebviewView,
@@ -65,36 +62,35 @@ export class LineagePanel implements vscode.WebviewViewProvider, vscode.Disposab
     _token: vscode.CancellationToken
   ) {
     try {
-    LineagePanel._view = webviewView;
-    this.context = context;
-    this.token = _token;
+      LineagePanel._view = webviewView;
+      this.context = context;
+      this.token = _token;
 
-    if (!webviewView.webview) {
-      throw new Error("Webview is undefined");
-    }
-
-    webviewView.webview.options = {
-      enableScripts: true,
-      localResourceRoots: [this._extensionUri],
-    };
-
-    this._setWebviewMessageListener(LineagePanel._view!.webview);
-    this.loadAndSendLineageData();
-    setTimeout(() => {
-      if(LineagePanel._view && LineagePanel._view.visible){
-      LineagePanel._view?.webview.postMessage({ command: "init", panelType: "Lineage" });
-    }
-    }, 100);
-
-    webviewView.onDidChangeVisibility(() => {
-      if (LineagePanel._view!.visible) {
-        LineagePanel._view?.webview.postMessage({ command: "init", panelType: "Lineage" });
+      if (!webviewView.webview) {
+        throw new Error("Webview is undefined");
       }
-    });
 
-    webviewView.webview.html = this._getWebviewContent(webviewView.webview);
-    }
-    catch (error) {
+      webviewView.webview.options = {
+        enableScripts: true,
+        localResourceRoots: [this._extensionUri],
+      };
+
+      this._setWebviewMessageListener(LineagePanel._view!.webview);
+      this.loadAndSendLineageData();
+      setTimeout(() => {
+        if (LineagePanel._view && LineagePanel._view.visible) {
+          LineagePanel._view?.webview.postMessage({ command: "init", panelType: "Lineage" });
+        }
+      }, 100);
+
+      webviewView.onDidChangeVisibility(() => {
+        if (LineagePanel._view!.visible) {
+          LineagePanel._view?.webview.postMessage({ command: "init", panelType: "Lineage" });
+        }
+      });
+
+      webviewView.webview.html = this._getWebviewContent(webviewView.webview);
+    } catch (error) {
       console.error("Error loading lineage data:", error);
     }
   }

--- a/src/panels/LineagePanel.ts
+++ b/src/panels/LineagePanel.ts
@@ -135,6 +135,13 @@ export class LineagePanel implements vscode.WebviewViewProvider, vscode.Disposab
         case "bruin.pipelineLineage":
           console.log("Pipeline Lineage from webview in the Lineage panel, well received");
           break;
+        case "bruin.openAssetDetails":
+          console.log("Asset Details from webview in the Lineage panel, well received");
+          const assetFilePath = message.payload;
+          vscode.workspace.openTextDocument(vscode.Uri.file(assetFilePath)).then((doc) => {
+            vscode.window.showTextDocument(doc);
+          });
+          break;
         case "bruin.assetGraphLineage":
           console.log("Asset Lineage from webview in the Lineage panel, well received");
           this._lastRenderedDocumentUri = vscode.window.activeTextEditor?.document.uri;

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,21 +1,36 @@
-import * as assert from 'assert';
+import * as assert from "assert";
 import * as vscode from "vscode";
 import * as os from "os";
-import { isFileExtensionSQL, isPythonBruinAsset, isBruinPipeline, isYamlBruinAsset, isBruinYaml, isBruinAsset, encodeHTML, removeAnsiColors, processLineageData, getDependsSectionOffsets, isChangeInDependsSection, getFileExtension } from '../utilities/helperUtils';
-import * as fs from 'fs';
-import path = require('path');
+import {
+  isFileExtensionSQL,
+  isPythonBruinAsset,
+  isBruinPipeline,
+  isYamlBruinAsset,
+  isBruinYaml,
+  isBruinAsset,
+  encodeHTML,
+  removeAnsiColors,
+  processLineageData,
+  getDependsSectionOffsets,
+  isChangeInDependsSection,
+  getFileExtension,
+} from "../utilities/helperUtils";
+import * as fs from "fs";
+import path = require("path");
 
 suite("Extension Initialization", () => {
   test("should set default path separator based on platform", async () => {
     // Determine the expected path separator based on the current platform
     const expectedPathSeparator = path.sep;
-  
+
     // Update the path separator setting
-    await vscode.workspace.getConfiguration("bruin").update("pathSeparator", expectedPathSeparator, vscode.ConfigurationTarget.Global);
-  
+    await vscode.workspace
+      .getConfiguration("bruin")
+      .update("pathSeparator", expectedPathSeparator, vscode.ConfigurationTarget.Global);
+
     // Retrieve the updated setting
     const pathSeparator = vscode.workspace.getConfiguration("bruin").get<string>("pathSeparator");
-  
+
     // Assert that the path separator matches the expected value
     assert.strictEqual(pathSeparator, expectedPathSeparator);
   });
@@ -52,7 +67,7 @@ suite("Render Command Helper functions", () => {
     assert.strictEqual(await isBruinPipeline("example.yml"), false);
   });
 
-/*   test("isYamlBruinAsset should return true for Yaml Bruin assets", async () => {
+  /*   test("isYamlBruinAsset should return true for Yaml Bruin assets", async () => {
     assert.strictEqual(await isYamlBruinAsset("example.asset.yml"), true);
     assert.strictEqual(await isYamlBruinAsset("example.asset.yaml"), true);
     assert.strictEqual(await isYamlBruinAsset("example.txt"), false);
@@ -63,14 +78,17 @@ suite("Render Command Helper functions", () => {
     assert.strictEqual(await isBruinYaml("example.yml"), false);
   });
 
-/*   test("isBruinAsset should return true for valid Bruin assets", async () => {
+  /*   test("isBruinAsset should return true for valid Bruin assets", async () => {
     assert.strictEqual(await isBruinAsset("example.py", ["py"]), true);
     assert.strictEqual(await isBruinAsset("example.asset.yml", ["asset.yml", "asset.yaml"]), true);
     assert.strictEqual(await isBruinAsset("example.txt", ["py", "sql", "asset.yml", "asset.yaml"]), false);
   }); */
 
   test("encodeHTML should encode HTML special characters", () => {
-    assert.strictEqual(encodeHTML("<script>alert('XSS');</script>"), "&lt;script&gt;alert(&#039;XSS&#039;);&lt;/script&gt;");
+    assert.strictEqual(
+      encodeHTML("<script>alert('XSS');</script>"),
+      "&lt;script&gt;alert(&#039;XSS&#039;);&lt;/script&gt;"
+    );
   });
 
   test("removeAnsiColors should remove ANSI color codes", () => {
@@ -81,7 +99,6 @@ suite("Render Command Helper functions", () => {
     const lineageString = { name: "example-name" };
     assert.strictEqual(processLineageData(lineageString), "example-name");
   });
-
 });
 
 /* import * as assert from "assert";

--- a/src/test/webview.test.ts
+++ b/src/test/webview.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from "assert";
 
 suite("Webview Tests", () => {
   const environments = ["dev", "qa", "prod"];
@@ -39,7 +39,6 @@ suite("Webview Tests", () => {
       wrapper.vm.selectedEnv = selectedEnvironment;
     }
 
-    assert.strictEqual(wrapper.vm.selectedEnv, null); 
+    assert.strictEqual(wrapper.vm.selectedEnv, null);
   });
-
 });

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -3,7 +3,6 @@ import * as fs from "fs";
 import path = require("path");
 export const isEditorActive = (): boolean => !!vscode.window.activeTextEditor;
 
-
 export interface Environment {
   name: string;
 }
@@ -13,7 +12,6 @@ export interface Input {
   environments: Environment[];
 }
 
-
 // Function to transform the input object to an array of environment names
 export function transformToEnvironmentsArray(input: string): string[] {
   const envResult = JSON.parse(input);
@@ -21,9 +19,8 @@ export function transformToEnvironmentsArray(input: string): string[] {
     return [];
   }
 
-  return envResult.environments.map((env: { name: string; }) => env.name);
+  return envResult.environments.map((env: { name: string }) => env.name);
 }
-
 
 export const isFileExtensionSQL = (fileName: string): boolean => {
   fileName = fileName.toLowerCase();
@@ -79,7 +76,10 @@ export const isBruinAsset = async (
 
   try {
     const assetContent = fs.readFileSync(fileName, "utf8");
-    const bruinAsset = bruinPattern.test(assetContent) || fileExtension === "asset.yml" || fileExtension === "asset.yaml";
+    const bruinAsset =
+      bruinPattern.test(assetContent) ||
+      fileExtension === "asset.yml" ||
+      fileExtension === "asset.yaml";
 
     return bruinAsset;
   } catch (err) {

--- a/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
+++ b/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
@@ -87,6 +87,7 @@ const updateNodePositions = (layout: any) => {
       return {
         ...node,
         position: { x: layoutNode.x, y: layoutNode.y },
+        zIndex: 1,
       };
     }
     return node;

--- a/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
+++ b/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
@@ -9,7 +9,7 @@
     </div>
     <VueFlow
       v-model:elements="elements"
-      :default-viewport="{ x: 50, zoom: 0.8 }"
+      :default-viewport="{ x: 50, y: 50, zoom: 0.7 }"
       :min-zoom="0.2"
       :max-zoom="4"
       class="basic-flow"
@@ -27,6 +27,8 @@
           :label="nodeProps.data.label"
           @addUpstream="onAddUpstream"
           @addDownstream="onAddDownstream"
+          @node-click="onNodeClick"
+          :selected-node-id="selectedNodeId"
         />
       </template>
 
@@ -56,6 +58,19 @@ const props = defineProps<{
   isLoading: boolean,  // Pass loading state
   LineageError: string | null,  // Pass error state
 }>();
+
+const selectedNodeId = ref<string | null>(null);
+
+const onNodeClick = (nodeId: string, event: MouseEvent) => {
+  console.log("Node clicked:", nodeId);
+  if (selectedNodeId.value === nodeId) {
+    // If clicking the same node, close the popup
+    selectedNodeId.value = null;
+  } else {
+    // If clicking a different node, open its popup
+    selectedNodeId.value = nodeId;
+  }
+};
 
 console.log("=====================================\n");
 

--- a/webview-ui/src/components/lineage-flow/asset-lineage/useAssetLineage.ts
+++ b/webview-ui/src/components/lineage-flow/asset-lineage/useAssetLineage.ts
@@ -23,6 +23,8 @@ export const getAssetDataset = (
       return {
         name: asset.name,
         type: asset.type,
+        pipeline: pipelineData.name,
+        path: asset.definition_file.path,
         isFocusAsset: false,
         hasUpstreamForClicking: asset.upstreams && asset.upstreams.length > 0,
         hasDownstreamForClicking: false,
@@ -61,6 +63,8 @@ export const getAssetDataset = (
       .map(a => ({
         name: a.name,
         type: a.type,
+        pipeline: pipelineData.name,
+        path: a.definition_file.path,
         isFocusAsset: false,
         hasUpstreamForClicking: false,
         hasDownstreamForClicking: deduceDownstream(a) && deduceDownstream(a).length > 0,
@@ -81,6 +85,8 @@ export const getAssetDataset = (
     isFocusAsset: asset.isFocusAsset || true,
     name: asset.name,
     type: asset.type,
+    pipeline: pipelineData.name,
+    path: asset.definition_file.path,
     upstreams: upstreams,
     downstream: downstreams,
   };

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -7,7 +7,6 @@
         @close="closeAssetInfo"
         @goToDetails="handleGoToDetails"
         :name="data.asset?.name!!"
-        :pipeline="data.asset?.pipeline!!"
         :type="data.asset?.type!!"
         :path="data.asset?.path!!"  
       />

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -1,5 +1,17 @@
 <template>
-  <div class="custom-node-wrapper">
+  <div class="custom-node-wrapper" @click.stop="toggleAssetInfo">
+    
+      <AssetProperties
+        v-if="showAssetInfo && !data.asset?.isFocusAsset"
+        :show="showAssetInfo"
+        @close="closeAssetInfo"
+        @goToDetails="handleGoToDetails"
+        :name="data.asset?.name!!"
+        :pipeline="data.asset?.pipeline!!"
+        :type="data.asset?.type!!"
+        :path="data.asset?.path!!"  
+      />
+    
     <div
       v-if="showUpstreamIcon"
       @click.stop="onAddUpstream"
@@ -60,18 +72,26 @@
       <PlusIcon class="h-4 w-4 fill-gray-300 text-gray-700/50 hover:text-gray-700" />
     </div>
   </div>
-  <Handle v-if="assetHasDownstreams || assetHasUpstreams" type="source" class="opacity-0" :position="Position.Right" />
-  <Handle v-if="assetHasUpstreams || assetHasDownstreams" type="target" class="opacity-0" :position="Position.Left" />
-
-  
-
+  <Handle
+    v-if="assetHasDownstreams || assetHasUpstreams"
+    type="source"
+    class="opacity-0"
+    :position="Position.Right"
+  />
+  <Handle
+    v-if="assetHasUpstreams || assetHasDownstreams"
+    type="target"
+    class="opacity-0"
+    :position="Position.Left"
+  />
 </template>
 
 <script lang="ts" setup>
-import { computed, defineProps, defineEmits } from "vue";
+import { computed, defineProps, defineEmits, ref, onMounted, onUnmounted } from "vue";
 import { Handle, Position } from "@vue-flow/core";
 import { PlusIcon } from "@heroicons/vue/20/solid";
 import type { BruinNodeProps } from "@/types";
+import AssetProperties from "@/components/ui/asset/AssetProperties.vue";
 import {
   defaultStyle,
   statusStyles,
@@ -127,6 +147,37 @@ const onAddUpstream = () => {
 const onAddDownstream = () => {
   emit("add-downstream", props.data.asset?.name);
 };
+
+const showAssetInfo = ref(false);
+
+
+const toggleAssetInfo = (event: Event) => {
+  event.stopPropagation();
+  showAssetInfo.value = !showAssetInfo.value;
+};
+
+const closeAssetInfo = () => {
+  showAssetInfo.value = false;
+};
+
+const handleGoToDetails = (asset: any) => {
+  // Implement the logic to navigate to asset details
+  console.log("Go to details for asset:", asset.path);
+};
+
+const handleClickOutside = (event: Event) => {
+  if (showAssetInfo.value) {
+    closeAssetInfo();
+  }
+};
+
+onMounted(() => {
+  document.addEventListener("click", handleClickOutside);
+});
+
+onUnmounted(() => {
+  document.removeEventListener("click", handleClickOutside);
+});
 </script>
 <style scoped>
 .custom-node-wrapper {

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -92,6 +92,8 @@ import { Handle, Position } from "@vue-flow/core";
 import { PlusIcon } from "@heroicons/vue/20/solid";
 import type { BruinNodeProps } from "@/types";
 import AssetProperties from "@/components/ui/asset/AssetProperties.vue";
+import { vscode } from "@/utilities/vscode";
+
 import {
   defaultStyle,
   statusStyles,
@@ -162,6 +164,10 @@ const closeAssetInfo = () => {
 
 const handleGoToDetails = (asset: any) => {
   // Implement the logic to navigate to asset details
+  vscode.postMessage({
+    command: "bruin.openAssetDetails",
+    payload: asset.path
+  });
   console.log("Go to details for asset:", asset.path);
 };
 

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -1,16 +1,15 @@
 <template>
   <div class="custom-node-wrapper" @click.stop="toggleAssetInfo">
-    
-      <AssetProperties
-        v-if="showAssetInfo && !data.asset?.isFocusAsset"
-        :show="showAssetInfo"
-        @close="closeAssetInfo"
-        @goToDetails="handleGoToDetails"
-        :name="data.asset?.name!!"
-        :type="data.asset?.type!!"
-        :path="data.asset?.path!!"  
-      />
-    
+    <AssetProperties
+      v-if="showAssetInfo && !data.asset?.isFocusAsset"
+      :show="showAssetInfo"
+      @close="closeAssetInfo"
+      @goToDetails="handleGoToDetails"
+      :name="data.asset?.name!!"
+      :type="data.asset?.type!!"
+      :path="data.asset?.path!!"
+    />
+
     <div
       v-if="showUpstreamIcon"
       @click.stop="onAddUpstream"
@@ -55,8 +54,21 @@
           class="rounded-b font-mono py-1 text-left px-1 border border-white/20"
           :class="[selectedStyle.main, status ? '' : 'rounded-tl']"
         >
-          <div class="truncate">
-            {{ label }}
+          <div class="relative group">
+            <!-- Truncated Text -->
+            <div class="truncate">
+              {{ label }}
+            </div>
+
+            <!-- Tooltip -->
+            <div
+              v-if="isTurncated"
+              class="absolute left-0 top-0 w-max px-2 text-sm rounded opacity-0 py-1
+              group-hover:opacity-100 transition-opacity duration-200 group-hover:cursor-pointer"
+              :class="selectedStyle.main"
+            >
+              {{ label }}
+            </div>
           </div>
         </div>
       </div>
@@ -134,6 +146,11 @@ const handleStyle = computed(() => ({
 const showUpstreamIcon = computed(() => isAsset.value && props.data?.hasUpstreamForClicking);
 const showDownstreamIcon = computed(() => isAsset.value && props.data?.hasDownstreamForClicking);
 
+const isTurncated = computed(()=> {
+  if(!props.data.asset?.name) return false;
+  return props.data.asset?.name.length > 26;
+});
+
 const assetClass = computed(() => {
   let classes = "rounded w-56";
   if (props.status) {
@@ -151,7 +168,6 @@ const onAddDownstream = () => {
 
 const showAssetInfo = ref(false);
 
-
 const toggleAssetInfo = (event: Event) => {
   event.stopPropagation();
   showAssetInfo.value = !showAssetInfo.value;
@@ -165,7 +181,7 @@ const handleGoToDetails = (asset: any) => {
   // Implement the logic to navigate to asset details
   vscode.postMessage({
     command: "bruin.openAssetDetails",
-    payload: asset.path
+    payload: asset.path,
   });
   console.log("Go to details for asset:", asset.path);
 };

--- a/webview-ui/src/components/ui/asset/AssetProperties.vue
+++ b/webview-ui/src/components/ui/asset/AssetProperties.vue
@@ -1,13 +1,15 @@
 <template>
   <div
     v-if="show"
-    class="absolute top-full left-0 bg-editor-bg border border-[#3c3c3c] rounded-md shadow-lg p-3 
-     w-auto text-editor-fg"
-    @click.stop
+      :style="{
+        position: 'absolute',
+        zIndex: 9999
+      }"
+      class="bg-editor-bg border border-editor-border b-[0.2px] rounded-md shadow-lg p-3 w-auto text-editor-fg -translate-x-8 -translate-y-24"
+      @click.stop
   >
     <div class="space-y-2">
       <p > <span class="text-lg font-semibold">Name: </span> <span class="text-lg">{{ name }}</span></p>
-      <p class="text-md">Pipeline: {{ pipeline }}</p>
       <p class="text-md flex items-center">
         Type:
         <span
@@ -21,7 +23,7 @@
         class="w-full mt-2 px-3 py-2 text-sm flex items-center justify-between bg-input-background hover:bg-menu-hoverBackground rounded-sm transition-colors duration-200"
       >
         Go to asset details
-        <ArrowTopRightOnSquareIcon class="h-4 w-4 text-[#569cd6]" />
+        <span class="pl-2"><ArrowTopRightOnSquareIcon class="h-4 w-4 text-[#569cd6]" /></span>
       </button>
     </div>
   </div>
@@ -34,7 +36,6 @@ import { defineProps, defineEmits } from "vue";
 const props = defineProps<{
   show: boolean;
   name: string;
-  pipeline: string;
   type: string;
   path: string;
   external?: boolean;
@@ -45,4 +46,6 @@ const emit = defineEmits(["close", "goToDetails"]);
 const goToDetails = () => {
   emit("goToDetails", props);
 };
+
+
 </script>

--- a/webview-ui/src/components/ui/asset/AssetProperties.vue
+++ b/webview-ui/src/components/ui/asset/AssetProperties.vue
@@ -1,0 +1,48 @@
+<template>
+  <div
+    v-if="show"
+    class="absolute top-full left-0 bg-editor-bg border border-[#3c3c3c] rounded-md shadow-lg p-3 
+     w-auto text-editor-fg"
+    @click.stop
+  >
+    <div class="space-y-2">
+      <p > <span class="text-lg font-semibold">Name: </span> <span class="text-lg">{{ name }}</span></p>
+      <p class="text-md">Pipeline: {{ pipeline }}</p>
+      <p class="text-md flex items-center">
+        Type:
+        <span
+          class="ml-1 px-1.5 py-0.5 text-sm font-medium rounded-full bg-editorWidget-background text-[#4ec9b0]"
+        >
+          {{ type }}
+        </span>
+      </p>
+      <button
+        @click="goToDetails"
+        class="w-full mt-2 px-3 py-2 text-sm flex items-center justify-between bg-input-background hover:bg-menu-hoverBackground rounded-sm transition-colors duration-200"
+      >
+        Go to asset details
+        <ArrowTopRightOnSquareIcon class="h-4 w-4 text-[#569cd6]" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ArrowTopRightOnSquareIcon } from "@heroicons/vue/20/solid";
+import { defineProps, defineEmits } from "vue";
+
+const props = defineProps<{
+  show: boolean;
+  name: string;
+  pipeline: string;
+  type: string;
+  path: string;
+  external?: boolean;
+}>();
+
+const emit = defineEmits(["close", "goToDetails"]);
+
+const goToDetails = () => {
+  emit("goToDetails", props);
+};
+</script>

--- a/webview-ui/src/components/ui/asset/AssetProperties.vue
+++ b/webview-ui/src/components/ui/asset/AssetProperties.vue
@@ -20,7 +20,7 @@
       </p>
       <button
         @click="goToDetails"
-        class="w-full mt-2 px-3 py-2 text-sm flex items-center justify-between bg-input-background hover:bg-menu-hoverBackground rounded-sm transition-colors duration-200"
+        class="w-full mt-2 px-3 py-2 text-sm flex items-center justify-between bg-input-background hover:bg-menu-hoverBackground hover:text-bl rounded-sm transition-colors duration-200"
       >
         Go to asset details
         <span class="pl-2"><ArrowTopRightOnSquareIcon class="h-4 w-4 text-[#569cd6]" /></span>

--- a/webview-ui/src/components/ui/asset/AssetProperties.vue
+++ b/webview-ui/src/components/ui/asset/AssetProperties.vue
@@ -1,15 +1,18 @@
 <template>
   <div
     v-if="show"
-      :style="{
-        position: 'absolute',
-        zIndex: 9999
-      }"
-      class="bg-editor-bg border border-input-background b-[0.2px] rounded-md shadow-lg p-3 w-auto text-editor-fg -translate-x-8 -translate-y-24"
-      @click.stop
+    :style="{
+      position: 'absolute',
+      zIndex: 9999,
+    }"
+    class="bg-editor-bg border border-input-background b-[0.2px] rounded-md shadow-lg p-3 w-auto text-editor-fg -translate-x-8 -translate-y-24"
+    @click.stop
   >
     <div class="space-y-2">
-      <p > <span class="text-lg font-semibold">Name: </span> <span class="text-lg">{{ name }}</span></p>
+      <div class="flex items-center">
+        <span class="text-lg font-semibold whitespace-nowrap">Name: </span>
+        <span class="text-lg ml-1 truncate">{{ name }}</span>
+      </div>
       <p class="text-md flex items-center">
         Type:
         <span
@@ -46,6 +49,4 @@ const emit = defineEmits(["close", "goToDetails"]);
 const goToDetails = () => {
   emit("goToDetails", props);
 };
-
-
 </script>

--- a/webview-ui/src/components/ui/asset/AssetProperties.vue
+++ b/webview-ui/src/components/ui/asset/AssetProperties.vue
@@ -5,7 +5,7 @@
         position: 'absolute',
         zIndex: 9999
       }"
-      class="bg-editor-bg border border-editor-border b-[0.2px] rounded-md shadow-lg p-3 w-auto text-editor-fg -translate-x-8 -translate-y-24"
+      class="bg-editor-bg border border-input-background b-[0.2px] rounded-md shadow-lg p-3 w-auto text-editor-fg -translate-x-8 -translate-y-24"
       @click.stop
   >
     <div class="space-y-2">

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -39,6 +39,7 @@ export interface Asset {
   hasUpstreams: boolean;
   hasDownstreams: boolean;
   isFocusAsset?: boolean;
+  path: string;
 }
 
 export interface Project {

--- a/webview-ui/src/utilities/graphGenerator.ts
+++ b/webview-ui/src/utilities/graphGenerator.ts
@@ -1,6 +1,7 @@
 // src/utils/graphGenerator.js
 
 import { getAssetDataset } from "@/components/lineage-flow/asset-lineage/useAssetLineage";
+import path from "path";
 
 export function generateGraphFromJSON(asset) {
   const localNodes = new Map();
@@ -18,6 +19,8 @@ export function generateGraphFromJSON(asset) {
           asset: {
             name: assetData.name,
             type: assetData.type || "unknown",
+            pipeline: assetData.pipeline || "unknown",
+            path: assetData.path || "unknown",
             hasDownstreams: (assetData.downstream && assetData.downstream.length > 0) || false,
             hasUpstreams: (assetData.upstreams && assetData.upstreams.length > 0) || false,
           },

--- a/webview-ui/tailwind.config.js
+++ b/webview-ui/tailwind.config.js
@@ -91,6 +91,7 @@ module.exports = {
         "inputValidation-warningBackground": "var(--vscode-inputValidation-warningBackground)",
         "inputValidation-warningBorder": "var(--vscode-inputValidation-warningBorder)",
         "inputValidation-errorBackground": "var(--vscode-inputValidation-errorBackground)",
+        'editorWidget-background': "var(--vscode-editorWidget-background)",
 
         "primary": {
           DEFAULT: "hsl(var(--primary))",


### PR DESCRIPTION
# PR Overview
This PR adds a feature to display asset details when a node is clicked, along with various UI enhancements and fixes.

## Key Changes
- **Asset Details Popup:** Added a popup to show detailed asset information.
- **"Go to Asset Details" Button:** Enabled the button to open the asset text document in VSCode via a message trigger.
- **Tooltip Enhancement:** Implemented a tooltip to display the full asset name on hover when the name is truncated.
- **Configuration Updates:** Included VSCode variables in the Tailwind config file for better integration.
- **GitHub Actions Workflow:** Updated to trigger actions on pushes to the main branch.

**Asset Details Popup**
![asset-details-popup](https://github.com/user-attachments/assets/eb508f2a-ba17-48fe-bc3c-8060e04b5802)

**Tooltip For Long Asset Name:** 
![long-asset-name](https://github.com/user-attachments/assets/a85991e2-0adf-4ebb-a3b4-dde1f92ebe14)
