### PR TITLE
 Add the Ability to Edit Existing Connections via the UI

### DIFF
--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -390,7 +390,40 @@ export class BruinPanel {
               message: this._lastRenderedDocumentUri?.fsPath,
             });
             break;
+          case "bruin.editConnection":
+            const { oldConnection, newConnection } = message.payload;
+            try {
+              // Delete the old connection
+              await deleteConnection(
+                oldConnection.environment,
+                oldConnection.name,
+                this._lastRenderedDocumentUri
+              );
 
+              // Create the new connection
+              await createConnection(
+                newConnection.environment,
+                newConnection.name,
+                newConnection.type,
+                newConnection.credentials,
+                this._lastRenderedDocumentUri
+              );
+
+              // Fetch updated connections list
+              await getConnections(this._lastRenderedDocumentUri);
+
+              this._panel.webview.postMessage({
+                command: "connection-edited-message",
+                payload: { status: "success", message: "Connection updated successfully" },
+              });
+            } catch (error) {
+              console.error("Error editing connection:", error);
+              this._panel.webview.postMessage({
+                command: "connection-edited-message",
+                payload: { status: "error", message: "Failed to edit connection" },
+              });
+            }
+            break;
           case "bruin.deleteConnection":
             const { name, environment } = message.payload;
             deleteConnection(environment, name, this._lastRenderedDocumentUri);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import * as assert from "assert";
 import * as vscode from "vscode";
 import * as os from "os";
@@ -181,32 +182,38 @@ suite("Manage Bruin Connections Tests", function () {
     const connections = extractNonNullConnections(singleEnvconnections);
     assert.deepStrictEqual(connections, []);
   });
+
   test("Should return an array of connections for all non-null connections", async () => {
     const singleEnvconnections = {
       environments: {
-        default: {
+        staging: {
           connections: {
-            aws: null,
-            google_cloud_platform: [
+            databricks: [
               {
-                project_id: "gcp_project",
-              },
+                name: "databrick",
+                token: "",
+                path: "",
+                host: "host",
+                port: 1228
+              }
             ],
-            snowflake: [
+            generic: [
               {
-                project_id: "snowflake_project",
-              },
-            ],
-          },
-        },
-      },
+                name: "test23",
+                value: "val"
+              }
+            ]
+          }
+        }
+      }
     };
     const connections = extractNonNullConnections(singleEnvconnections);
     assert.deepStrictEqual(connections, [
-      { environment: "default", type: "google_cloud_platform", name: null },
-      { environment: "default", type: "snowflake", name: null },
+      { environment: "staging", type: "databricks", name: "databrick", token: "", path: "", host: "host", port: 1228 },
+      { environment: "staging", type: "generic", name: "test23", value: "val" },
     ]);
   });
