### PR TITLE
Rearrange Asset Details Layout: Move Asset Name and Tags Above Tabs

### DIFF
--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -1,17 +1,25 @@
 <template>
-  <div class="flex items-center space-x-2 w-full justify-between pt-2">
-    <!-- Name editing -->
-    <div class="font-md text-editor-fg text-lg font-mono cursor-pointer truncate max-w-[70%]">
-      {{ assetDetailsProps?.name }}
-    </div>
+  <div class="">
+    <div class="flex items-center space-x-2 w-full justify-between pt-2">
+      <!-- Name editing -->
+      <div class="font-md text-editor-fg text-lg font-mono cursor-pointer truncate max-w-[70%]">
+        {{ assetDetailsProps?.name }}
+      </div>
 
-    <div class="space-x-2">
-      <DescriptionItem :value="assetDetailsProps?.type" :className="badgeClass.badgeStyle" />
-      <DescriptionItem
-        :value="assetDetailsProps?.pipeline.schedule"
-        :className="badgeClass.grayBadge"
-      />
+      <div class="space-x-2">
+        <DescriptionItem :value="assetDetailsProps?.type" :className="badgeClass.badgeStyle" />
+        <DescriptionItem
+          :value="assetDetailsProps?.pipeline.schedule"
+          :className="badgeClass.grayBadge"
+        />
+      </div>
     </div>
+   <!--  <div class="">
+      <DescriptionItem
+        :value="assetDetailsProps?.pipeline.name"
+        class="font-semibold text-editor-fg opacity-30"
+      />
+    </div> -->
   </div>
   <vscode-panels :activeid="`tab-${activeTab}`" aria-label="Tabbed Content" class="pl-0">
     <!-- Tab Headers -->

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -1,5 +1,19 @@
 <template>
-  <vscode-panels :activeid="`tab-${activeTab}`" aria-label="Tabbed Content">
+  <div class="flex items-center space-x-2 w-full justify-between pt-2">
+    <!-- Name editing -->
+    <div class="font-md text-editor-fg text-lg font-mono cursor-pointer truncate max-w-[70%]">
+      {{ assetDetailsProps?.name }}
+    </div>
+
+    <div class="space-x-2">
+      <DescriptionItem :value="assetDetailsProps?.type" :className="badgeClass.badgeStyle" />
+      <DescriptionItem
+        :value="assetDetailsProps?.pipeline.schedule"
+        :className="badgeClass.grayBadge"
+      />
+    </div>
+  </div>
+  <vscode-panels :activeid="`tab-${activeTab}`" aria-label="Tabbed Content" class="pl-0">
     <!-- Tab Headers -->
     <vscode-panel-tab
       v-for="(tab, index) in visibleTabs"
@@ -18,6 +32,7 @@
       :key="`view-${index}`"
       :id="`view-${index}`"
       v-show="activeTab === index"
+      class="px-0"
     >
       <component
         v-if="tab.props"
@@ -42,14 +57,14 @@ import { parseAssetDetails, parseEnvironmentList } from "./utilities/helper";
 import { updateValue } from "./utilities/helper";
 import MessageAlert from "@/components/ui/alerts/AlertMessage.vue";
 import { useConnectionsStore } from "./store/bruinStore";
-import { ArrowPathIcon } from "@heroicons/vue/20/solid";
 import type { EnvironmentsList } from "./types";
 import AssetColumns from "@/components/asset/columns/AssetColumns.vue";
 import BruinSettings from "@/components/bruin-settings/BruinSettings.vue";
