### PR TITLE
Add Duplicate Connection Functionality  

### DIFF
--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -71,6 +71,13 @@
               </td>
               <td class="w-1/5 whitespace-nowrap px-2 py-2 text-right text-sm font-medium">
                 <button
+                  @click="$emit('duplicate-connection', connection)"
+                  class="text-descriptionFg hover:text-editor-fg mr-3"
+                  title="Duplicate"
+                >
+                <DocumentDuplicateIcon class="h-5 w-5 inline-block" />
+                </button>
+                <button
                   @click="$emit('edit-connection', connection)"
                   class="text-descriptionFg hover:text-editor-fg mr-3"
                   title="Edit"
@@ -98,7 +105,7 @@
 <script setup>
 import { useConnectionsStore } from "@/store/connections";
 import { computed } from "vue";
-import { TrashIcon, PencilIcon } from "@heroicons/vue/24/outline";
+import { TrashIcon, PencilIcon, DocumentDuplicateIcon } from "@heroicons/vue/24/outline";
 import AlertMessage from "@/components/ui/alerts/AlertMessage.vue";
 
 const connectionsStore = useConnectionsStore();
@@ -113,7 +120,7 @@ const groupedConnections = computed(() => {
   }, {});
 });
 
-defineEmits(["new-connection", "edit-connection", "delete-connection"]);
+defineEmits(["new-connection", "edit-connection", "delete-connection", "duplicate-connection"]);
 </script>
 
 <style scoped>

--- a/webview-ui/src/store/connections.ts
+++ b/webview-ui/src/store/connections.ts
@@ -15,6 +15,10 @@ export const useConnectionsStore = defineStore("connections", {
         return conn;
       });
     },
+    addDuplicatedConnection(connection) {
+      const duplicatedConnection = { ...connection, id: uuidv4(), name: `${connection.name} (Copy)` };
+      this.addConnection(duplicatedConnection); 
+    },    
     updateConnection(updatedConnection) {
       const index = this.connections.findIndex(conn => conn.id === updatedConnection.id);
       if (index !== -1) {


### PR DESCRIPTION
# PR Overview

This update introduces the ability to duplicate an existing connection. When clicking the duplicate button, a form is shown prefilled with the connection details. The connection name is automatically concatenated with " (Copy)" to differentiate it. Upon saving, a new connection is created based on the duplicated information.

![duplicate-connection](https://github.com/user-attachments/assets/78c5640a-0504-41c5-bff2-be83686e943a)
