### PR TITLE
Refactor Error Handling to Prevent UI Break on Parsing Issues

### DIFF
--- a/src/bruin/bruinRender.ts
+++ b/src/bruin/bruinRender.ts
@@ -79,9 +79,10 @@ export class BruinRender extends BruinCommand {
           console.log("SQL rendered successfully");
         },
         (error) => {
+          console.error("Error rendering SQL asset in the reject", this.parseError(error));
           BruinPanel?.postMessage("render-message", {
             status: "error",
-            message: error,
+            message: this.parseError(error), 
           });
         }
       )
@@ -94,6 +95,14 @@ export class BruinRender extends BruinCommand {
       });
   }
 
+  private parseError(error: string): string {
+    if(error.startsWith("{")) {
+      return error;
+    }
+    else {
+      return JSON.stringify({ error: error });
+    }
+  }
   private async isBruinPipeline(filePath: string): Promise<boolean> {
     return await isBruinPipeline(filePath);
   }
@@ -161,6 +170,7 @@ export class BruinRender extends BruinCommand {
         console.log("SQL rendered successfully without JSON", result);
       },
       (err) => {
+        console.error("Error rendering SQL asset without JSON", err);
         BruinPanel?.postMessage("render-message", {
           status: "error",
           message: JSON.stringify({ error: err }),

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -339,11 +339,6 @@ export class BruinPanel {
               });
             }, 1500);
             break;
