### PR TITLE
Fix render issue when clicking query part after full-refresh

### DIFF
--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -21,167 +21,177 @@
             <CheckboxGroup :checkboxItems="checkboxItems" />
           </div>
         </div>
-        <div class="flex flex-wrap justify-between items-center"> 
-       <EnvSelectMenu :options="environments" @selected-env="setSelectedEnv" :selectedEnvironment="selectedEnvironment" /> 
-        <div class="flex justify-end items-center space-x-2 sm:space-x-4 mt-2 sm:mt-0">
-          <div class="inline-flex rounded-md shadow-sm">
-            <button
-              type="button"
-              class="relative inline-flex items-center rounded-l-md bg-editor-button-bg px-3 py-2 text-sm font-medium text-editor-button-fg ring-1 ring-inset ring-editor-button-border hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed focus:z-10"
-              @click="handleBruinValidateCurrentAsset"
-              :disabled="isNotAsset || isError"
-            >
-              <SparklesIcon v-if="!validateButtonStatus" class="h-4 w-4 mr-1"></SparklesIcon>
-              <template v-else>
-                <CheckCircleIcon
-                  v-if="validateButtonStatus === 'validated'"
-                  class="h-4 w-4 mr-1 text-editor-button-fg"
-                  aria-hidden="true"
-                />
-                <XCircleIcon
-                  v-else-if="validateButtonStatus === 'failed'"
-                  class="h-4 w-4 mr-1 text-editorError-foreground"
-                  aria-hidden="true"
-                />
-                <svg
-                  v-else-if="validateButtonStatus === 'loading'"
-                  class="animate-spin mr-1 h-4 w-4 text-editor-bg"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                >
-                  <circle
-                    class="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    stroke-width="4"
-                  ></circle>
-                  <path
-                    class="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  ></path>
-                </svg>
-              </template>
-              Validate
-            </button>
-            <Menu as="div" class="relative -ml-px block">
-              <MenuButton
+        <div class="flex flex-wrap justify-between items-center">
+          <EnvSelectMenu
+            :options="environments"
+            @selected-env="setSelectedEnv"
+            :selectedEnvironment="selectedEnvironment"
+          />
+          <div class="flex justify-end items-center space-x-2 sm:space-x-4 mt-2 sm:mt-0">
+            <div class="inline-flex rounded-md shadow-sm">
+              <button
+                type="button"
+                class="relative inline-flex items-center rounded-l-md bg-editor-button-bg px-3 py-2 text-sm font-medium text-editor-button-fg ring-1 ring-inset ring-editor-button-border hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed focus:z-10"
+                @click="handleBruinValidateCurrentAsset"
                 :disabled="isNotAsset || isError"
-                class="relative inline-flex items-center disabled:opacity-50 disabled:cursor-not-allowed rounded-r-md bg-editor-button-bg px-2 py-2 text-editor-button-fg ring-1 ring-inset ring-editor-button-border hover:bg-editor-button-hover-bg focus:z-10"
               >
-                <ChevronDownIcon class="h-5 w-5" aria-hidden="true" />
-              </MenuButton>
-              <transition
-                enter-active-class="transition ease-out duration-100"
-                enter-from-class="transform opacity-0 scale-95"
-                enter-to-class="transform opacity-100 scale-100"
-                leave-active-class="transition ease-in duration-75"
-                leave-from-class="transform opacity-100 scale-100"
-                leave-to-class="transform opacity-0 scale-95"
-              >
-                <MenuItems
-                  class="absolute right-0 z-10 -mr-1 mt-2 w-56 origin-top-right rounded-md bg-editor-button-bg shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                <SparklesIcon v-if="!validateButtonStatus" class="h-4 w-4 mr-1"></SparklesIcon>
+                <template v-else>
+                  <CheckCircleIcon
+                    v-if="validateButtonStatus === 'validated'"
+                    class="h-4 w-4 mr-1 text-editor-button-fg"
+                    aria-hidden="true"
+                  />
+                  <XCircleIcon
+                    v-else-if="validateButtonStatus === 'failed'"
+                    class="h-4 w-4 mr-1 text-editorError-foreground"
+                    aria-hidden="true"
+                  />
+                  <svg
+                    v-else-if="validateButtonStatus === 'loading'"
+                    class="animate-spin mr-1 h-4 w-4 text-editor-bg"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      class="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      stroke-width="4"
+                    ></circle>
+                    <path
+                      class="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
+                  </svg>
+                </template>
+                Validate
+              </button>
+              <Menu as="div" class="relative -ml-px block">
+                <MenuButton
+                  :disabled="isNotAsset || isError"
+                  class="relative inline-flex items-center disabled:opacity-50 disabled:cursor-not-allowed rounded-r-md bg-editor-button-bg px-2 py-2 text-editor-button-fg ring-1 ring-inset ring-editor-button-border hover:bg-editor-button-hover-bg focus:z-10"
                 >
