### PR TITLE
Align Date Input Background with GitHub Dimmed Dark Theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the Bruin extension will be documented in this file.
 
+## [0.25.15] - [2024-11-01]
+- Adjust date input background color to align with GitHub's dimmed dark theme.
 
 ## [0.25.14] - [2024-10-31]
 - Removed the connections from the `fullasset` snippet

--- a/README.md
+++ b/README.md
@@ -106,10 +106,11 @@ Use the new connections section from `Settings` tab to view, add, or delete conn
 Access the Bruin CLI management tab `Settings` in the side panel for easy installation and updates.
 
 ## Release Notes
-### Latest Release: 0.25.14
-- Removed the connections from the `fullasset` snippet.
+### Latest Release: 0.25.15
+- Adjust date input background color to align with GitHub's dimmed dark theme.
 
 ### Previous Highlights
+- **0.25.14**: Removed the connections from the `fullasset` snippet.
 - **0.25.13**: Replaced ellipsis icon with arrow icon to toggle checkbox group.
 - **0.25.12**: Improved UI consistency for DateInput and CheckboxGroup components, including updated styling and layout adjustments.
 - **0.25.11**: Improved error handling to display 'panic' errors more clearly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.25.14",
+  "version": "0.25.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.25.14",
+      "version": "0.25.15",
       "dependencies": {
         "@tailwindcss/forms": "^0.5.7",
         "@vue-flow/background": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.25.14",
+  "version": "0.25.15",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/ui/date-inputs/DateInput.vue
+++ b/webview-ui/src/components/ui/date-inputs/DateInput.vue
@@ -4,7 +4,7 @@
     <div class="relative">
       <input
         type="datetime-local"
-        class="w-full text-2xs px-1 border-0 py-0.5 bg-input-background focus:border-input-border"
+        class="w-full text-2xs text-dropdown-fg px-1 border-0 py-0.5 bg-dropdown-bg focus:border-input-border"
         :value="modelValue"
         @input="updateValue($event)"
       />

--- a/webview-ui/tailwind.config.js
+++ b/webview-ui/tailwind.config.js
@@ -106,6 +106,9 @@ module.exports = {
         "commandCenter-border": "var(--vscode-commandCenter-border)",
         "commandCenter-fg":"var(--vscode-commandCenter-foreground)",
         "icon-forground": "var(--vscode-icon-foreground)",
+        "dropdown-bg": "var(--vscode-dropdown-background)",
+        "dropdown-fg": "var(--vscode-dropdown-foreground)",
+
 
         "primary": {
           DEFAULT: "hsl(var(--primary))",


### PR DESCRIPTION
# PR Overview
This PR updates the background color of date input fields to match the GitHub dimmed dark theme.