### PR TITLE
Refactor Error Handling in BruinValidate for Improved Message Clarity

### DIFF
--- a/src/bruin/bruinValidate.ts
+++ b/src/bruin/bruinValidate.ts
@@ -67,7 +67,7 @@ export class BruinValidate extends BruinCommand {
       // Handle the error and notify the user
       BruinPanel.postMessage("validation-message", {
         status: "error",
-        message: `Validation failed: 'Unknown error'`,
+        message: error || "An error occurred while validating the asset.",
       });
       console.error("Validation error:", error);
     } finally {

--- a/webview-ui/src/components/ui/alerts/ErrorAlert.vue
+++ b/webview-ui/src/components/ui/alerts/ErrorAlert.vue
@@ -25,7 +25,7 @@
     <!-- Expanded section to display detailed error messages -->
     <div v-if="isExpanded" class="overflow-y-auto" style="max-height: 200px">
       <div v-for="(errorMessage, index) in processedErrors" :key="index">
-        <div v-if="errorPhase === 'Validation'" class="mt-4">
+        <div v-if="errorPhase === 'Validation' && errorMessage.pipeline !=='Error'" class="mt-4">
           <div @click="toggleExpansion(index)" class="flex items-center cursor-pointer">
             <component :is="errorMessage.expanded ? ChevronDownIcon : ChevronRightIcon" class="h-5 w-5 text-red-500" aria-hidden="true" />
             <span class="ml-2 text-red-700">Pipeline: {{ errorMessage.pipeline }}</span>

--- a/webview-ui/src/components/ui/alerts/ErrorAlert.vue
+++ b/webview-ui/src/components/ui/alerts/ErrorAlert.vue
@@ -23,7 +23,7 @@
       </div>
     </div>
     <!-- Expanded section to display detailed error messages -->
-    <div v-if="isExpanded" class="mt-4 overflow-y-auto" style="max-height: 200px">
+    <div v-if="isExpanded" class="overflow-y-auto" style="max-height: 200px">
       <div v-for="(errorMessage, index) in processedErrors" :key="index">
         <div v-if="errorPhase === 'Validation'" class="mt-4">
           <div @click="toggleExpansion(index)" class="flex items-center cursor-pointer">


### PR DESCRIPTION
# PR Overview

This PR refines the error message handling in the BruinValidate component to catch and display "panic" errors effectively, removes the extra top margin from the error message component and omits the pipeline name and the expansion property in panic error messages.

<img width="427" alt="Screenshot 2024-10-31 at 12 58 36" src="https://github.com/user-attachments/assets/240386b4-505e-4dac-acc4-ab6ec776c7c2">
