### PR TITLE
Make Port Field Editable and Fix PostgreSQL Connection

### DIFF
--- a/schemas/config-schema.json
+++ b/schemas/config-schema.json
@@ -267,7 +267,8 @@
                     "type": "string",
                     "enum": [
                         "enable",
-                        "disable"
+                        "disable",
+                        ""
                     ],
                     "default": "disable"
                 }

--- a/webview-ui/src/components/connections/FormField.vue
+++ b/webview-ui/src/components/connections/FormField.vue
@@ -1,43 +1,42 @@
 <template>
   <div class="sm:col-span-4">
     <label :for="id" class="block text-sm font-medium leading-6 text-editor-fg">
-      {{ label }}{{ !required ? ' (Optional)' : '' }}
+      {{ label }}{{ !required ? " (Optional)" : "" }}
     </label>
     <div class="mt-2 relative">
       <input
         v-if="type === 'text' || type === 'password' || type === 'number'"
         :id="id"
         :type="type"
-        :value="defaultValue ? defaultValue : modelValue"
+        :value="internalValue"
         @input="updateValue"
         :class="[
           'block bg-input-background w-full rounded-md border-0 py-1.5 text-input-foreground shadow-sm ring-1 ring-inset placeholder:text-editorInlayHint-fg focus:ring-2 focus:ring-inset focus:ring-accent sm:text-sm',
           isInvalid ? 'ring-inputValidation-errorBorder' : 'ring-editor-border',
         ]"
-        :placeholder="`Enter ${label.toLowerCase()}`"
+        :placeholder="defaultValue !== undefined ? String(defaultValue) : `Enter ${label.toLowerCase()}`"
         :required="required"
       />
       <div v-if="type === 'textarea'" class="flex flex-col">
         <textarea
           :id="id"
-          :value="defaultValue ? defaultValue : modelValue"
+          :value="internalValue"
           @input="updateValue"
           :class="[
             'block bg-input-background w-full rounded-md border-0 py-1.5 text-input-foreground shadow-sm ring-1 ring-inset placeholder:text-editorInlayHint-fg focus:ring-2 focus:ring-inset focus:ring-accent sm:text-sm',
             isInvalid ? 'ring-inputValidation-errorBorder' : 'ring-editor-border',
           ]"
-          :placeholder="`Enter ${label.toLowerCase()}`"
+          :placeholder="defaultValue !== undefined ? String(defaultValue) : `Enter ${label.toLowerCase()}`"
           :required="required"
           :rows="rows"
           :cols="cols"
         />
-        <!-- File input label remains unchanged -->
       </div>
       <template v-if="type === 'select'">
         <div class="relative">
           <select
             :id="id"
-            :value="modelValue"
+            :value="internalValue"
             :required="required"
             @change="updateValue"
             :class="[
@@ -63,8 +62,8 @@
 </template>
 
 <script setup>
-import { ChevronDownIcon, DocumentPlusIcon } from "@heroicons/vue/24/outline";
-import { defineProps, defineEmits } from "vue";
+import { ChevronDownIcon } from "@heroicons/vue/24/outline";
+import { defineProps, defineEmits, ref, watch } from "vue";
 import { formatConnectionName } from "./connectionUtility";
 
 const props = defineProps({
@@ -78,33 +77,25 @@ const props = defineProps({
   cols: Number,
   required: {
     type: Boolean,
-    default: false
+    default: false,
   },
-  isInvalid: Boolean, // New prop for validation
+  isInvalid: Boolean,
 });
 
 const emit = defineEmits(["update:modelValue"]);
+
+const internalValue = ref(props.modelValue ?? props.defaultValue ?? "");
+
+watch(() => props.modelValue, (newValue) => {
+  internalValue.value = newValue ?? props.defaultValue ?? "";
+});
 
 const updateValue = (event) => {
   let value = event.target.value;
   if (props.type === "number") {
     value = Number(value);
   }
+  internalValue.value = value;
   emit("update:modelValue", value);
-};
-
-
-const handleFileUpload = async (event) => {
-  const file = event.target.files[0];
-  if (file && file.type === "application/json") {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const fileContent = e.target.result;
-      emit("update:modelValue", fileContent);
-    };
-    reader.readAsText(file);
-  } else {
-    alert("Please upload a valid JSON file.");
-  }
 };
 </script>

--- a/webview-ui/src/components/connections/connectionUtility.ts
+++ b/webview-ui/src/components/connections/connectionUtility.ts
@@ -7,7 +7,7 @@ export const formatConnectionName = (option) => {
       google_cloud_platform: "Google Cloud Platform",
       synapse: "Azure Synapse",
       databricks: "Databricks",
-      postgresql: "PostgreSQL",
+      postgres: "PostgreSQL",
       redshift: "Redshift",
       snowflake: "Snowflake",
       shopify: "Shopify",
@@ -51,7 +51,7 @@ export const formatConnectionName = (option) => {
       { id: "catalog", label: "Catalog", type: "text", required: false },
       { id: "schema", label: "Schema", type: "text", required: false },
     ],
-    postgresql: [
+    postgres: [
       { id: "username", label: "Username", type: "text", required: true },
       { id: "password", label: "Password", type: "password", required: true},
       { id: "host", label: "Host", type: "text", required: true },


### PR DESCRIPTION
# PR Overview:
This PR introduces the following updates:
- Made the port field editable with a default value in the connection form, allowing users to modify it as needed.
- Fixed an issue with PostgreSQL connections.
- Allowed `ssl_mode` to have an empty string for schema validation. 