### PR TITLE
Resolve push-metadata Causing Unnecessary Re-Renders

### DIFF
--- a/src/extension/commands/renderCommand.ts
+++ b/src/extension/commands/renderCommand.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { BruinPanel } from "../../panels/BruinPanel";
 import { BruinRender } from "../../bruin";
 import { getDefaultBruinExecutablePath } from "../configuration";
+import { prepareFlags } from "../../utilities/helperUtils";
 
 export const renderCommand = async (extensionUri: vscode.Uri) => {
   const activeEditor = vscode.window.activeTextEditor;
@@ -39,7 +40,7 @@ export const renderCommandWithFlags = async (flags: string, lastRenderedDocument
     );
 
     await bruinSqlRenderer.render(filePath, {
-      flags: ['-o', 'json'].concat(flags.split(" ").filter((flag) => flag !== "" && flag !== "--downstream")),
+      flags: prepareFlags(flags, ['--downstream', '--push-metadata']),
     });
   }
 };

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -151,3 +151,17 @@ export function isChangeInDependsSection(
     (changeEndOffset >= start && changeEndOffset <= end)
   );
 }
+
+/**
+ * Filter and concatenate flags for a command.
+ * 
+ * @param {string} flags - A space-separated string of flags.
+ * @param {string[]} excludeFlags - Flags to be excluded from the result.
+ * @returns {string[]} - An array of concatenated flags.
+ */
+export function prepareFlags(flags: string, excludeFlags: string[] = []): string[] {
+  const baseFlags = ['-o', 'json'];
+  const filteredFlags = flags.split(' ')
+                             .filter(flag => flag !== '' && !excludeFlags.includes(flag));
+  return baseFlags.concat(filteredFlags);
+}


### PR DESCRIPTION
# PR Overview

This PR resolves an issue where checking the `push-metadata` checkbox caused unnecessary re-renders in the SQL Preview, resulting in changes to the rendered content. The fix ensures that metadata pushes no longer trigger these unwanted re-renders.
