### PR TITLE
Fix Windows Installation Message and CLI Command Execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.25.19] - [2024-11-06]
+- Clarified Windows installation message to specify Git requirement and fixed CLI installation command to run from the command palette.
 
 ## [0.25.18] - [2024-11-06]
 - Enhanced Bruin CLI installation process with a new shell script for Windows and Linux, and Homebrew support for macOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Bruin extension will be documented in this file.
 
-## [0.25.17] - [2024-11-06]
+## [0.25.18] - [2024-11-06]
 - Enhanced Bruin CLI installation process with a new shell script for Windows and Linux, and Homebrew support for macOS.
 
 ## [0.25.17] - [2024-11-01]

--- a/README.md
+++ b/README.md
@@ -106,10 +106,11 @@ Use the new connections section from `Settings` tab to view, add, or delete conn
 Access the Bruin CLI management tab `Settings` in the side panel for easy installation and updates.
 
 ## Release Notes
-### Latest Release: 0.25.18
-- Enhanced Bruin CLI installation process with a new shell script for Windows and Linux, and Homebrew support for macOS.
+### Latest Release: 0.25.19
+- Clarified Windows installation message to specify Git requirement and fixed CLI installation command to run from the command palette.
 
 ### Previous Highlights
+- **0.25.18**: Enhanced Bruin CLI installation process with a new shell script for Windows and Linux, and Homebrew support for macOS.
 - **0.25.17**: Refactored asset validation and run button styles to improve consistency with the VSCode editor.
 - **0.25.16**: Adjust the position of the environment dropdown menu, moving it from the top to the bottom.
 - **0.25.15**: Adjust date input background color to align with GitHub's dimmed dark theme.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.25.18",
+      "version": "0.25.19",
       "dependencies": {
         "@tailwindcss/forms": "^0.5.7",
         "@vue-flow/background": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -49,8 +49,13 @@ export function activate(context: ExtensionContext) {
     commands.registerCommand("bruin.renderSQL", () => {
       renderCommand(context.extensionUri);
     }),
-    commands.registerCommand("bruin.installCli", () => {
-      installOrUpdateCli();
+    commands.registerCommand("bruin.installCli", async () => {
+      try {
+        await installOrUpdateCli();
+      } catch (error) {
+        const errorMessage = (error instanceof Error) ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error installing/updating Bruin CLI: ${errorMessage}`);
+      }
     }),
     foldingDisposable,
     window.registerWebviewViewProvider(LineagePanel.viewId, lineageWebviewProvider)

--- a/webview-ui/src/components/bruin-settings/BruinCLI.vue
+++ b/webview-ui/src/components/bruin-settings/BruinCLI.vue
@@ -14,15 +14,9 @@
         </p>
       </div>
       <div class="mt-5">
-        <template v-if="isWindows && !isBruinCliInstalled && !goInstalled">
+        <template v-if="isWindows && !isBruinCliInstalled && !gitAvailble">
           <div class="mt-3 text-sm leading-6">
-            <a
-              href="https://golang.org/doc/install"
-              class="font-semibold text-editorLink-activeFg  hover:text-link-activeForeground"
-            >
-              Go is required to install Bruin CLI on Windows. Please install Go first.
-              <span aria-hidden="true"> &rarr;</span>
-            </a>
+              Git is required to install Bruin CLI on Windows. Please install Git first.
           </div>
         </template>
 
@@ -44,7 +38,7 @@ import { vscode } from "@/utilities/vscode";
 
 const isBruinCliInstalled = ref(false);
 const isWindows = ref(false);
-const goInstalled = ref(false);
+const gitAvailble = ref(false);
 
 onMounted(() => {
   checkBruinCliInstallation();
@@ -54,7 +48,7 @@ onMounted(() => {
     if (message.command === "bruinCliInstallationStatus") {
       isBruinCliInstalled.value = message.installed;
       isWindows.value = message.isWindows;
-      goInstalled.value = message.goInstalled;
+      gitAvailble.value = message.gitAvailble;
     }
   });
 });


### PR DESCRIPTION
# PR Overview

- Corrected the Windows installation message to specify Git instead of Go as the requirement.
- Fixed the CLI installation command to execute correctly from the command palette.





