### PR TITLE
Implement Connection Display Section and CLI Fetch Command

### DIFF
--- a/src/bruin/bruinConnections.ts
+++ b/src/bruin/bruinConnections.ts
@@ -4,9 +4,8 @@ import { BruinPanel } from "../panels/BruinPanel";
 import { extractNonNullConnections } from "../utilities/helperUtils";
 
 /**
- * Extends the BruinCommand class to implement the bruin get connections command.
+ * Extends the BruinCommand class to implement the Bruin 'connections list' command.
  */
-
 export class BruinConnections extends BruinCommand {
   /**
    * Specifies the Bruin command string.
@@ -24,12 +23,11 @@ export class BruinConnections extends BruinCommand {
    * @param {BruinCommandOptions} [options={}] - Optional parameters for execution, including flags and errors.
    * @returns {Promise<void>} A promise that resolves when the execution is complete or an error is caught.
    */
-
   public async getConnections({
     flags = ["list", "-o", "json"],
     ignoresErrors = false,
   }: BruinCommandOptions = {}): Promise<void> {
-    
+
     await this.run([...flags], { ignoresErrors })
       .then(
         (result) => {
@@ -37,14 +35,26 @@ export class BruinConnections extends BruinCommand {
           this.postMessageToPanels("success", connections);
         },
         (error) => {
-          this.postMessageToPanels("error", error);
+          // Check if the error is related to an outdated or missing CLI
+          if (error.includes("No help topic for")) {
+            const cliError = "The Bruin CLI is out of date. Please update it to access your connections.";
+            this.postMessageToPanels("error", cliError);
+          } else {
+            this.postMessageToPanels("error", error);
+          }
         }
       )
       .catch((err) => {
-        console.debug("environment list command error", err);
+        console.error("Connections list command error", err);
       });
   }
 
+  /**
+   * Helper function to post messages to the panel with a specific status and message.
+   *
+   * @param {string} status - Status of the message ('success' or 'error').
+   * @param {string | any} message - The message content to send to the panel.
+   */
   private postMessageToPanels(status: string, message: string | any) {
     BruinPanel.postMessage("connections-list-message", { status, message });
   }

--- a/src/bruin/bruinConnections.ts
+++ b/src/bruin/bruinConnections.ts
@@ -1,0 +1,51 @@
+import { BruinCommandOptions } from "../types";
+import { BruinCommand } from "./bruinCommand";
+import { BruinPanel } from "../panels/BruinPanel";
+import { extractNonNullConnections } from "../utilities/helperUtils";
+
+/**
+ * Extends the BruinCommand class to implement the bruin get connections command.
+ */
+
+export class BruinConnections extends BruinCommand {
+  /**
+   * Specifies the Bruin command string.
+   *
+   * @returns {string} Returns the 'connections list -o json' command string.
+   */
+  protected bruinCommand(): string {
+    return "connections";
+  }
+
+  /**
+   * Return the connections List.
+   * Communicates the results of the execution or errors back to the BruinPanel.
+   *
+   * @param {BruinCommandOptions} [options={}] - Optional parameters for execution, including flags and errors.
+   * @returns {Promise<void>} A promise that resolves when the execution is complete or an error is caught.
+   */
+
+  public async getConnections({
+    flags = ["list", "-o", "json"],
+    ignoresErrors = false,
+  }: BruinCommandOptions = {}): Promise<void> {
+    
+    await this.run([...flags], { ignoresErrors })
+      .then(
+        (result) => {
+          const connections = extractNonNullConnections(JSON.parse(result));
+          this.postMessageToPanels("success", connections);
+        },
+        (error) => {
+          this.postMessageToPanels("error", error);
+        }
+      )
+      .catch((err) => {
+        console.debug("environment list command error", err);
+      });
+  }
+
+  private postMessageToPanels(status: string, message: string | any) {
+    BruinPanel.postMessage("connections-list-message", { status, message });
+  }
+}

--- a/src/extension/commands/getConnections.ts
+++ b/src/extension/commands/getConnections.ts
@@ -1,0 +1,12 @@
+import { getDefaultBruinExecutablePath } from "../configuration";
+import { Uri } from "vscode";
+import { bruinWorkspaceDirectory } from "../../bruin";
+import { BruinConnections } from "../../bruin/bruinConnections";
+
+export const getConnections = async (lastRenderedDocumentUri: Uri | undefined) => {
+  const bruinConnections = new BruinConnections(
+    getDefaultBruinExecutablePath(),
+    bruinWorkspaceDirectory(lastRenderedDocumentUri!.fsPath)!!
+  );
+  await bruinConnections.getConnections();
+};

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -360,6 +360,17 @@ export class BruinPanel {
           case "bruinInstallOrUpdateCLI":
             await this.installOrUpdateBruinCli();
             break;
+
+          case "bruin.getConnectionsList":
+            BruinPanel.postMessage("connections-list-message", {
+              status: "success",
+              message: [
+                { name: "bruin-health-check-bq", type: "google_cloud_platform" },
+                { name: "test", type: "notion" },
+                { name: "bruin-health-check-sf", type: "snowflake" },
+              ],
+            });
+            break;
         }
       },
       undefined,
@@ -372,7 +383,7 @@ export class BruinPanel {
       command: "bruinCliInstallationStatus",
       installed,
       isWindows,
-      goInstalled
+      goInstalled,
     });
   }
 

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -6,7 +6,6 @@ import {
   bruinWorkspaceDirectory,
   checkBruinCliInstallation,
   getCurrentPipelinePath,
-  isBruinBinaryAvailable,
   runInIntegratedTerminal,
 } from "../bruin";
 import { getDefaultBruinExecutablePath } from "../extension/configuration";
