### PR TITLE
Fix handling of duplicate connection names under the same environment

### DIFF
--- a/src/bruin/bruinConnections.ts
+++ b/src/bruin/bruinConnections.ts
@@ -131,18 +131,23 @@ export class BruinCreateConnection extends BruinCommand {
       connectionName,
       "--credentials",
       credentialsString,
+      "-o",
+      "json"
     ];
 
     await this.run(flags, { ignoresErrors })
       .then(
         (result) => {
-          if (result.includes("Connection created successfully")) {
-            this.postMessageToPanels(
-              "success",
-              `Connection "${connectionName}" created successfully.`
-            );
+          if (!result) {
+            const connection = {
+              name: connectionName,
+              type: connectionType,
+              environment: env,
+              credentials: credentials,
+            };
+            this.postMessageToPanels("success", connection);
           } else {
-            this.postMessageToPanels("error", result);
+            this.postMessageToPanels("error", JSON.parse(result).error);
           }
         },
         (error) => {
@@ -154,7 +159,7 @@ export class BruinCreateConnection extends BruinCommand {
       });
   }
 
-  private postMessageToPanels(status: string, message: string) {
+  private postMessageToPanels(status: string, message: any) {
     BruinPanel.postMessage("connection-created-message", { status, message });
   }
 }

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -429,11 +429,6 @@ export class BruinPanel {
             deleteConnection(environment, name, this._lastRenderedDocumentUri);
             break;
           case "bruin.createConnection":
-            await deleteConnection(
-              message.payload.environment,
-              message.payload.name,
-              this._lastRenderedDocumentUri
-            );
             await createConnection(
               message.payload.environment,
               message.payload.name,

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -88,10 +88,12 @@ const handleMessage = (event) => {
 
 const handleConnectionsList = (payload) => {
   if (payload.status === "success") {
-    const connectionsWithIds = payload.message.map((conn) => ({
-      ...conn,
-      id: conn.id || uuidv4(),
-    }));
+    const connectionsWithIds = message.payload.message.map((conn) => {
+      if (!conn.id) {
+        return { ...conn, id: uuidv4() };
+      }
+      return conn;
+    });
     connectionsStore.updateConnectionsFromMessage(connectionsWithIds);
   } else {
     connectionsStore.updateErrorFromMessage(payload.message);
@@ -124,9 +126,9 @@ const showConnectionForm = (connection = null) => {
     isEditing.value = true;
   } else {
     connectionToEdit.value = {
-      name: '',
-      type: '',
-      environment: '',
+      name: "",
+      type: "",
+      environment: "",
       credentials: {},
     };
     isEditing.value = false;
@@ -165,7 +167,7 @@ const createConnection = (connection) => {
     environment: connection.environment,
     credentials: connection.credentials,
   };
-  
+
   vscode.postMessage({
     command: "bruin.createConnection",
     payload: newConnection,

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -106,7 +106,6 @@ const groupedConnections = computed(() => {
   return connections.value.reduce((grouped, connection) => {
     const { environment } = connection;
     (grouped[environment] = grouped[environment] || []).push(connection);
-    console.log("connections......", connections.value);
     return grouped;
   }, {});
 });

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -4,7 +4,10 @@
       <div class="flex flex-col items-start space-y-2 mb-2">
         <h2 class="text-xl font-semibold text-editor-fg">Connections</h2>
         <div v-if="!error" class="mt-2 max-w-xl text-sm text-editor-fg">
-          <p>View your connections across different environments in one place.</p>
+          <p>
+            Manage your connections across different environments all in one place. View existing
+            connections, edit their details, or delete them as needed.
+          </p>
         </div>
       </div>
       <div class="flex items-center justify-end">

--- a/webview-ui/src/components/connections/FormField.vue
+++ b/webview-ui/src/components/connections/FormField.vue
@@ -4,28 +4,30 @@
       {{ label }}{{ !required ? " (Optional)" : "" }}
     </label>
     <div class="mt-2 relative">
-      <input
-        v-if="type === 'text' || type === 'password' || type === 'number'"
-        :id="id"
-        :type="inputType"
-        :value="internalValue"
-        @input="updateValue"
-        :class="[
-          'block bg-input-background w-full rounded-md border-0 py-1.5 text-input-foreground shadow-sm ring-1 ring-inset placeholder:text-editorInlayHint-fg focus:ring-2 focus:ring-inset focus:ring-accent sm:text-sm',
-          isInvalid ? 'ring-inputValidation-errorBorder' : 'ring-editor-border',
-        ]"
-        :placeholder="internalValue ? '' : `Enter ${label.toLowerCase()}`"
-        :required="required"
-      />
-      <button
-        v-if="type === 'password'"
-        type="button"
-        class="absolute inset-y-0 right-0 flex items-center pr-3"
-        @click="togglePasswordVisibility"
-      >
-        <EyeIcon v-if="!showPassword" class="h-5 w-5 text-input-foreground" />
-        <EyeSlashIcon v-else class="h-5 w-5 text-input-foreground" />
-      </button>
+      <div class="relative">
+        <input
+          v-if="type === 'text' || type === 'password' || type === 'number'"
+          :id="id"
+          :type="inputType"
+          :value="internalValue"
+          @input="updateValue"
+          :class="[
+            'block bg-input-background w-full rounded-md border-0 py-1.5 text-input-foreground shadow-sm ring-1 ring-inset placeholder:text-editorInlayHint-fg focus:ring-2 focus:ring-inset focus:ring-accent sm:text-sm',
+            isInvalid ? 'ring-inputValidation-errorBorder' : 'ring-editor-border',
+          ]"
+          :placeholder="internalValue ? '' : `Enter ${label.toLowerCase()}`"
+          :required="required"
+        />
+        <button
+          v-if="type === 'password'"
+          type="button"
+          class="absolute inset-y-0 right-0 flex items-center pr-3"
+          @click="togglePasswordVisibility"
+        >
+          <EyeIcon v-if="!showPassword" class="h-5 w-5 text-input-foreground" />
+          <EyeSlashIcon v-else class="h-5 w-5 text-input-foreground" />
+        </button>
+      </div>
 
       <div v-if="type === 'textarea'" class="flex flex-col">
         <textarea
@@ -66,8 +68,8 @@
           </div>
         </div>
       </template>
-      <p v-if="isInvalid" class="mt-1 text-sm text-inputValidation-errorBorder absolute">
-        This field is required
+      <p v-if="isInvalid" class="mt-2 text-sm text-inputValidation-errorBorder">
+        {{ formattedErrorMessage }}
       </p>
     </div>
   </div>
@@ -79,6 +81,7 @@ import { defineProps, defineEmits, ref, watch, computed } from "vue";
 import { formatConnectionName } from "./connectionUtility";
 
 const props = defineProps({
+  errorMessage: String,
   id: String,
   label: String,
   type: String,
@@ -107,6 +110,19 @@ const inputType = computed(() => {
   return props.type;
 });
 
+const formattedErrorMessage = computed(() => {
+  if (!props.errorMessage) return "This field is required";
+  try {
+    const errorObj = JSON.parse(props.errorMessage);
+    if (errorObj.error) {
+      return errorObj.error.charAt(0).toUpperCase() + errorObj.error.slice(1);
+    }
+  } catch (e) {
+    // If parsing fails, it's not a JSON string
+  }
+  return props.errorMessage;
+});
+
 const togglePasswordVisibility = () => {
   showPassword.value = !showPassword.value;
 };
@@ -125,6 +141,7 @@ const updateValue = (event) => {
   }
   internalValue.value = value;
   emit("update:modelValue", value);
+  emit("clearError");
 };
 </script>
 

--- a/webview-ui/src/components/connections/FormField.vue
+++ b/webview-ui/src/components/connections/FormField.vue
@@ -14,7 +14,7 @@
           'block bg-input-background w-full rounded-md border-0 py-1.5 text-input-foreground shadow-sm ring-1 ring-inset placeholder:text-editorInlayHint-fg focus:ring-2 focus:ring-inset focus:ring-accent sm:text-sm',
           isInvalid ? 'ring-inputValidation-errorBorder' : 'ring-editor-border',
         ]"
-        :placeholder="defaultValue !== undefined ? String(defaultValue) : `Enter ${label.toLowerCase()}`"
+        :placeholder="internalValue ? '' : `Enter ${label.toLowerCase()}`"
         :required="required"
       />
       <button
@@ -36,7 +36,9 @@
             'block bg-input-background w-full rounded-md border-0 py-1.5 text-input-foreground shadow-sm ring-1 ring-inset placeholder:text-editorInlayHint-fg focus:ring-2 focus:ring-inset focus:ring-accent sm:text-sm',
             isInvalid ? 'ring-inputValidation-errorBorder' : 'ring-editor-border',
           ]"
-          :placeholder="defaultValue !== undefined ? String(defaultValue) : `Enter ${label.toLowerCase()}`"
+          :placeholder="
+            defaultValue !== undefined ? String(defaultValue) : `Enter ${label.toLowerCase()}`
+          "
           :required="required"
           :rows="rows"
           :cols="cols"
@@ -72,8 +74,8 @@
 </template>
 
 <script setup>
-import { ChevronDownIcon, EyeIcon, EyeSlashIcon} from "@heroicons/vue/24/outline";
-import { defineProps, defineEmits, ref, watch, computed} from "vue";
+import { ChevronDownIcon, EyeIcon, EyeSlashIcon } from "@heroicons/vue/24/outline";
+import { defineProps, defineEmits, ref, watch, computed } from "vue";
 import { formatConnectionName } from "./connectionUtility";
 
 const props = defineProps({
@@ -99,8 +101,8 @@ const internalValue = ref(props.modelValue ?? props.defaultValue ?? "");
 const showPassword = ref(false);
 
 const inputType = computed(() => {
-  if (props.type === 'password') {
-    return showPassword.value ? 'text' : 'password';
+  if (props.type === "password") {
+    return showPassword.value ? "text" : "password";
   }
   return props.type;
 });
@@ -109,9 +111,12 @@ const togglePasswordVisibility = () => {
   showPassword.value = !showPassword.value;
 };
 
-watch(() => props.modelValue, (newValue) => {
-  internalValue.value = newValue ?? props.defaultValue ?? "";
-});
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    internalValue.value = newValue ?? props.defaultValue ?? "";
+  }
+);
 
 const updateValue = (event) => {
   let value = event.target.value;
@@ -122,3 +127,11 @@ const updateValue = (event) => {
   emit("update:modelValue", value);
 };
 </script>
+
+<style scoped>
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+</style>

--- a/webview-ui/src/components/connections/connectionUtility.ts
+++ b/webview-ui/src/components/connections/connectionUtility.ts
@@ -87,7 +87,7 @@ export const formatConnectionName = (option) => {
       { id: "username", label: "Username", type: "text", required: true },
       { id: "password", label: "Password", type: "password", required: true },
       { id: "host", label: "Host", type: "text", required: true },
-      { id: "port", label: "Port", type: "number", defaultValue: 5439, required: true },
+      { id: "port", label: "Port", type: "number", defaultValue: 5439, required: false },
       { id: "database", label: "Database", type: "text", required: true },
       { id: "schema", label: "Schema", type: "text", required: false },
       { id: "ssl_mode", label: "SSL Mode", type: "select", options: ["disable", "require"], required: false },

--- a/webview-ui/src/store/connections.ts
+++ b/webview-ui/src/store/connections.ts
@@ -15,6 +15,12 @@ export const useConnectionsStore = defineStore("connections", {
         return conn;
       });
     },
+    updateConnection(updatedConnection) {
+      const index = this.connections.findIndex(conn => conn.id === updatedConnection.id);
+      if (index !== -1) {
+        this.connections[index] = updatedConnection;
+      }
+    },
     updateErrorFromMessage(data) {
       this.error = data;
       this.connections = [];


### PR DESCRIPTION
# PR Overview:
This PR resolves an issue where attempting to add a connection with the same name as an existing one in the same environment would provide no feedback. 

With this Fix, when the user tries to submit a connection with a duplicate name, the input field is marked as invalid, displaying an error message: "A connection with the name 'name' exists." Additionally, the port field is now editable and connection management functions have been optimized for efficiency.

## Main Changes:

- Added validation for duplicate connection names under the same environment.
- Updated the UI to display an error message when a duplicate name is detected.
- Optimized connection management functions.
- Fixed issues related to connection IDs and editing connections.
- Updated the port field to be an editable input for better flexibility.


![add-connection-with-exsiting-name](https://github.com/user-attachments/assets/d10ac581-4ff8-4a7b-9313-594ce3aa4067)
