### PR TITLE
Fix Service Account File Save Issue in GCP Connection

### DIFF
--- a/webview-ui/src/components/connections/ConnectionsForm.vue
+++ b/webview-ui/src/components/connections/ConnectionsForm.vue
@@ -239,7 +239,7 @@ const submitForm = () => {
 
   // Handle the file upload for service_account_json
   if (selectedFile.value && form.value.connection_type === "google_cloud_platform") {
-    connectionData.credentials.service_account_json = selectedFile.value.path;
+    connectionData.credentials.service_account_file = selectedFile.value.path;
   }
 
   emit("submit", connectionData);


### PR DESCRIPTION
# PR Overview

This PR addresses an issue where, when adding a GCP connection using the file picker for the service account file, the file was incorrectly saved as `service_account_json` in `.bruin.yml`. This caused an error when attempting to use the connection. The fix ensures that the selected file is saved as `service_account_file`, resolving the error.