-
+import DescriptionItem from "./components/ui/description-item/DescriptionItem.vue";
+import { badgeStyles, defaultBadgeStyle } from "./components/ui/badges/CustomBadgesStyle";
 /**
  * App Component
- * 
+ *
  * This component serves as the main application interface for managing assets.
  * It handles communication with the VSCode extension, manages the state of
  * asset data, and renders different tabs for asset details, columns, and settings.
@@ -240,4 +255,20 @@ const updateAssetName = (newName) => {
   });
   vscode.postMessage({ command: "bruin.updateAssetName", name: newName });
 };
+
+const badgeClass = computed(() => {
+  const commonStyle =
+    "inline-flex items-center rounded-md px-1 py-0.5 text-xs font-medium ring-1 ring-inset";
+  const styleForType = badgeStyles[assetDetailsProps.value?.type] || defaultBadgeStyle;
+  return {
+    commonStyle: commonStyle,
+    grayBadge: `${commonStyle} ${defaultBadgeStyle.main}`,
+    badgeStyle: `${commonStyle} ${styleForType.main}`,
+  };
+});
 </script>
+<style>
+vscode-panels::part(tablist) {
+  padding-left: 0 !important;
+}
+</style>

--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="flex flex-col items-start justify-between w-full">
     <div class="w-full">
-      <div class="flex items-center space-x-2 w-full justify-between">
-        <!-- Name editing -->
+    <!--   <div class="flex items-center space-x-2 w-full justify-between">
+ 
         <div
           v-if="!editingName"
           class="font-md text-editor-fg text-lg font-mono cursor-pointer truncate max-w-[70%]"
@@ -23,8 +23,8 @@
           <DescriptionItem :value="type" :className="badgeClass.badgeStyle" />
           <DescriptionItem :value="pipeline.schedule" :className="badgeClass.grayBadge" />
         </div>
-      </div>
- <!--      <div v-if="ownerExists" class="flex flex-wrap items-center">
+      </div> 
+      <div v-if="ownerExists" class="flex flex-wrap items-center">
         <DescriptionItem :value="owner" className="font-semibold text-editor-fg opacity-30" />
       </div> -->
     </div>
@@ -35,7 +35,7 @@
         <!-- Have max-h for the description, and have `show more`to expand -->
         <div
           v-if="!editingDescription"
-          class="text-xs text-editor-fg opacity-65 prose prose-sm pt-4 cursor-pointer max-w-none"
+          class="text-xs text-editor-fg opacity-65 prose prose-sm cursor-pointer max-w-none"
           v-html="markdownDescription"
           @click="editDescription"
         ></div>
@@ -44,7 +44,7 @@
           v-model="editableDescription"
           @blur="saveDescription"
           @keydown.enter.prevent="saveDescription"
-          class="text-sm text-editor-fg opacity-65 prose prose-sm pt-4 bg-transparent border-none focus:outline-none w-full resize-none"
+          class="text-sm text-editor-fg opacity-65 prose prose-sm bg-transparent border-none focus:outline-none w-full resize-none"
           rows="4"
           autofocus
         ></textarea>

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -4,16 +4,16 @@
       <div class="flex flex-col space-y-4">
         <div class="flex flex-col space-y-3">
           <div>
-            <div class="flex space-x-2 items-center">
-              <DateInput class="w-2/5" label="Start Date" v-model="startDate" />
-              <DateInput class="w-2/5" label="End Date" v-model="endDate" />
+            <div class="flex space-x-2 items-center justify-end">
+              <DateInput class="w-32" label="Start Date" v-model="startDate" />
+              <DateInput class="w-32" label="End Date" v-model="endDate" />
               <button
                 type="button"
-                class="rounded-md bg-editor-button-bg p-2 mt-6 text-editor-button-fg hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed"
+                class="rounded-md bg-editor-button-bg p-1 mt-6 text-editor-button-fg hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed"
                 @click="resetDatesOnSchedule"
                 :title="`Reset Start and End Date`"
               >
-                <ArrowPathRoundedSquareIcon class="sm:h-5 sm:w-5 h-4 w-4" aria-hidden="true" />
+                <ArrowPathRoundedSquareIcon class="h-3 w-3" aria-hidden="true" />
               </button>
             </div>
           </div>

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -4,16 +4,16 @@
       <div class="flex flex-col space-y-4">
         <div class="flex flex-col space-y-3">
           <div>
-            <div class="flex space-x-2 items-center justify-end">
-              <DateInput class="w-32" label="Start Date" v-model="startDate" />
-              <DateInput class="w-32" label="End Date" v-model="endDate" />
+            <div class="flex space-x-2 items-center">
+              <DateInput class="w-2/5" label="Start Date" v-model="startDate" />
+              <DateInput class="w-2/5" label="End Date" v-model="endDate" />
               <button
                 type="button"
-                class="rounded-md bg-editor-button-bg p-1 mt-6 text-editor-button-fg hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed"
+                class="rounded-md bg-editor-button-bg p-2 mt-6 text-editor-button-fg hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed"
                 @click="resetDatesOnSchedule"
                 :title="`Reset Start and End Date`"
               >
-                <ArrowPathRoundedSquareIcon class="h-3 w-3" aria-hidden="true" />
+                <ArrowPathRoundedSquareIcon class="h-4 w-4" aria-hidden="true" />
               </button>
             </div>
           </div>
@@ -27,7 +27,7 @@
             @selected-env="setSelectedEnv"
             :selectedEnvironment="selectedEnvironment"
           />
-          <div class="flex justify-end items-center space-x-2 sm:space-x-4 mt-2 sm:mt-0">
+          <div class="flex justify-end items-center space-x-2 sm:space-x-4 sm:mt-0">
             <div class="inline-flex rounded-md shadow-sm">
               <button
                 type="button"
@@ -87,7 +87,7 @@
                   leave-to-class="transform opacity-0 scale-95"
                 >
                   <MenuItems
-                    class="absolute right-0 z-10 -mr-1 mt-2 w-56 origin-top-right rounded-md bg-editor-button-bg shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                    class="absolute right-2 z-10 -mr-1 w-56 origin-top-right rounded-md bg-editor-button-bg ring-1 ring-opacity-5 focus:outline-none"
                   >
                     <div class="py-1">
                       <MenuItem key="validate-current" v-slot="{ active }">

--- a/webview-ui/src/components/ui/date-inputs/DateInput.vue
+++ b/webview-ui/src/components/ui/date-inputs/DateInput.vue
@@ -7,13 +7,13 @@
       <input
         id="datetime-picker"
         type="datetime-local"
-        class="block px-1 py-0.5 w-full text-xs text-input-foreground bg-input-background rounded-sm focus:border-inputOption-activeBorder border border-commandCenter-border"
+        class="block w-full text-xs text-input-foreground bg-input-background rounded-md focus:border-inputOption-activeBorder border border-commandCenter-border"
         :value="modelValue"
         @input="updateValue($event)"
       />
- <!--      <div class="absolute inset-y-0 right-0 flex px-1 items-center pointer-events-none">
+      <div class="absolute inset-y-0 right-0 flex px-1 items-center pointer-events-none">
         <CalendarIcon class="w-4 h-4 text-input-foreground" />
-      </div> -->
+      </div>
     </div>
   </div>
 </template>
@@ -46,5 +46,9 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   width: 100%;
   height: 100%;
   cursor: pointer;
+}
+
+input[type="datetime-local"] {
+  padding-right: 2.5rem;
 }
 </style>

--- a/webview-ui/src/components/ui/date-inputs/DateInput.vue
+++ b/webview-ui/src/components/ui/date-inputs/DateInput.vue
@@ -7,13 +7,13 @@
       <input
         id="datetime-picker"
         type="datetime-local"
-        class="p-2 block w-full text-input-foreground bg-input-background rounded-md focus:border-inputOption-activeBorder sm:text-sm border border-commandCenter-border"
+        class="block px-1 py-0.5 w-full text-xs text-input-foreground bg-input-background rounded-sm focus:border-inputOption-activeBorder border border-commandCenter-border"
         :value="modelValue"
         @input="updateValue($event)"
       />
-      <div class="absolute inset-y-0 right-0 flex py-1.5 pr-1.5 items-center pointer-events-none">
-        <CalendarIcon class="w-5 h-5 text-input-foreground" />
-      </div>
+ <!--      <div class="absolute inset-y-0 right-0 flex px-1 items-center pointer-events-none">
+        <CalendarIcon class="w-4 h-4 text-input-foreground" />
+      </div> -->
     </div>
   </div>
 </template>
@@ -46,9 +46,5 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   width: 100%;
   height: 100%;
   cursor: pointer;
-}
-
-input[type="datetime-local"] {
-  padding-right: 2.5rem;
 }
 </style>


### PR DESCRIPTION
# PR Overview

This PR refines the layout of the asset details view by positioning the asset name and tags at the top, with tabs now displayed directly below. This update improves the overall visual structure, making the layout more intuitive and consistent.

## Key Changes:
- Moved asset name and tags to the top of the asset details view.
- Placed tabs for additional asset information underneath them.
- Removed the text lineage tab.

![Screenshot 2024-10-25 at 17 24 10](https://github.com/user-attachments/assets/57cff22f-29ea-449a-9237-538b62cc9305)