-                  <div class="py-1">
-                    <MenuItem key="validate-current" v-slot="{ active }">
-                      <button
-                        :class="[
-                          active
-                            ? 'bg-editor-button-hover-bg text-editor-button-fg'
-                            : 'bg-editor-button-bg',
-                          'block w-full text-left px-4 py-2 text-sm',
-                        ]"
-                        @click="handleBruinValidateCurrentPipeline"
-                      >
-                        Validate current pipeline
-                      </button>
-                    </MenuItem>
-                    <MenuItem key="validate-all" v-slot="{ active }">
-                      <button
-                        :class="[
-                          active
-                            ? 'bg-editor-button-hover-bg text-editor-button-fg'
-                            : 'bg-editor-button-bg',
-                          'block w-full text-left px-4 py-2 text-sm',
-                        ]"
-                        @click="handleBruinValidateAllPipelines"
+                  <ChevronDownIcon class="h-5 w-5" aria-hidden="true" />
+                </MenuButton>
+                <transition
+                  enter-active-class="transition ease-out duration-100"
+                  enter-from-class="transform opacity-0 scale-95"
+                  enter-to-class="transform opacity-100 scale-100"
+                  leave-active-class="transition ease-in duration-75"
+                  leave-from-class="transform opacity-100 scale-100"
+                  leave-to-class="transform opacity-0 scale-95"
+                >
+                  <MenuItems
+                    class="absolute right-0 z-10 -mr-1 mt-2 w-56 origin-top-right rounded-md bg-editor-button-bg shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                  >
+                    <div class="py-1">
+                      <MenuItem key="validate-current" v-slot="{ active }">
+                        <button
+                          :class="[
+                            active
+                              ? 'bg-editor-button-hover-bg text-editor-button-fg'
+                              : 'bg-editor-button-bg',
+                            'block w-full text-left px-4 py-2 text-sm',
+                          ]"
+                          @click="handleBruinValidateCurrentPipeline"
                         >
-                        Validate all pipelines
-                      </button>
-                    </MenuItem>
-                  </div>
-                </MenuItems>
-              </transition>
-            </Menu>
-          </div>
+                          Validate current pipeline
+                        </button>
+                      </MenuItem>
+                      <MenuItem key="validate-all" v-slot="{ active }">
+                        <button
+                          :class="[
+                            active
+                              ? 'bg-editor-button-hover-bg text-editor-button-fg'
+                              : 'bg-editor-button-bg',
+                            'block w-full text-left px-4 py-2 text-sm',
+                          ]"
+                          @click="handleBruinValidateAllPipelines"
+                        >
+                          Validate all pipelines
+                        </button>
+                      </MenuItem>
+                    </div>
+                  </MenuItems>
+                </transition>
+              </Menu>
+            </div>
 
-          <div class="inline-flex rounded-md shadow-sm sm:mt-0">
-            <button
-              type="button"
-              :disabled="isNotAsset || isError"
-              class="relative inline-flex items-center rounded-l-md bg-editor-button-bg px-3 py-2 text-sm font-medium text-editor-button-fg ring-1 ring-inset ring-editor-button-border hover:bg-editor-button-hover-bg focus:z-10 disabled:opacity-50 disabled:cursor-not-allowed"
-              @click="runAssetOnly"
-            >
-              <PlayIcon class="h-4 w-4 mr-1"></PlayIcon>
-              Run
-            </button>
-            <Menu as="div" class="relative -ml-px block">
-              <MenuButton
+            <div class="inline-flex rounded-md shadow-sm sm:mt-0">
+              <button
+                type="button"
                 :disabled="isNotAsset || isError"
-                class="relative inline-flex items-center rounded-r-md bg-editor-button-bg px-2 py-2 text-editor-button-fg ring-1 ring-inset ring-editor-button-border hover:bg-editor-button-hover-bg focus:z-10 disabled:opacity-50 disabled:cursor-not-allowed"
+                class="relative inline-flex items-center rounded-l-md bg-editor-button-bg px-3 py-2 text-sm font-medium text-editor-button-fg ring-1 ring-inset ring-editor-button-border hover:bg-editor-button-hover-bg focus:z-10 disabled:opacity-50 disabled:cursor-not-allowed"
+                @click="runAssetOnly"
               >