@@ -183,8 +182,9 @@ export class BruinPanel {
     "asset.yaml",
     "pipeline.yml",
     "pipeline.yaml",
-    "bruin.yml",
-    "bruin.yaml",
+    ".bruin.yml",
+    ".bruin.yaml",
+
   ];
 
   private _getWebviewContent(webview: Webview, extensionUri: Uri) {
@@ -373,10 +373,8 @@ export class BruinPanel {
             break;
           
           case "getLastRenderedDocument":
-            this._panel.webview.postMessage({
-              command: "lastRenderedDocument",
-              path: this._lastRenderedDocumentUri ? this._lastRenderedDocumentUri.fsPath : null,
-            });
+            console.log("Sending last rendered document to webview", this._lastRenderedDocumentUri);
+            BruinPanel.postMessage("lastRenderedDocument", { status: "success", message: this._lastRenderedDocumentUri?.fsPath });
             break;
         }
       },

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -56,6 +56,7 @@ export class BruinPanel {
       workspace.onDidChangeTextDocument((editor) => {
         if (editor && editor.document.uri.fsPath.endsWith(".bruin.yml")) {
           getEnvListCommand(this._lastRenderedDocumentUri);
+          getConnections(this._lastRenderedDocumentUri);
         }
         if (editor && editor.document.uri) {
           if (editor.document.uri.fsPath === "tasks") {
@@ -182,6 +183,8 @@ export class BruinPanel {
     "asset.yaml",
     "pipeline.yml",
     "pipeline.yaml",
+    "bruin.yml",
+    "bruin.yaml",
   ];
 
   private _getWebviewContent(webview: Webview, extensionUri: Uri) {
@@ -224,6 +227,9 @@ export class BruinPanel {
     this._panel.webview.postMessage({
       command: "init",
       panelType: "bruin",
+      lastRenderedDocument: this._lastRenderedDocumentUri
+        ? this._lastRenderedDocumentUri.fsPath
+        : null,
     });
 
     webview.onDidReceiveMessage(
@@ -363,7 +369,15 @@ export class BruinPanel {
             break;
 
           case "bruin.getConnectionsList":
-            getConnections(this._lastRenderedDocumentUri); 
+            getConnections(this._lastRenderedDocumentUri);
+            break;
+          
+          case "getLastRenderedDocument":
+            this._panel.webview.postMessage({
+              command: "lastRenderedDocument",
+              path: this._lastRenderedDocumentUri ? this._lastRenderedDocumentUri.fsPath : null,
+            });
+            break;
         }
       },
       undefined,
@@ -391,5 +405,4 @@ export class BruinPanel {
       vscode.window.showErrorMessage("Failed to install/update Bruin CLI. Please try again.");
     }
   }
-
 }

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -16,6 +16,7 @@ import { lineageCommand } from "../extension/commands/lineageCommand";
 import { parseAssetCommand } from "../extension/commands/parseAssetCommand";
 import { getEnvListCommand } from "../extension/commands/getEnvListCommand";
 import { BruinInstallCLI } from "../bruin/bruinInstallCli";
+import { getConnections } from "../extension/commands/getConnections";
 
 /**
  * This class manages the state and behavior of Bruin webview panels.
@@ -362,15 +363,7 @@ export class BruinPanel {
             break;
 
           case "bruin.getConnectionsList":
-            BruinPanel.postMessage("connections-list-message", {
-              status: "success",
-              message: [
-                { name: "bruin-health-check-bq", type: "google_cloud_platform" },
-                { name: "test", type: "notion" },
-                { name: "bruin-health-check-sf", type: "snowflake" },
-              ],
-            });
-            break;
+            getConnections(this._lastRenderedDocumentUri); 
         }
       },
       undefined,
@@ -398,4 +391,5 @@ export class BruinPanel {
       vscode.window.showErrorMessage("Failed to install/update Bruin CLI. Please try again.");
     }
   }
+
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -203,8 +203,8 @@ suite("Manage Bruin Connections Tests", function () {
     };
     const connections = extractNonNullConnections(singleEnvconnections);
     assert.deepStrictEqual(connections, [
-      { type: "google_cloud_platform", name: "gcp_project" },
-      { type: "snowflake", name: "snowflake_project" },
+      { environment: "default", type: "google_cloud_platform", name: "gcp_project" },
+      { environment: "default", type: "snowflake", name: "snowflake_project" },
     ]);
   });
   test("Should return an array of connections from multiple environments", async () => {
@@ -234,8 +234,8 @@ suite("Manage Bruin Connections Tests", function () {
     };
     const connections = extractNonNullConnections(multiEnvconnections);
     assert.deepStrictEqual(connections, [
-      { type: "google_cloud_platform", name: "gcp_project" },
-      { type: "aws", name: "aws_project" },
+      { environment: "default", type: "google_cloud_platform", name: "gcp_project" },
+      { environment: "staging", type: "aws", name: "aws_project" },
     ]);
   });
   test("Should handle connections without project_id or name", async () => {
@@ -259,8 +259,8 @@ suite("Manage Bruin Connections Tests", function () {
     };
     const connections = extractNonNullConnections(singleEnvconnections);
     assert.deepStrictEqual(connections, [
-      { type: "google_cloud_platform", name: null }, // No project_id or name
-      { type: "aws", name: "aws_connection" },
+      { environment: "default", type: "google_cloud_platform", name: null }, // No project_id or name
+      { environment: "default", type: "aws", name: "aws_connection" },
     ]);
   });
   test("Should return an empty array when input is completely empty", async () => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -203,8 +203,8 @@ suite("Manage Bruin Connections Tests", function () {
     };
     const connections = extractNonNullConnections(singleEnvconnections);
     assert.deepStrictEqual(connections, [
-      { environment: "default", type: "google_cloud_platform", name: "gcp_project" },
-      { environment: "default", type: "snowflake", name: "snowflake_project" },
+      { environment: "default", type: "google_cloud_platform", name: null },
+      { environment: "default", type: "snowflake", name: null },
     ]);
   });
   test("Should return an array of connections from multiple environments", async () => {
@@ -224,7 +224,7 @@ suite("Manage Bruin Connections Tests", function () {
           connections: {
             aws: [
               {
-                project_id: "aws_project",
+                name: "aws_project",
               },
             ],
             snowflake: null,
@@ -234,7 +234,7 @@ suite("Manage Bruin Connections Tests", function () {
     };
     const connections = extractNonNullConnections(multiEnvconnections);
     assert.deepStrictEqual(connections, [
-      { environment: "default", type: "google_cloud_platform", name: "gcp_project" },
+      { environment: "default", type: "google_cloud_platform", name: null },
       { environment: "staging", type: "aws", name: "aws_project" },
     ]);
   });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -10,12 +10,12 @@ import {
   removeAnsiColors,
   processLineageData,
   getFileExtension,
+  extractNonNullConnections,
 } from "../utilities/helperUtils";
 import * as fs from "fs";
 import path = require("path");
 import sinon = require("sinon");
-const proxyquire = require('proxyquire').noCallThru();
-
+const proxyquire = require("proxyquire").noCallThru();
 
 suite("Extension Initialization", () => {
   test("should set default path separator based on platform", async () => {
@@ -99,285 +99,198 @@ suite("Render Command Helper functions", () => {
     assert.strictEqual(processLineageData(lineageString), "example-name");
   });
 });
-suite('checkBruinCliInstallation Tests', function() {
+suite("checkBruinCliInstallation Tests", function () {
   let osStub: sinon.SinonStub<[], string>;
   let execAsyncStub: sinon.SinonStub<[string], Promise<{ stdout: string; stderr: string }>>;
   let promisifyStub: sinon.SinonStub;
   let checkBruinCliInstallation: any;
 
-  setup(function() {
-    osStub = sinon.stub(os, 'platform');
+  setup(function () {
+    osStub = sinon.stub(os, "platform");
     execAsyncStub = sinon.stub();
     promisifyStub = sinon.stub().returns(execAsyncStub);
 
-    const proxyquire = require('proxyquire');
-    ({ checkBruinCliInstallation } = proxyquire('../bruin/bruinUtils', {
-      'os': { platform: () => osStub() },
-      'util': { promisify: promisifyStub },
-      'child_process': { exec: sinon.stub() },
+    const proxyquire = require("proxyquire");
+    ({ checkBruinCliInstallation } = proxyquire("../bruin/bruinUtils", {
+      os: { platform: () => osStub() },
+      util: { promisify: promisifyStub },
+      child_process: { exec: sinon.stub() },
     }));
   });
 
-  teardown(function() {
+  teardown(function () {
     sinon.restore();
   });
 
-  test('Should return installed true on non-Windows when bruin is installed', async function() {
-    osStub.returns('darwin');
-    execAsyncStub.withArgs('bruin --version').resolves({ stdout: 'version info', stderr: '' });
+  test("Should return installed true on non-Windows when bruin is installed", async function () {
+    osStub.returns("darwin");
+    execAsyncStub.withArgs("bruin --version").resolves({ stdout: "version info", stderr: "" });
 
     const result = await checkBruinCliInstallation();
     assert.deepStrictEqual(result, { installed: true, isWindows: false, goInstalled: false });
   });
 
-  test('Should return installed false on non-Windows when bruin is not installed', async function() {
-    osStub.returns('darwin');
-    execAsyncStub.withArgs('bruin --version').rejects(new Error("Command failed: bruin --version"));
+  test("Should return installed false on non-Windows when bruin is not installed", async function () {
+    osStub.returns("darwin");
+    execAsyncStub.withArgs("bruin --version").rejects(new Error("Command failed: bruin --version"));
 
     const result = await checkBruinCliInstallation();
     assert.deepStrictEqual(result, { installed: false, isWindows: false, goInstalled: false });
   });
 
-  test('Should return installed false on non-Windows when bruin is not installed', async function() {
-    osStub.returns('linux');
-    execAsyncStub.withArgs('bruin --version').rejects(new Error('Command not found'));
-    
-    const result = await checkBruinCliInstallation();
-    assert.deepStrictEqual(result, { installed: false, isWindows: false, goInstalled: false });
-  });
-
-  test('Should return correct values on Windows when bruin is installed', async function() {
-    osStub.returns('win32');
-    execAsyncStub.withArgs('bruin --version').resolves({ stdout: 'version info', stderr: '' });
+  test("Should return correct values on Windows when bruin is installed", async function () {
+    osStub.returns("win32");
+    execAsyncStub.withArgs("bruin --version").resolves({ stdout: "version info", stderr: "" });
 
     const result = await checkBruinCliInstallation();
     assert.deepStrictEqual(result, { installed: true, isWindows: true, goInstalled: false });
   });
 
-  test('Should check for Go on Windows when bruin is not installed', async function() {
-    osStub.returns('win32');
-    execAsyncStub.withArgs('bruin --version').rejects(new Error('Command not found'));
-    execAsyncStub.withArgs('go version').resolves({ stdout: 'go version info', stderr: '' });
+  test("Should check for Go on Windows when bruin is not installed", async function () {
+    osStub.returns("win32");
+    execAsyncStub.withArgs("bruin --version").rejects(new Error("Command not found"));
+    execAsyncStub.withArgs("go version").resolves({ stdout: "go version info", stderr: "" });
 
     const result = await checkBruinCliInstallation();
     assert.deepStrictEqual(result, { installed: false, isWindows: true, goInstalled: true });
   });
 
-  test('Should return goInstalled false on Windows when neither bruin nor Go are installed', async function() {
-    osStub.returns('win32');
-    execAsyncStub.withArgs('bruin --version').rejects(new Error('Command not found'));
-    execAsyncStub.withArgs('go version').rejects(new Error('Command not found'));
+  test("Should return goInstalled false on Windows when neither bruin nor Go are installed", async function () {
+    osStub.returns("win32");
+    execAsyncStub.withArgs("bruin --version").rejects(new Error("Command not found"));
+    execAsyncStub.withArgs("go version").rejects(new Error("Command not found"));
 
     const result = await checkBruinCliInstallation();
     assert.deepStrictEqual(result, { installed: false, isWindows: true, goInstalled: false });
   });
 });
 
-/* import * as assert from "assert";
-import * as vscode from "vscode";
-import { bruinFoldingRangeProvider } from "../providers/bruinFoldingRangeProvider";
-import { test } from "mocha";
-import sinon from 'sinon';
-import { buildCommand, commandExecution } from "../utils/bruinUtils";
-const proxyquire = require('proxyquire').noCallThru();
-
-const child_process = require('child_process');
-
-function createMockTextDocument(content: string[], languageId: string): any {
-  return {
-    lineAt: (lineNumber: number) => {
-      return { text: content[lineNumber] };
-    },
-    lineCount: content.length,
-    languageId,
-  };
-}
-suite('bruinWorkspaceDirectory Tests', function() {
-  let fsStub: { statSync: any; accessSync: any; }, pathStub: { dirname: any; join?: sinon.SinonStub<any[], any>; };
-
-  setup(function() {
-    // Setup fs and path stubs before each test
-    fsStub = {
-      statSync: sinon.stub(),
-      accessSync: sinon.stub(),
+suite("Manage Bruin Connections Tests", function () {
+  test("Should return an empty array for all null connections", async () => {
+    const singleEnvconnections = {
+      environments: {
+        default: {
+          connections: {
+            aws: null,
+            google_cloud_platform: null,
+            snowflake: null,
+          },
+        },
+      },
     };
-    pathStub = {
-      dirname: sinon.stub(),
-      join: sinon.stub().callsFake((...args) => args.join('/')), 
+    const connections = extractNonNullConnections(singleEnvconnections);
+    assert.deepStrictEqual(connections, []);
+  });
+  test("Should return an array of connections for all non-null connections", async () => {
+    const singleEnvconnections = {
+      environments: {
+        default: {
+          connections: {
+            aws: null,
+            google_cloud_platform: [
+              {
+                project_id: "gcp_project",
+              },
+            ],
+            snowflake: [
+              {
+                project_id: "snowflake_project",
+              },
+            ],
+          },
+        },
+      },
     };
+    const connections = extractNonNullConnections(singleEnvconnections);
+    assert.deepStrictEqual(connections, [
+      { type: "google_cloud_platform", name: "gcp_project" },
+      { type: "snowflake", name: "snowflake_project" },
+    ]);
+  });
+  test("Should return an array of connections from multiple environments", async () => {
+    const multiEnvconnections = {
+      environments: {
+        default: {
+          connections: {
+            aws: null,
+            google_cloud_platform: [
+              {
+                project_id: "gcp_project",
+              },
+            ],
+          },
+        },
+        staging: {
+          connections: {
+            aws: [
+              {
+                project_id: "aws_project",
+              },
+            ],
+            snowflake: null,
+          },
+        },
+      },
+    };
+    const connections = extractNonNullConnections(multiEnvconnections);
+    assert.deepStrictEqual(connections, [
+      { type: "google_cloud_platform", name: "gcp_project" },
+      { type: "aws", name: "aws_project" },
+    ]);
+  });
+  test("Should handle connections without project_id or name", async () => {
+    const singleEnvconnections = {
+      environments: {
+        default: {
+          connections: {
+            google_cloud_platform: [
+              {
+                // No project_id or name provided
+              },
+            ],
+            aws: [
+              {
+                name: "aws_connection",
+              },
+            ],
+          },
+        },
+      },
+    };
+    const connections = extractNonNullConnections(singleEnvconnections);
+    assert.deepStrictEqual(connections, [
+      { type: "google_cloud_platform", name: null }, // No project_id or name
+      { type: "aws", name: "aws_connection" },
+    ]);
+  });
+  test("Should return an empty array when input is completely empty", async () => {
+    const emptyConnections = {};
+    const connections = extractNonNullConnections(emptyConnections);
+    assert.deepStrictEqual(connections, []);
+  });
+  test("Should return an empty array when connections object is empty", async () => {
+    const singleEnvconnections = {
+      environments: {
+        default: {
+          connections: {},
+        },
+      },
+    };
+    const connections = extractNonNullConnections(singleEnvconnections);
+    assert.deepStrictEqual(connections, []);
   });
 
-  teardown(function() {
-    // Cleanup actions after each test
-    sinon.restore();
-  });
-
-  // Define a test
-  test('should return the directory containing the .bruin.yml file', function() {
-    const fsPath = '/some/path/to/project/file.txt';
-    const expectedDir = '/some/path/to/project';
-
-    // Configure stubs
-    fsStub.statSync.returns({ isFile: () => true });
-    fsStub.accessSync.withArgs('/some/path/to/project/.bruin.yml').throws(new Error('Not found'));
-    fsStub.accessSync.withArgs('/some/path/to/project/.bruin.yaml').returns(undefined); // Found
-
-    pathStub.dirname.onFirstCall().returns('/some/path/to/project');
-    pathStub.dirname.onSecondCall().returns('/some/path/to');
-
-    // path to the function to be tested
-    const bruinWorkspaceDirectory = proxyquire('../utils/bruinUtils', {
-      fs: fsStub,
-      path: pathStub,
-    }).bruinWorkspaceDirectory;
-
-    const result = bruinWorkspaceDirectory(fsPath) === undefined ? expectedDir : bruinWorkspaceDirectory(fsPath);
-  
-    assert.strictEqual(result, expectedDir);
-    
+  test("Should return an empty array when environments key is missing", async () => {
+    const missingEnvironmentsKey = {
+      connections: {
+        aws: [
+          {
+            name: "aws_connection",
+          },
+        ],
+      },
+    };
+    const connections = extractNonNullConnections(missingEnvironmentsKey);
+    assert.deepStrictEqual(connections, []);
   });
 });
-
-suite('Command Execution Test Suite', function() {
-    let execStub : sinon.SinonStub;
-
-    setup(function() {
-        execStub = sinon.stub(child_process, 'exec');
-    });
-
-    teardown(function() {
-        execStub.restore();
-    });
-
-    test('Should resolve with stdout on successful execution', function(done) {
-        const expectedOutput = 'command output';
-        execStub.callsArgWith(2, null, expectedOutput); // Simulate successful execution
-
-        commandExecution('echo "Hello World"').then(result => {
-            assert.strictEqual(execStub.calledOnce, true);
-            assert.strictEqual(result.stdout, expectedOutput);
-            assert.strictEqual(result.stderr, undefined);
-            done();
-        }).catch(done);
-    });
-
-    test('Should resolve with stderr on execution error', function(done) {
-        const expectedErrorOutput = 'Error occurred';
-        execStub.callsArgWith(2, new Error('error'), expectedErrorOutput); 
-    
-        commandExecution('invalid_command').then(result => {
-            assert.strictEqual(execStub.calledOnce, true, "Stub was not called exactly once");
-            assert.strictEqual(result.stderr, expectedErrorOutput, "Error message does not match expected output");
-            assert.strictEqual(result.stdout, undefined, "Expected no stdout on execution error");
-            done();
-        }).catch(err => done(err));
-    });
-    
-});
-
-suite("Utils Test Suite", () => {
-    let platformStub: sinon.SinonStub;
-
-    setup(() => {
-        platformStub = sinon.stub(process, 'platform');
-    });
-
-    teardown(() => {
-        platformStub.restore();
-    });
-
-    test('Builds correct command on Windows', () => {
-        platformStub.value('win32');
-        const command = buildCommand('myCommand');
-        assert.strictEqual(command, 'cmd.exe /c bruin.exe myCommand');
-    });
-
-    test('Builds correct command on Unix-based systems', () => {
-        platformStub.value('darwin');
-        const command = buildCommand('myCommand');
-        assert.strictEqual(command, 'bruin myCommand');
-    });
-});
-
-suite("Folding Range Provider Test Suite", () => {
-  vscode.window.showInformationMessage("Start all tests.");
-  const tests = [
-    {
-      languageId: "python",
-      content: [
-        '""" @bruin',
-        "name: dashboard.bookings",
-        "type: python",
-        " depends:",
-        " - raw.Bookings",
-        "    pass",
-        '@bruin """',
-      ],
-      expectedStart: 0,
-      expectedEnd: 6,
-      expectedFoldingRangeKind: 3,
-    },
-    {
-      languageId: "sql",
-      content: [
-        "/* @bruin",
-        "name: dbo.hello_ms",
-        "type: ms.sql",
-        "materialization:",
-        "   type: table",
-        "columns:",
-        "  - name: one",
-        "    type: integer",
-        "    description: 'Just a number'",
-        "    checks:",
-        "        - name: unique",
-        "        - name: not_null",
-        "        - name: positive",
-        "        - name: accepted_values",
-        "          value: [1, 2]",
-        "@bruin */
-//",
-/*
-      ],
-      expectedStart: 0,
-      expectedEnd: 15,
-      expectedFoldingRangeKind: 3,
-    },
-  ];
-
-  tests.forEach(
-    ({
-      languageId,
-      content,
-      expectedStart,
-      expectedEnd,
-      expectedFoldingRangeKind,
-    }) => {
-      test(`Detects Foldable Regions for ${languageId}`, async () => {
-        const mockDocument = createMockTextDocument(content, languageId);
-        const ranges = bruinFoldingRangeProvider(mockDocument);
-        assert.strictEqual(
-          ranges.length,
-          1,
-          "Should detect one foldable region"
-        );
-        assert.strictEqual(
-          ranges[0].start,
-          expectedStart,
-          `Foldable region start should be ${expectedStart}`
-        );
-        assert.strictEqual(
-          ranges[0].end,
-          expectedEnd,
-          `Foldable region end should be ${expectedEnd}`
-        );
-        assert.strictEqual(
-          ranges[0].kind,
-          expectedFoldingRangeKind,
-          `Folding range kind should be ${expectedFoldingRangeKind}`
-        );
-      });
-    }
-  );
-});
- */

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -203,12 +203,12 @@ export const extractNonNullConnections = (json: any): Connection[] => {
       if (Array.isArray(connection)) {
         connection.forEach((conn) => {
           if (conn) {
-            const name = conn.project_id || conn.name || null;
+            const name = conn.name || null;
             connections.push({ environment: environmentName, type: connectionType as ConnectionType, name });
           }
         });
       } else if (connection !== null) {
-        const name = connection.project_id || connection.name || null;
+        const name = connection.name || null;
         connections.push({ environment: environmentName, type: connectionType as ConnectionType, name });
       }
     });

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -171,18 +171,29 @@ type ConnectionType = "aws" | "athena" | "google_cloud_platform" | "snowflake" |
 interface Connection {
   type: ConnectionType;
   name: string | null;
+  environment: string;
 }
+
+/**
+ * Extracts non-null connections from the JSON object.
+ * param {any} json - The JSON object to extract connections from.
+ * returns {Connection[]} - An array of connections.
+ * 
+ * @param json
+ * @returns
+ * */
+
 
 export const extractNonNullConnections = (json: any): Connection[] => {
   const connections: Connection[] = [];
 
+  // Ensure json and environments exist
   if (!json || !json.environments) {
-    // Return an empty array if json or environments key is missing/undefined
-    return connections;
+    return connections; // Return empty if environments key is missing
   }
 
   // Iterate through each environment
-  Object.keys(json.environments).forEach((environmentName) => {
+  Object.keys(json.environments).forEach(environmentName => {
     const environmentConnections = json.environments[environmentName].connections;
 
     // Iterate through each connection type within the environment
@@ -193,16 +204,17 @@ export const extractNonNullConnections = (json: any): Connection[] => {
         connection.forEach((conn) => {
           if (conn) {
             const name = conn.project_id || conn.name || null;
-            connections.push({ type: connectionType as ConnectionType, name });
+            connections.push({ environment: environmentName, type: connectionType as ConnectionType, name });
           }
         });
       } else if (connection !== null) {
         const name = connection.project_id || connection.name || null;
-        connections.push({ type: connectionType as ConnectionType, name });
+        connections.push({ environment: environmentName, type: connectionType as ConnectionType, name });
       }
     });
   });
 
   return connections;
 };
+
 

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -165,3 +165,44 @@ export function prepareFlags(flags: string, excludeFlags: string[] = []): string
                              .filter(flag => flag !== '' && !excludeFlags.includes(flag));
   return baseFlags.concat(filteredFlags);
 }
+
+type ConnectionType = "aws" | "athena" | "google_cloud_platform" | "snowflake" | "postgres" | "redshift" | "mssql" | "databricks" | "synapse" | "mongo" | "mysql" | "notion" | "hana" | "shopify" | "gorgias" | "generic";
+
+interface Connection {
+  type: ConnectionType;
+  name: string | null;
+}
+
+export const extractNonNullConnections = (json: any): Connection[] => {
+  const connections: Connection[] = [];
+
+  if (!json || !json.environments) {
+    // Return an empty array if json or environments key is missing/undefined
+    return connections;
+  }
+
+  // Iterate through each environment
+  Object.keys(json.environments).forEach((environmentName) => {
+    const environmentConnections = json.environments[environmentName].connections;
+
+    // Iterate through each connection type within the environment
+    Object.keys(environmentConnections).forEach((connectionType: string) => {
+      const connection = environmentConnections[connectionType];
+
+      if (Array.isArray(connection)) {
+        connection.forEach((conn) => {
+          if (conn) {
+            const name = conn.project_id || conn.name || null;
+            connections.push({ type: connectionType as ConnectionType, name });
+          }
+        });
+      } else if (connection !== null) {
+        const name = connection.project_id || connection.name || null;
+        connections.push({ type: connectionType as ConnectionType, name });
+      }
+    });
+  });
+
+  return connections;
+};
+

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -45,7 +45,6 @@
 import AssetDetails from "@/components/asset/AssetDetails.vue";
 import AssetLineageText from "@/components/lineage-text/AssetLineageText.vue";
 import AssetLineageFlow from "@/components/lineage-flow/asset-lineage/AssetLineage.vue";
-import BruinCLI from "@/components/bruin-settings/BruinCLI.vue";
 import { vscode } from "@/utilities/vscode";
 import { ref, onMounted, computed, watch } from "vue";
 import { parseAssetDetails, parseEnvironmentList } from "./utilities/helper";
@@ -54,9 +53,8 @@ import MessageAlert from "@/components/ui/alerts/AlertMessage.vue";
 import { getAssetDataset } from "@/components/lineage-flow/asset-lineage/useAssetLineage";
 import { ArrowPathIcon } from "@heroicons/vue/20/solid";
 import type { EnvironmentsList } from "./types";
-import ConnectionsList from "@/components/connections/ConnectionList.vue";
 import AssetColumns from "@/components/asset/columns/AssetColumns.vue";
-import EditColumns from "@/components/asset/columns/EditColumns.vue";
+import BruinSettings from "@/components/bruin-settings/BruinSettings.vue";
 
 const panelType = ref("");
 const parseError = ref();
@@ -179,18 +177,10 @@ const tabs = ref([
       columns: columns.value,
     })),
   },
-  /* {
-    label: "Edit Columns",
-    component: EditColumns,
-    includeIn: ["bruin"],
-    props: computed(() => ({
-      columns: columns.value,
-    })),
-  }, */
   { label: "Asset Lineage", component: AssetLineageText, includeIn: ["bruin"] },
   {
     label: "Settings",
-    component: BruinCLI,
+    component: BruinSettings,
     includeIn: ["bruin"],
     props: {
       isBruinInstalled: computed(() => isBruinInstalled.value),

--- a/webview-ui/src/components/asset/columns/AssetColumns.vue
+++ b/webview-ui/src/components/asset/columns/AssetColumns.vue
@@ -144,6 +144,11 @@
           />
         </div> -->
       </div>
+      <div v-else>
+        <p class="flex text-md italic justify-start items-center text-editor-fg opacity-70 p-2">
+          No columns to display.
+        </p>
+      </div>
     </div>
 
     <!-- Notification -->
@@ -153,6 +158,7 @@
     >
       {{ notification }}
     </div>
+
   </div>
 </template>
 

--- a/webview-ui/src/components/bruin-settings/BruinCLI.vue
+++ b/webview-ui/src/components/bruin-settings/BruinCLI.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="bg-editorWidget-bg shadow sm:rounded-lg">
-    <div class="px-4 py-5 sm:p-6">
-      <h3 class="text-base font-semibold leading-6 text-editor-fg">
+    <div class="p-4 sm:p-4">
+      <h3 class="text-lg font-semibold leading-6 text-editor-fg">
         {{ isBruinCliInstalled ? "Update" : "Install" }} Bruin CLI
       </h3>
       <div class="mt-2 max-w-xl text-sm text-editor-fg">
@@ -29,7 +29,7 @@
         <vscode-button
           v-else
           @click="installOrUpdateBruinCli"
-          class="inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold shadow-sm"
+          class="inline-flex items-center rounded-md px-3 py-2 text-lg font-semibold shadow-sm"
         >
           {{ isBruinCliInstalled ? "Update" : "Install" }} Bruin CLI
         </vscode-button>

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -8,20 +8,21 @@
     <!-- Connections Section -->
     <div class="bg-editorWidget-bg shadow sm:rounded-lg">
       <ConnectionsList
-        v-if="props.isBruinInstalled"
+        v-if="isBruinInstalled"
+        :connections="connections"
         @new-connection="showConnectionForm"
         @edit-connection="showConnectionForm"
         @delete-connection="confirmDeleteConnection"
       />
     </div>
 
-      <div v-if="showForm" class="mt-6 bg-editorWidget-bg shadow sm:rounded-lg p-6">
-        <ConnectionForm
-          :connection="connectionToEdit"
-          @submit="saveConnection"
-          @cancel="cancelConnectionForm"
-        />
-      </div>
+    <div v-if="showForm" class="mt-6 bg-editorWidget-bg shadow sm:rounded-lg p-6">
+      <ConnectionForm
+        :connection="connectionToEdit"
+        @submit="saveConnection"
+        @cancel="cancelConnectionForm"
+      />
+    </div>
 
     <!-- Delete Confirmation Modal -->
     <DeleteAlert
@@ -37,9 +38,10 @@
 import BruinCLI from "@/components/bruin-settings/BruinCLI.vue";
 import ConnectionsList from "@/components/connections/ConnectionList.vue";
 import ConnectionForm from "@/components/connections/ConnectionsForm.vue";
-import { ref, defineProps, onMounted } from "vue";
+import { ref, defineProps, onMounted, computed } from "vue";
 import DeleteAlert from "@/components/ui/alerts/AlertWithActions.vue";
 import { useConnectionsStore } from "@/store/connections";
+import { vscode } from "@/utilities/vscode";
 
 const props = defineProps({
   isBruinInstalled: Boolean,
@@ -50,9 +52,21 @@ const connectionToEdit = ref(null);
 const showDeleteAlert = ref(false);
 const connectionToDelete = ref(null);
 const connectionsStore = useConnectionsStore();
+const connections = computed(() => connectionsStore.connections);
 
 onMounted(() => {
-  connectionsStore.loadConnections();
+  window.addEventListener("message", (event) => {
+    const message = event.data;
+    if (message.command === "connections-list-message") {
+      if (message.payload.status === "success") {
+        connectionsStore.updateConnectionsFromMessage(message.payload.message);
+      } else {
+        console.error("Error fetching connections:", message.payload.message);
+      }
+    }
+  });
+
+  vscode.postMessage({ command: "bruin.getConnectionsList" });
 });
 
 const showConnectionForm = (connection = null) => {
@@ -61,16 +75,14 @@ const showConnectionForm = (connection = null) => {
 };
 
 const saveConnection = (connection) => {
-  const existingIndex = connectionsStore.connections.findIndex(
-    (c) => c.name === connectionToEdit.value.name
-  );
+  // Update the connections in the store
+  const existingIndex = connections.value.findIndex((c) => c.name === connectionToEdit.value.name);
   if (existingIndex === -1) {
-    connectionsStore.saveConnection(connection);
-    prepareCliPayload(connection);
+    connections.value.push(connection);
   } else {
-    connectionsStore.updateConnection(existingIndex, connection);
-    prepareCliPayload(connection);
+    connections.value[existingIndex] = connection;
   }
+
   showForm.value = false;
   connectionToEdit.value = null;
 };
@@ -86,7 +98,13 @@ const confirmDeleteConnection = (connection) => {
 };
 
 const deleteConnection = () => {
-  connectionsStore.deleteConnection(connectionToDelete.value);
+  const updatedConnections = connections.value.filter(
+    (c) => c.name !== connectionToDelete.value.name
+  );
+  // Update the local state
+  connections.value = updatedConnections;
+  // Update the Pinia store
+  connectionsStore.updateConnectionsFromMessage(updatedConnections);
   showDeleteAlert.value = false;
   connectionToDelete.value = null;
 };
@@ -95,10 +113,4 @@ const cancelDeleteConnection = () => {
   showDeleteAlert.value = false;
   connectionToDelete.value = null;
 };
-
-const prepareCliPayload = (connection) => {
-  const cliPayload = `${connection.name} ${connection.type} '${JSON.stringify(connection)}'`;
-  console.log('CLI Payload:', cliPayload);
-};
-
 </script>

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -13,6 +13,7 @@
         @new-connection="showConnectionForm"
         @edit-connection="showConnectionForm"
         @delete-connection="confirmDeleteConnection"
+        :error="error"
       />
     </div>
 
@@ -54,6 +55,7 @@ const showDeleteAlert = ref(false);
 const connectionToDelete = ref(null);
 const connectionsStore = useConnectionsStore();
 const connections = computed(() => connectionsStore.connections);
+const error = computed(() => connectionsStore.error);
 
 onMounted(() => {
   window.addEventListener("message", (event) => {
@@ -62,13 +64,14 @@ onMounted(() => {
       if (message.payload.status === "success") {
         connectionsStore.updateConnectionsFromMessage(message.payload.message);
       } else {
-        console.error("Error fetching connections:", message.payload.message);
+        connectionsStore.updateErrorFromMessage(message.payload.message);
       }
     }
   });
 
   vscode.postMessage({ command: "bruin.getConnectionsList" });
 });
+
 
 const showConnectionForm = (connection = null) => {
   connectionToEdit.value = connection || { name: "", type: "" };

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -1,61 +1,59 @@
-<template>
-  <div class="flex flex-col justify-center">
-    <header
-      class="flex bg-editorWidget-bg shadow w-full mx-auto py-6 px-4 sm:px-6 lg:px-8 sm:rounded-lg items-center justify-between mb-2"
-    >
-      <h2 class="text-base font-semibold leading-7 text-editor-fg">Connections</h2>
+<!-- <template>
+  <div class="max-w-7xl mx-auto p-4 sm:px-6 lg:px-">
+    <div class="sm:flex sm:items-center sm:justify-between">
+      <div class="flex flex-col items-start space-y-2">
+      <h2 class="text-xl font-semibold text-editor-fg">Connections</h2>
       <vscode-button
         @click="$emit('new-connection')"
-        class="rounded-md px-4 py-2 font-semibold"
+        class="mt-3 sm:mt-0 rounded-md px-3 py-2 text-sm font-semibold"
       >
         New connection
       </vscode-button>
-    </header>
-    <div class="bg-editorWidget-bg shadow sm:rounded-lg px-4 sm:px-6">
-      <table class="min-w-full divide-y divide-gray-300">
-        <thead>
-          <tr>
-            <th
-              scope="col"
-              class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-editor-fg sm:pl-0"
-            >
-              Name
-            </th>
-            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-editor-fg">
-              Type
-            </th>
-            <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0">
-              <span class="sr-only">Actions</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-editorInlayHint-fg">
-          <tr v-for="connection in connections" :key="connection.name">
-            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-editor-fg sm:pl-0">
-              {{ connection.name }}
-            </td>
-            <td class="whitespace-nowrap px-3 py-4 text-sm text-descriptionFg">
-              {{ connection.type }}
-            </td>
-            <td
-              class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0"
-            >
-              <button
-                @click="$emit('edit-connection', connection)"
-                class="text-descriptionFg hover:text-editor-fg mr-2"
-              >
-                <PencilIcon class="h-5 w-5" />
-              </button>
-              <button
-                @click="$emit('delete-connection', connection)"
-                class="text-errorForeground hover:text-editorError-foreground"
-              >
-                <TrashIcon class="h-5 w-5" />
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div> This is a description for the connection list  </div>
+    </div>
+    </div> 
+    
+    <div v-for="(connections, environment) in groupedConnections" :key="environment" class="mt-6">
+      <h3 class="text-lg font-medium text-editor-fg mb-2 font-mono">{{ environment }}</h3>
+      <div class="overflow-hidden bg-editorWidget-bg sm:rounded-lg">
+        <table class="min-w-full divide-y divide-editor-fg divide-opacity-30">
+          <thead>
+            <tr>
+              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-editor-fg sm:pl-6 opacity-70">Name</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-editor-fg opacity-70">Type</th>
+             <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
+                <span class="sr-only">Actions</span>
+              </th> 
+            </tr>
+          </thead>
+          <tbody class=" ">
+            <tr v-for="connection in connections" :key="connection.name" class="hover:bg-editor-hoverBackground">
+              <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-editor-fg sm:pl-6 font-mono">
+                {{ connection.name }}
+              </td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-descriptionFg font-mono">
+                {{ connection.type }}
+              </td>
+           <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                <button
+                  @click="$emit('edit-connection', connection)"
+                  class="text-descriptionFg hover:text-editor-fg mr-3"
+                  title="Edit"
+                >
+                  <PencilIcon class="h-5 w-5" />
+                </button>
+                <button
+                  @click="$emit('delete-connection', connection)"
+                  class="text-errorForeground hover:text-editorError-foreground"
+                  title="Delete"
+                >
+                  <TrashIcon class="h-5 w-5" />
+                </button>
+              </td> 
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </template>
@@ -63,16 +61,90 @@
 <script setup>
 import { TrashIcon, PencilIcon } from "@heroicons/vue/24/outline";
 import { useConnectionsStore } from "@/store/connections";
-import { computed, defineEmits } from "vue";
+import { computed } from "vue";
 
 const connectionsStore = useConnectionsStore();
 const connections = computed(() => connectionsStore.connections);
 
+const groupedConnections = computed(() => {
+  return connections.value.reduce((grouped, connection) => {
+    const { environment } = connection;
+    (grouped[environment] = grouped[environment] || []).push(connection);
+    return grouped;
+  }, {});
+});
+
 defineEmits(['new-connection', 'edit-connection', 'delete-connection']);
 </script>
+
 <style scoped>
 vscode-button::part(control) {
   border: none;
   outline: none;
+}
+</style> -->
+
+
+
+<template>
+  <div class="max-w-7xl mx-auto p-4">
+    <div class="sm:flex sm:items-center sm:justify-between">
+      <div class="flex flex-col items-start space-y-2">
+        <h2 class="text-xl font-semibold text-editor-fg">Connections</h2>
+        <div>This is a description for the connection list</div>
+      </div>
+    </div>
+    
+    <div v-for="(connections, environment) in groupedConnections" :key="environment" class="mt-6">
+      <h3 class="text-lg font-medium text-editor-fg mb-2 font-mono">{{ environment }}</h3>
+      <div class="overflow-hidden bg-editorWidget-bg sm:rounded-lg">
+        <table class="min-w-full divide-y divide-commandCenter-border">
+          <thead>
+            <tr>
+              <th scope="col" class="w-1/2 px-2 py-2 text-left text-sm font-semibold text-editor-fg opacity-70 ">Name</th>
+              <th scope="col" class="w-1/2 px-2 py-2 text-left text-sm font-semibold text-editor-fg opacity-70">Type</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="connection in connections" :key="connection.name" class="hover:bg-editor-hoverBackground">
+              <td class="w-1/2 whitespace-nowrap px-2 py-4 text-sm font-medium text-editor-fg font-mono">
+                {{ connection.name }}
+              </td>
+              <td class="w-1/2 whitespace-nowrap px-2 py-4 text-sm text-descriptionFg font-mono">
+                {{ connection.type }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useConnectionsStore } from "@/store/connections";
+import { computed } from "vue";
+
+const connectionsStore = useConnectionsStore();
+const connections = computed(() => connectionsStore.connections);
+
+const groupedConnections = computed(() => {
+  return connections.value.reduce((grouped, connection) => {
+    const { environment } = connection;
+    (grouped[environment] = grouped[environment] || []).push(connection);
+    return grouped;
+  }, {});
+});
+
+defineEmits(['new-connection', 'edit-connection', 'delete-connection']);
+</script>
+
+<style scoped>
+vscode-button::part(control) {
+  border: none;
+  outline: none;
+}
+.divide-y-opacity{
+  border: 0.5;
 }
 </style>

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -84,35 +84,77 @@ vscode-button::part(control) {
 }
 </style> -->
 
-
-
 <template>
   <div class="max-w-7xl mx-auto p-4">
-    <div class="sm:flex sm:items-center sm:justify-between">
+    <div class="sm:flex sm:items-center sm:justify-between mb-2">
       <div class="flex flex-col items-start space-y-2">
         <h2 class="text-xl font-semibold text-editor-fg">Connections</h2>
-        <div>This is a description for the connection list</div>
+        <div class="mt-2 max-w-xl text-sm text-editor-fg">
+          <p>
+            View your connections across different environments in one place.
+          </p>
+        </div>
       </div>
+      <!--  <vscode-button
+        @click="$emit('new-connection')"
+        class="mt-3 sm:mt-0 rounded-md px-3 py-2 text-sm font-semibold"
+      >
+        New connection
+      </vscode-button> -->
     </div>
-    
+
     <div v-for="(connections, environment) in groupedConnections" :key="environment" class="mt-6">
       <h3 class="text-lg font-medium text-editor-fg mb-2 font-mono">{{ environment }}</h3>
       <div class="overflow-hidden bg-editorWidget-bg sm:rounded-lg">
         <table class="min-w-full divide-y divide-commandCenter-border">
           <thead>
             <tr>
-              <th scope="col" class="w-1/2 px-2 py-2 text-left text-sm font-semibold text-editor-fg opacity-70 ">Name</th>
-              <th scope="col" class="w-1/2 px-2 py-2 text-left text-sm font-semibold text-editor-fg opacity-70">Type</th>
+              <th
+                scope="col"
+                class="w-1/2 px-2 py-2 text-left text-sm font-semibold text-editor-fg opacity-70"
+              >
+                Name
+              </th>
+              <th
+                scope="col"
+                class="w-1/2 px-2 py-2 text-left text-sm font-semibold text-editor-fg opacity-70"
+              >
+                Type
+              </th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="connection in connections" :key="connection.name" class="hover:bg-editor-hoverBackground">
-              <td class="w-1/2 whitespace-nowrap px-2 py-4 text-sm font-medium text-editor-fg font-mono">
+            <tr
+              v-for="connection in connections"
+              :key="connection.name"
+              class="hover:bg-editor-hoverBackground"
+            >
+              <td
+                class="w-1/2 whitespace-nowrap px-2 py-4 text-sm font-medium text-editor-fg font-mono"
+              >
                 {{ connection.name }}
               </td>
               <td class="w-1/2 whitespace-nowrap px-2 py-4 text-sm text-descriptionFg font-mono">
                 {{ connection.type }}
               </td>
+              <!--  <td
+                class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
+              >
+                <button
+                  @click="$emit('edit-connection', connection)"
+                  class="text-descriptionFg hover:text-editor-fg mr-3"
+                  title="Edit"
+                >
+                  <PencilIcon class="h-5 w-5" />
+                </button>
+                <button
+                  @click="$emit('delete-connection', connection)"
+                  class="text-errorForeground hover:text-editorError-foreground"
+                  title="Delete"
+                >
+                  <TrashIcon class="h-5 w-5" />
+                </button>
+              </td> -->
             </tr>
           </tbody>
         </table>
@@ -124,6 +166,7 @@ vscode-button::part(control) {
 <script setup>
 import { useConnectionsStore } from "@/store/connections";
 import { computed } from "vue";
+import { TrashIcon, PencilIcon } from "@heroicons/vue/24/outline";
 
 const connectionsStore = useConnectionsStore();
 const connections = computed(() => connectionsStore.connections);
@@ -136,7 +179,7 @@ const groupedConnections = computed(() => {
   }, {});
 });
 
-defineEmits(['new-connection', 'edit-connection', 'delete-connection']);
+defineEmits(["new-connection", "edit-connection", "delete-connection"]);
 </script>
 
 <style scoped>
@@ -144,7 +187,7 @@ vscode-button::part(control) {
   border: none;
   outline: none;
 }
-.divide-y-opacity{
+.divide-y-opacity {
   border: 0.5;
 }
 </style>

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -89,10 +89,8 @@ vscode-button::part(control) {
     <div class="sm:flex sm:items-center sm:justify-between mb-2">
       <div class="flex flex-col items-start space-y-2">
         <h2 class="text-xl font-semibold text-editor-fg">Connections</h2>
-        <div class="mt-2 max-w-xl text-sm text-editor-fg">
-          <p>
-            View your connections across different environments in one place.
-          </p>
+        <div v-if="!error" class="mt-2 max-w-xl text-sm text-editor-fg">
+          <p>View your connections across different environments in one place.</p>
         </div>
       </div>
       <!--  <vscode-button
@@ -103,7 +101,15 @@ vscode-button::part(control) {
       </vscode-button> -->
     </div>
 
-    <div v-for="(connections, environment) in groupedConnections" :key="environment" class="mt-6">
+    <div v-if="error">
+      <AlertMessage :message="error" />
+    </div>
+    <div
+      v-else
+      v-for="(connections, environment) in groupedConnections"
+      :key="environment"
+      class="mt-6"
+    >
       <h3 class="text-lg font-medium text-editor-fg mb-2 font-mono">{{ environment }}</h3>
       <div class="overflow-hidden bg-editorWidget-bg sm:rounded-lg">
         <table class="min-w-full divide-y divide-commandCenter-border">
@@ -133,7 +139,7 @@ vscode-button::part(control) {
                 class="w-1/2 whitespace-nowrap px-2 py-4 text-sm font-medium text-editor-fg font-mono"
                 :class="{ 'opacity-80 italic': !connection.name }"
               >
-                {{ connection.name || 'undefined' }}
+                {{ connection.name || "undefined" }}
               </td>
               <td class="w-1/2 whitespace-nowrap px-2 py-4 text-sm text-descriptionFg font-mono">
                 {{ connection.type }}
@@ -168,9 +174,12 @@ vscode-button::part(control) {
 import { useConnectionsStore } from "@/store/connections";
 import { computed } from "vue";
 import { TrashIcon, PencilIcon } from "@heroicons/vue/24/outline";
+import AlertMessage from "@/components/ui/alerts/AlertMessage.vue";
+
 
 const connectionsStore = useConnectionsStore();
 const connections = computed(() => connectionsStore.connections);
+const error = computed(() => connectionsStore.error);
 
 const groupedConnections = computed(() => {
   return connections.value.reduce((grouped, connection) => {

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -131,8 +131,9 @@ vscode-button::part(control) {
             >
               <td
                 class="w-1/2 whitespace-nowrap px-2 py-4 text-sm font-medium text-editor-fg font-mono"
+                :class="{ 'opacity-80 italic': !connection.name }"
               >
-                {{ connection.name }}
+                {{ connection.name || 'undefined' }}
               </td>
               <td class="w-1/2 whitespace-nowrap px-2 py-4 text-sm text-descriptionFg font-mono">
                 {{ connection.type }}

--- a/webview-ui/src/store/connections.ts
+++ b/webview-ui/src/store/connections.ts
@@ -1,12 +1,19 @@
+import { error } from 'console';
 import { defineStore } from 'pinia';
 
 export const useConnectionsStore = defineStore('connections', {
   state: () => ({
     connections: [],
+    error: null,
   }),
   actions: {
     updateConnectionsFromMessage(data) {
       this.connections = data;
+      this.error = null;
+    },
+    updateErrorFromMessage(data) {
+      this.error = data;
+      this.connections = [];
     },
   },
 });

--- a/webview-ui/src/store/connections.ts
+++ b/webview-ui/src/store/connections.ts
@@ -1,22 +1,12 @@
-import { defineStore } from "pinia";
+import { defineStore } from 'pinia';
 
-export const useConnectionsStore = defineStore("connections", {
+export const useConnectionsStore = defineStore('connections', {
   state: () => ({
-    connections: [
-      { name: "bruin-health-check-bq", type: "google_cloud_platform" },
-      { name: "test", type: "notion" },
-      { name: "bruin-health-check-sf", type: "snowflake" },
-    ],
+    connections: [],
   }),
   actions: {
-    saveConnection(connection) {
-      this.connections.push({ id: this.connections.length + 1, ...connection });
-    },
-    updateConnection(index, connection) {
-      this.connections[index] = { ...this.connections[index], ...connection };
-    },
-    deleteConnection(connection) {
-      this.connections = this.connections.filter((c) => c.name !== connection.name);
+    updateConnectionsFromMessage(data) {
+      this.connections = data;
     },
   },
 });


### PR DESCRIPTION
# PR Overview
This PR introduces a new section for displaying connections and integrates a Bruin CLI command to fetch all available connections. It includes both backend and frontend updates:

- **New UI Section:** Added a section to display connections in the 'Settings' tab.
- **Grouping by Environment**: The connection are grouped by environment.
- **CLI Integration:** Implemented functionality to fetch connections using the Bruin CLI command.
- **Alert for CLI Version:** Added an alert to ensure users have the latest Bruin CLI version to utilize this feature.
- **Enhance the Column Tab**: Added message to display when no columns are available

1. Asset with No Columns to Show
<img width="605" alt="asset-with-no-columns" src="https://github.com/user-attachments/assets/33099c30-578e-40b8-8561-6fe285c09be1">

2. Connections Section 
<img width="751" alt="connection-list" src="https://github.com/user-attachments/assets/d81fcf0e-8a99-4609-af82-9ebdc6a26f20">

3- Alert Message for Outdated CLI  
<img width="752" alt="outdated-cli" src="https://github.com/user-attachments/assets/578881c8-bdd0-496f-9a3e-8788db992f81">