-          case "checkboxChange":
-            this._flags = message.payload;
-            await renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
-            break;
-
           case "bruin.getAssetLineage":
             if (!this._lastRenderedDocumentUri) {
               return;

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -289,4 +289,3 @@ function updateAssetName(newName) {
   vscode.postMessage({ command: "bruin.updateAssetName", name: newName });
 }
 </script>
-./store/bruinStore

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -96,8 +96,10 @@ window.addEventListener("message", (event) => {
       connectionsStore.setDefaultEnvironment(selectedEnvironment.value); // Set the default environment in the store
       break;
     case "parse-message":
-      data.value = updateValue(message, "success");
       parseError.value = updateValue(message, "error");
+      if(!parseError.value) {
+        data.value = updateValue(message, "success");
+      }
       lastRenderedDocument.value = updateValue(message, "success");
       break;
     case "bruinCliInstallationStatus":

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -236,10 +236,15 @@ const errorMessage = computed(() => errorState.value?.errorMessage);
 
 const parsedErrorMessages = computed(() => {
   if (!errorMessage.value) return [];
-  try {
-    return JSON.parse(errorMessage.value);
-  } catch {
-    return [];
+  if (errorState.value?.isValidationError) {
+    try {
+      return JSON.parse(errorMessage.value);
+    } catch {
+      return [{ issues: [{ severity: "critical", message: errorMessage.value }] }];
+    }
+  } else {
+    // Handle render errors
+    return [{ issues: [{ severity: "critical", message: errorMessage.value }] }];
   }
 });
 const isNotAsset = computed(() => (renderAssetAlert.value ? true : false));
@@ -269,8 +274,7 @@ const hasCriticalErrors = computed(() =>
       error.issues &&
       Object.values(error.issues)
         .flat()
-        .some((issue) => (issue as { severity: string }).severity === "critical")
-  )
+        .some((issue) => (issue as { severity: string }).severity === "critical")  )
 );
 
 const hasWarnings = computed(

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -230,23 +230,9 @@ import { ChevronDownIcon, CheckCircleIcon, XCircleIcon } from "@heroicons/vue/24
 import { SparklesIcon, PlayIcon, ArrowPathRoundedSquareIcon } from "@heroicons/vue/24/outline";
 import type { FormattedErrorMessage } from "@/types";
 
-const errorState = computed(() => handleError(validationError.value, renderSQLAssetError.value));
-const isError = computed(() => errorState.value?.errorCaptured);
-const errorMessage = computed(() => errorState.value?.errorMessage);
 
-const parsedErrorMessages = computed(() => {
-  if (!errorMessage.value) return [];
-  if (errorState.value?.isValidationError) {
-    try {
-      return JSON.parse(errorMessage.value);
-    } catch {
-      return [{ issues: [{ severity: "critical", message: errorMessage.value }] }];
-    }
-  } else {
-    // Handle render errors
-    return [{ issues: [{ severity: "critical", message: errorMessage.value }] }];
-  }
-});
+
+
 const isNotAsset = computed(() => (renderAssetAlert.value ? true : false));
 const errorPhase = ref<"Validation" | "Rendering" | "Unknown">("Unknown");
 const validationSuccess = ref(null);
@@ -256,8 +242,37 @@ const renderPythonAsset = ref(null);
 const renderSQLAssetError = ref(null);
 const renderAssetAlert = ref(null);
 const validateButtonStatus = ref<"validated" | "failed" | "loading" | null>(null);
-
 const showWarnings = ref(true);
+const errorState = computed(() => handleError(validationError.value, renderSQLAssetError.value));
+const isError = computed(() => errorState.value?.errorCaptured);
+const errorMessage = computed(() => errorState.value?.errorMessage);
+
+const parsedErrorMessages = computed(() => {
+  if (!errorMessage.value) return [];
+
+  let errors;
+  if (errorState.value?.isValidationError) {
+    try {
+      errors = JSON.parse(errorMessage.value);
+    } catch {
+      errors = [{ issues: [{ severity: "critical", message: errorMessage.value }] }];
+    }
+  } else {
+    // Handle render errors (both JSON and plain text)
+    let message = errorMessage.value;
+    if (typeof message === "string" && message.startsWith("{")) {
+      try {
+        const parsedError = JSON.parse(message);
+        message = parsedError.error || message;
+      } catch {
+      }
+    }
+    errors = [{ issues: [{ severity: "critical", message }] }];
+  }
+
+  return Array.isArray(errors) ? errors : [errors];
+});
+
 
 const handleErrorClose = () => {
   resetStates([validationError, renderSQLAssetError, errorPhase]);
@@ -274,7 +289,8 @@ const hasCriticalErrors = computed(() =>
       error.issues &&
       Object.values(error.issues)
         .flat()
-        .some((issue) => (issue as { severity: string }).severity === "critical")  )
+        .some((issue) => (issue as { severity: string }).severity === "critical")
+  )
 );
 
 const hasWarnings = computed(

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -46,14 +46,28 @@ export const concatCommandFlags = (
   return flags;
 };
 
-export const handleError = (validationError: any | null, renderSQLAssetError: string | null) => {
+export const handleError = (validationError: any | null, renderSQLAssetError: any | null) => {
   if (validationError || renderSQLAssetError) {
+    let errorMessage = validationError || renderSQLAssetError || "An error occurred";
+    let isValidationError = !!validationError;
+
+    // Handle JSON-formatted errors
+    if (typeof errorMessage === 'string' && errorMessage.startsWith('{')) {
+      try {
+        const parsedError = JSON.parse(errorMessage);
+        errorMessage = parsedError.error || errorMessage;
+      } catch (e) {
+        // If parsing fails, use the original error message
+      }
+    }
+
     return {
       errorCaptured: true,
-      errorMessage: validationError || renderSQLAssetError || "An error occurred",
-      isValidationError: !!validationError,
+      errorMessage,
+      isValidationError,
     };
   }
+  return null;
 };
 
 export const resetStates = (states: any[]) => {

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -51,6 +51,7 @@ export const handleError = (validationError: any | null, renderSQLAssetError: st
     return {
       errorCaptured: true,
       errorMessage: validationError || renderSQLAssetError || "An error occurred",
+      isValidationError: !!validationError,
     };
   }
 };


### PR DESCRIPTION
# PR Overview
This PR refactors error handling in the Bruin extension to catch and properly display parsing errors, ensuring the UI does not go completely black. Previously, if an error were returned in text format, the entire UI would crash. With this fix, errors are now caught and displayed without breaking the UI, improving overall user experience.

- Refactor error handling to gracefully catch and display parsing errors.
- Fixes issues with parsing message data and error in App.vue.
- Removed unused code from BruinPanel to clean up the codebase.