+
   test("Should return an array of connections from multiple environments", async () => {
     const multiEnvconnections = {
       environments: {
@@ -215,7 +222,8 @@ suite("Manage Bruin Connections Tests", function () {
             aws: null,
             google_cloud_platform: [
               {
-                project_id: "gcp_project",
+                name: "gcp_project",
+                project_id: "gcp_project_id",
               },
             ],
           },
@@ -225,6 +233,7 @@ suite("Manage Bruin Connections Tests", function () {
             aws: [
               {
                 name: "aws_project",
+                access_key_id: "aws_access_key",
               },
             ],
             snowflake: null,
@@ -234,23 +243,25 @@ suite("Manage Bruin Connections Tests", function () {
     };
     const connections = extractNonNullConnections(multiEnvconnections);
     assert.deepStrictEqual(connections, [
-      { environment: "default", type: "google_cloud_platform", name: null },
-      { environment: "staging", type: "aws", name: "aws_project" },
+      { environment: "default", type: "google_cloud_platform", name: "gcp_project", project_id: "gcp_project_id" },
+      { environment: "staging", type: "aws", name: "aws_project", access_key_id: "aws_access_key" },
     ]);
   });
-  test("Should handle connections without project_id or name", async () => {
+
+  test("Should handle connections without name", async () => {
     const singleEnvconnections = {
       environments: {
         default: {
           connections: {
             google_cloud_platform: [
               {
-                // No project_id or name provided
+                project_id: "gcp_project_id",
               },
             ],
             aws: [
               {
                 name: "aws_connection",
+                access_key_id: "aws_access_key",
               },
             ],
           },
@@ -259,15 +270,17 @@ suite("Manage Bruin Connections Tests", function () {
     };
     const connections = extractNonNullConnections(singleEnvconnections);
     assert.deepStrictEqual(connections, [
-      { environment: "default", type: "google_cloud_platform", name: null }, // No project_id or name
-      { environment: "default", type: "aws", name: "aws_connection" },
+      { environment: "default", type: "google_cloud_platform", project_id: "gcp_project_id" },
+      { environment: "default", type: "aws", name: "aws_connection", access_key_id: "aws_access_key" },
     ]);
   });
+
   test("Should return an empty array when input is completely empty", async () => {
     const emptyConnections = {};
     const connections = extractNonNullConnections(emptyConnections);
     assert.deepStrictEqual(connections, []);
   });
+
   test("Should return an empty array when connections object is empty", async () => {
     const singleEnvconnections = {
       environments: {
@@ -286,6 +299,7 @@ suite("Manage Bruin Connections Tests", function () {
         aws: [
           {
             name: "aws_connection",
+            access_key_id: "aws_access_key",
           },
         ],
       },

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -185,10 +185,11 @@ type ConnectionType =
   | "gorgias"
   | "generic";
 
-interface Connection {
+export interface Connection {
   type: ConnectionType;
   name: string | null;
   environment: string;
+  [key: string]: any; // This allows for any additional properties
 }
 
 /**
@@ -219,20 +220,18 @@ export const extractNonNullConnections = (json: any): Connection[] => {
       if (Array.isArray(connection)) {
         connection.forEach((conn) => {
           if (conn) {
-            const name = conn.name || null;
             connections.push({
               environment: environmentName,
               type: connectionType as ConnectionType,
-              name,
+              ...conn, // Spread all properties of the connection
             });
           }
         });
       } else if (connection !== null) {
-        const name = connection.name || null;
         connections.push({
           environment: environmentName,
           type: connectionType as ConnectionType,
-          name,
+          ...connection, // Spread all properties of the connection
         });
       }
     });

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -20,9 +20,11 @@
     <div v-if="showForm" class="mt-6 bg-editorWidget-bg shadow sm:rounded-lg p-6" ref="formRef">
       <ConnectionForm
         :connection="connectionToEdit"
+        :isEditing="isEditing"
         :environments="environments"
-        @submit="createConnection"
+        @submit="handleConnectionSubmit"
         @cancel="cancelConnectionForm"
+        @close="closeConnectionForm"
       />
     </div>
 
@@ -54,6 +56,7 @@ const props = defineProps({
 
 const showForm = ref(false);
 const connectionToEdit = ref(null);
+const isEditing = ref(false);
 const showDeleteAlert = ref(false);
 const connectionToDelete = ref(null);
 const connectionsStore = useConnectionsStore();
@@ -94,7 +97,23 @@ onMounted(() => {
 });
 
 const showConnectionForm = (connection = null) => {
-  connectionToEdit.value = connection || { name: "", type: "", environment: "" };
+  if (connection) {
+    connectionToEdit.value = {
+      name: connection.name,
+      type: connection.type,
+      environment: connection.environment,
+      credentials: { ...connection.credentials }, // Ensure we're copying all credentials
+    };
+    isEditing.value = true;
+  } else {
+    connectionToEdit.value = {
+      name: '',
+      type: '',
+      environment: '',
+      credentials: {},
+    };
+    isEditing.value = false;
+  }
   showForm.value = true;
   setTimeout(() => {
     if (formRef.value) {
@@ -103,15 +122,45 @@ const showConnectionForm = (connection = null) => {
   }, 100);
 };
 
+const handleConnectionSubmit = async (connectionData) => {
+  try {
+    if (isEditing.value) {
+      // Editing existing connection
+      await vscode.postMessage({
+        command: "bruin.editConnection",
+        payload: {
+          oldConnection: connectionToEdit.value,
+          newConnection: connectionData,
+        },
+      });
+    } else {
+      // Creating new connection
+      await vscode.postMessage({
+        command: "bruin.createConnection",
+        payload: connectionData,
+      });
+    }
+    closeConnectionForm();
+  } catch (error) {
+    console.error("Error submitting connection:", error);
+    // Optionally, show an error message to the user
+  }
+};
+
 const cancelConnectionForm = () => {
-  showForm.value = false;
-  connectionToEdit.value = null;
+  closeConnectionForm();
 };
 
 const confirmDeleteConnection = (connection) => {
   connectionToDelete.value = connection;
   console.log("Connection to delete:", connection);
   showDeleteAlert.value = true;
+};
+
+const closeConnectionForm = () => {
+  showForm.value = false;
+  connectionToEdit.value = null;
+  isEditing.value = false;
 };
 
 const deleteConnection = async () => {
@@ -132,6 +181,7 @@ const deleteConnection = async () => {
     console.error("Error deleting connection:", error);
   }
 };
+
 const closeForm = () => {
   showForm.value = false;
   connectionToEdit.value = null;
@@ -175,6 +225,7 @@ const createConnection = async (connection) => {
     console.error("Error creating connection:", error);
   }
 };
+
 const cancelDeleteConnection = () => {
   showDeleteAlert.value = false;
   connectionToDelete.value = null;

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -96,15 +96,12 @@ onMounted(() => {
   vscode.postMessage({ command: "bruin.getConnectionsList" });
 });
 
+
 const showConnectionForm = (connection = null) => {
   if (connection) {
-    connectionToEdit.value = {
-      name: connection.name,
-      type: connection.type,
-      environment: connection.environment,
-      credentials: { ...connection.credentials }, // Ensure we're copying all credentials
-    };
+    connectionToEdit.value = { ...connection }; // Pass the entire connection object
     isEditing.value = true;
+    console.log("connection to edit", connection)
   } else {
     connectionToEdit.value = {
       name: '',

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -33,43 +33,47 @@
             <tr>
               <th
                 scope="col"
-                class="w-1/2 px-2 py-2 text-left text-sm font-semibold text-editor-fg opacity-70"
+                class="w-2/5 px-2 py-2 text-left text-sm font-semibold text-editor-fg opacity-70"
               >
                 Name
               </th>
               <th
                 scope="col"
-                class="w-1/2 px-2 py-2 text-left text-sm font-semibold text-editor-fg opacity-70"
+                class="w-2/5 px-2 py-2 text-left text-sm font-semibold text-editor-fg opacity-70"
               >
                 Type
               </th>
+              <th
+                scope="col"
+                class="w-1/5 px-2 py-2 text-right text-sm font-semibold text-editor-fg opacity-70"
+              >
+                Actions
+              </th>
             </tr>
           </thead>
-          <tbody class="">
+          <tbody>
             <tr
               v-for="connection in connections"
               :key="connection.name"
               class="hover:bg-editor-hoverBackground"
             >
               <td
-                class="w-1/2 whitespace-nowrap px-2 py-2 text-sm font-medium text-editor-fg font-mono"
+                class="w-2/5 whitespace-nowrap px-2 py-2 text-sm font-medium text-editor-fg font-mono"
                 :class="{ 'opacity-80 italic': !connection.name }"
               >
                 {{ connection.name || "undefined" }}
               </td>
-              <td class="w-1/2 whitespace-nowrap px-2 py-2 text-sm text-descriptionFg font-mono">
+              <td class="w-2/5 whitespace-nowrap px-2 py-2 text-sm text-descriptionFg font-mono">
                 {{ connection.type }}
               </td>
-              <td
-                class="relative whitespace-nowrap py-2 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
-              >
-                  <button
+              <td class="w-1/5 whitespace-nowrap px-2 py-2 text-right text-sm font-medium">
+                <button
                   @click="$emit('edit-connection', connection)"
                   class="text-descriptionFg hover:text-editor-fg mr-3"
                   title="Edit"
                 >
-                  <PencilIcon class="h-5 w-5" />
-                </button> 
+                  <PencilIcon class="h-5 w-5 inline-block" />
+                </button>
                 <button
                   @click="
                     $emit('delete-connection', { name: connection.name, environment: environment })
@@ -77,7 +81,7 @@
                   class="text-errorForeground opacity-70 hover:text-editorError-foreground"
                   title="Delete"
                 >
-                  <TrashIcon class="h-5 w-5" />
+                  <TrashIcon class="h-5 w-5 inline-block" />
                 </button>
               </td>
             </tr>
@@ -98,12 +102,11 @@ const connectionsStore = useConnectionsStore();
 const connections = computed(() => connectionsStore.connections);
 const error = computed(() => connectionsStore.error);
 
-
 const groupedConnections = computed(() => {
   return connections.value.reduce((grouped, connection) => {
     const { environment } = connection;
     (grouped[environment] = grouped[environment] || []).push(connection);
-    console.log("connections......", connections.value)
+    console.log("connections......", connections.value);
     return grouped;
   }, {});
 });

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -63,13 +63,13 @@
               <td
                 class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
               >
-                <!--    <button
+                  <button
                   @click="$emit('edit-connection', connection)"
                   class="text-descriptionFg hover:text-editor-fg mr-3"
                   title="Edit"
                 >
                   <PencilIcon class="h-5 w-5" />
-                </button> -->
+                </button> 
                 <button
                   @click="
                     $emit('delete-connection', { name: connection.name, environment: environment })

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -98,10 +98,12 @@ const connectionsStore = useConnectionsStore();
 const connections = computed(() => connectionsStore.connections);
 const error = computed(() => connectionsStore.error);
 
+
 const groupedConnections = computed(() => {
   return connections.value.reduce((grouped, connection) => {
     const { environment } = connection;
     (grouped[environment] = grouped[environment] || []).push(connection);
+    console.log("connections......", connections.value)
     return grouped;
   }, {});
 });

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -45,23 +45,23 @@
               </th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="">
             <tr
               v-for="connection in connections"
               :key="connection.name"
               class="hover:bg-editor-hoverBackground"
             >
               <td
-                class="w-1/2 whitespace-nowrap px-2 py-4 text-sm font-medium text-editor-fg font-mono"
+                class="w-1/2 whitespace-nowrap px-2 py-2 text-sm font-medium text-editor-fg font-mono"
                 :class="{ 'opacity-80 italic': !connection.name }"
               >
                 {{ connection.name || "undefined" }}
               </td>
-              <td class="w-1/2 whitespace-nowrap px-2 py-4 text-sm text-descriptionFg font-mono">
+              <td class="w-1/2 whitespace-nowrap px-2 py-2 text-sm text-descriptionFg font-mono">
                 {{ connection.type }}
               </td>
               <td
-                class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
+                class="relative whitespace-nowrap py-2 pl-3 pr-4 text-right text-sm font-medium sm:pr-6"
               >
                   <button
                   @click="$emit('edit-connection', connection)"

--- a/webview-ui/src/components/connections/ConnectionsForm.vue
+++ b/webview-ui/src/components/connections/ConnectionsForm.vue
@@ -87,7 +87,7 @@ const props = defineProps({
       name: '',
       type: '',
       environment: '',
-      credentials: {},
+      
     }),
   },
   isEditing: {
@@ -162,6 +162,7 @@ const closeForm = () => {
         name: props.connection.name,
         type: props.connection.type,
         environment: props.connection.environment,
+        ...props.connection
       };
 
       await vscode.postMessage({
@@ -192,7 +193,7 @@ watch(
       connection_type: newConnection.type || "",
       connection_name: newConnection.name || "",
       environment: newConnection.environment || "",
-      ...newConnection.credentials, // Spread the credentials into the form
+      ...newConnection, // Spread the credentials into the form
     };
     validationErrors.value = {};
   },


### PR DESCRIPTION
# PR Overview

This PR introduces the functionality of editing existing connections directly through the UI. Key updates include:

- Added functionality to enable users to edit existing connections, utilizing CLI commands by removing and adding connections.
- The connection form now displays all existing prefilled fields when updating a connection.
- Updated connection parsing logic and corresponding tests to handle updates.
- Minimized vertical padding between connection entries for a more compact view.
- Fix the actions column width.


![edit-connection](https://github.com/user-attachments/assets/41c84238-1896-46c0-82c5-bafc938aa63d)
