### PR TITLE
Replace the Input Date Indicator with Heroicon and Fix the Color

### DIFF
--- a/webview-ui/src/components/ui/date-inputs/DateInput.vue
+++ b/webview-ui/src/components/ui/date-inputs/DateInput.vue
@@ -1,20 +1,26 @@
 <template>
-  <div id="dateInput" class="flex flex-col space-y-1 max-w-md ">
+  <div id="dateInput" class="flex flex-col space-y-1 max-w-md">
     <label for="datetime-picker" class="block text-sm font-medium">
       {{ label }}
     </label>
-    <input
-      id="datetime-picker"
-      type="datetime-local"
-      class="p-2 block max-w-sm text-input-foreground bg-input-background rounded-md focus:border-inputOption-activeBorder sm:text-sm"
-      :value="value"
-      @input="updateValue(($event.target as HTMLInputElement).value)"
-    />
+    <div class="relative mt-2 flex items-center">
+      <input
+        id="datetime-picker"
+        type="datetime-local"
+        class="p-2 block w-full text-input-foreground bg-input-background rounded-md focus:border-inputOption-activeBorder sm:text-sm border border-commandCenter-border"
+        :value="value"
+        @input="updateValue(($event.target as HTMLInputElement).value)"
+      />
+      <div class="absolute inset-y-0 right-0 flex py-1.5 pr-1.5 items-center">
+        <CalendarIcon class="inline-flex items-center w-5 h-5 text-input-foreground" />
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { defineProps, defineEmits, computed } from "vue";
+import { CalendarIcon } from "@heroicons/vue/20/solid";
 
 const props = defineProps({
   label: String,
@@ -25,18 +31,28 @@ const props = defineProps({
 });
 const emit = defineEmits(["update:modelValue"]);
 
-
 const value = computed({
   get: () => props.modelValue,
-  set: (val) => emit('update:modelValue', val)
+  set: (val) => emit("update:modelValue", val),
 });
 
 const updateValue = (value: string) => {
-  emit('update:modelValue', value);
+  emit("update:modelValue", value);
 };
-
 </script>
 
 <style>
+input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+  display: none;
+}
 
+button {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+input[type="datetime-local"] {
+  padding-right: 2.5rem; /* Adjust space for the custom icon */
+}
 </style>

--- a/webview-ui/tailwind.config.js
+++ b/webview-ui/tailwind.config.js
@@ -91,8 +91,9 @@ module.exports = {
         "inputValidation-warningBackground": "var(--vscode-inputValidation-warningBackground)",
         "inputValidation-warningBorder": "var(--vscode-inputValidation-warningBorder)",
         "inputValidation-errorBackground": "var(--vscode-inputValidation-errorBackground)",
-        'editorWidget-bg': "var(--vscode-editorWidget-background)",
-        "editorLink-activeFg"	: "var(--vscode-editorLink-activeForeground)",
+        "editorWidget-bg": "var(--vscode-editorWidget-background)",
+        "editorLink-activeFg": "var(--vscode-editorLink-activeForeground)",
+        "commandCenter-border": "var(--vscode-commandCenter-border)",
 
         "primary": {
           DEFAULT: "hsl(var(--primary))",


### PR DESCRIPTION
# PR Overview

This PR updates the input date indicator by replacing it with a Heroicon for a more consistent design. Additionally, it corrects the color to align with the vscode themes, ensuring better visual integration.

![update-input-date-indicator](https://github.com/user-attachments/assets/8f768b70-0c68-4f89-9950-e4eac3da2a27)