-                <ChevronDownIcon class="h-5 w-5" aria-hidden="true" />
-              </MenuButton>
-              <transition
-                enter-active-class="transition ease-out duration-100"
-                enter-from-class="transform opacity-0 scale-95"
-                enter-to-class="transform opacity-100 scale-100"
-                leave-active-class="transition ease-in duration-75"
-                leave-from-class="transform opacity-100 scale-100"
-                leave-to-class="transform opacity-0 scale-95"
-              >
-                <MenuItems
-                  class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-editor-button-bg shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                <PlayIcon class="h-4 w-4 mr-1"></PlayIcon>
+                Run
+              </button>
+              <Menu as="div" class="relative -ml-px block">
+                <MenuButton
+                  :disabled="isNotAsset || isError"
+                  class="relative inline-flex items-center rounded-r-md bg-editor-button-bg px-2 py-2 text-editor-button-fg ring-1 ring-inset ring-editor-button-border hover:bg-editor-button-hover-bg focus:z-10 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  <div class="py-1">
-                    <MenuItem key="validate-current" v-slot="{ active }">
-                      <button
-                        :class="[
-                          active
-                            ? 'bg-editor-button-hover-bg text-editor-button-fg'
-                            : 'bg-editor-button-bg',
-                          'block w-full text-left px-4 py-2 text-sm',
-                        ]"
-                        @click="runAssetWithDownstream"
-                      >
-                        Run with downstream
-                      </button>
-                    </MenuItem>
-                    <MenuItem key="validate-all" v-slot="{ active }">
-                      <button
-                        :class="[
-                          active
-                            ? 'bg-editor-button-hover-bg text-editor-button-fg'
-                            : 'bg-editor-button-bg',
-                          'block w-full text-left px-4 py-2 text-sm',
-                        ]"
-                        @click="runCurrentPipeline"
-                      >
-                        Run the whole pipeline
-                      </button>
-                    </MenuItem>
-                  </div>
-                </MenuItems>
-              </transition>
-            </Menu>
+                  <ChevronDownIcon class="h-5 w-5" aria-hidden="true" />
+                </MenuButton>
+                <transition
+                  enter-active-class="transition ease-out duration-100"
+                  enter-from-class="transform opacity-0 scale-95"
+                  enter-to-class="transform opacity-100 scale-100"
+                  leave-active-class="transition ease-in duration-75"
+                  leave-from-class="transform opacity-100 scale-100"
+                  leave-to-class="transform opacity-0 scale-95"
+                >
+                  <MenuItems
+                    class="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-editor-button-bg shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                  >
+                    <div class="py-1">
+                      <MenuItem key="validate-current" v-slot="{ active }">
+                        <button
+                          :class="[
+                            active
+                              ? 'bg-editor-button-hover-bg text-editor-button-fg'
+                              : 'bg-editor-button-bg',
+                            'block w-full text-left px-4 py-2 text-sm',
+                          ]"
+                          @click="runAssetWithDownstream"
+                        >
+                          Run with downstream
+                        </button>
+                      </MenuItem>
+                      <MenuItem key="validate-all" v-slot="{ active }">
+                        <button
+                          :class="[
+                            active
+                              ? 'bg-editor-button-hover-bg text-editor-button-fg'
+                              : 'bg-editor-button-bg',
+                            'block w-full text-left px-4 py-2 text-sm',
+                          ]"
+                          @click="runCurrentPipeline"
+                        >
+                          Run the whole pipeline
+                        </button>
+                      </MenuItem>
+                    </div>
+                  </MenuItems>
+                </transition>
+              </Menu>
+            </div>
           </div>
         </div>
-             </div>
- 
-        <ErrorAlert v-if="isError" :errorMessage="errorMessage!" class="mb-4" :errorPhase="errorPhase"  @close="handleClose"/>
+
+        <ErrorAlert
+          v-if="isError"
+          :errorMessage="errorMessage!"
+          class="mb-4"
+          :errorPhase="errorPhase"
+          @close="handleClose"
+        />
         <div v-if="language === 'sql'" class="mt-4">
           <SqlEditor :code="code" :copied="false" :language="language" />
         </div>
@@ -198,7 +208,12 @@ import { vscode } from "@/utilities/vscode";
 import { computed, onBeforeUnmount, onMounted, ref, defineProps } from "vue";
 import { watch } from "vue";
 import ErrorAlert from "@/components/ui/alerts/ErrorAlert.vue";
-import { handleError, concatCommandFlags, adjustEndDateForExclusive, resetStartEndDate } from "@/utilities/helper";
+import {
+  handleError,
+  concatCommandFlags,
+  adjustEndDateForExclusive,
+  resetStartEndDate,
+} from "@/utilities/helper";
 import "@/assets/index.css";
 import DateInput from "@/components/ui/date-inputs/DateInput.vue";
 import SqlEditor from "@/components/asset/SqlEditor.vue";
@@ -217,10 +232,9 @@ const errorPhase = ref<"Validation" | "Rendering" | "Unknown">("Unknown");
 
 const props = defineProps<{
   schedule: string;
-  environments: string [];
+  environments: string[];
   selectedEnvironment: string;
 }>();
-
 
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 import { ChevronDownIcon, CheckCircleIcon, XCircleIcon } from "@heroicons/vue/24/solid";
@@ -247,22 +261,34 @@ function handleBruinValidateCurrentAsset() {
 const checkboxItems = ref([
   { name: "Full-Refresh", checked: false },
   { name: "Exclusive-End-Date", checked: true },
-  { name: "Push-Metadata", checked: false}
+  { name: "Push-Metadata", checked: false },
 ]);
 
-
-const selectedEnv = ref<string>(""); 
-
+const selectedEnv = ref<string>("");
 
 onMounted(() => {
   if (props.selectedEnvironment) {
     selectedEnv.value = props.selectedEnvironment;
   }
+  if ((vscode.getState() as { checkboxState?: { [key: string]: boolean } })?.checkboxState) {
+    checkboxItems.value = checkboxItems.value.map((item) => ({
+      ...item,
+      checked:
+        (vscode.getState() as { checkboxState: { [key: string]: boolean } }).checkboxState[
+          item.name
+        ] || item.checked,
+    }));
+  }
+
+  sendInitialMessage();
 });
 
-watch(() => props.selectedEnvironment, (newValue) => {
-  selectedEnv.value = newValue;
-});
+watch(
+  () => props.selectedEnvironment,
+  (newValue) => {
+    selectedEnv.value = newValue;
+  }
+);
 
 
 function setSelectedEnv(env: string) {
@@ -296,7 +322,6 @@ function runCurrentPipeline() {
   });
 }
 
-
 const validationSuccess = ref(null);
 const validationError = ref(null);
 const renderSQLAssetSuccess = ref(null);
@@ -309,13 +334,13 @@ const today = new Date(Date.now() - timzone * 60000);
 const startDate = ref(
   new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate() - 1, 0, 0, 0, 0))
     .toISOString()
-    .slice(0, -1) 
+    .slice(0, -1)
 );
 
 const endDate = ref(
   new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0))
     .toISOString()
-    .slice(0, -1) 
+    .slice(0, -1)
 );
 
 const endDateExclusive = ref("");
@@ -327,7 +352,6 @@ watch(
   },
   { immediate: true }
 );
-
 
 function getCheckboxChangePayload() {
   console.log("start date", startDate.value);
@@ -344,15 +368,23 @@ const language = ref("");
 const code = ref(null);
 
 function sendInitialMessage() {
-  const initialPayload = getCheckboxChangePayload();
-  console.log("Initial payload", initialPayload);
+  const checkboxState = checkboxItems.value.reduce((acc, item) => {
+    acc[item.name] = item.checked;
+    return acc;
+  }, {});
+
+  const initialPayload = {
+    flags: getCheckboxChangePayload(),
+    checkboxState
+  };
+
   vscode.postMessage({
     command: "checkboxChange",
     payload: initialPayload,
   });
 }
 
-function resetDatesOnSchedule(){
+function resetDatesOnSchedule() {
   resetStartEndDate(props.schedule, today, startDate, endDate);
 }
 onMounted(() => {
@@ -364,19 +396,22 @@ onBeforeUnmount(() => {
   window.removeEventListener("message", receiveMessage);
 });
 
-watch(
-  [checkboxItems, startDate, endDate, endDateExclusive],
-  () => {
-    const payload = getCheckboxChangePayload();
-    console.log("Checkbox change payload", payload);
-    vscode.postMessage({
-      command: "checkboxChange",
-      payload: payload,
-    });
-  },
-  { deep: true }
-);
+watch([checkboxItems, startDate, endDate, endDateExclusive], () => {
+  const checkboxState = checkboxItems.value.reduce((acc, item) => {
+    acc[item.name] = item.checked;
+    return acc;
+  }, {});
 
+  const payload = {
+    flags: getCheckboxChangePayload(),
+    checkboxState
+  };
+
+  vscode.postMessage({
+    command: "checkboxChange",
+    payload: payload,
+  });
+}, { deep: true });
 function receiveMessage(event: { data: any }) {
   if (!event) return;
 


### PR DESCRIPTION
# PR Overview

This PR resolves an issue where the UI would incorrectly re-render after clicking on an asset file to edit, ignoring the state of the "full-refresh" checkbox. The SQL preview would incorrectly reset to its initial state. This fix ensures the correct behavior of the SQL preview by considering the checkbox state during rendering.