### PR TITLE
Use only the shell script for install/update the CLI 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.25.22] - [2024-11-06]
+- Remove blockers.
+
 ## [0.25.21] - [2024-11-06]
-- FRemove blockers.
+- Remove blockers.
 
 ## [0.25.20] - [2024-11-06]
 - Fixed Bruin Render command to run properly from the command palette.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Use the new connections section from `Settings` tab to view, add, or delete conn
 Access the Bruin CLI management tab `Settings` in the side panel for easy installation and updates.
 
 ## Release Notes
+### Latest Release: 0.25.22
+- Remove blockers.
+
 ### Latest Release: 0.25.21
 - Remove blockers.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.25.21",
+  "version": "0.25.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.25.21",
+      "version": "0.25.22",
       "dependencies": {
         "@tailwindcss/forms": "^0.5.7",
         "@vue-flow/background": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.25.21",
+  "version": "0.25.22",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/bruin/bruinInstallCli.ts
+++ b/src/bruin/bruinInstallCli.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+/* import * as vscode from "vscode";
 import { exec } from "child_process";
 import * as os from "os";
 import { promisify } from "util";
@@ -75,6 +75,103 @@ export class BruinInstallCLI {
 
   public async updateBruinCli(): Promise<void> {
     const updateCommand = await this.getUpdateCommand();
+    console.log("updateBruinCli:", { updateCommand });
+    await this.executeCommand(updateCommand);
+  }
+
+  public async installOrUpdate(isInstalled: boolean): Promise<void> {
+    if (isInstalled) {
+      await this.updateBruinCli();
+    } else {
+      await this.installBruinCli();
+    }
+  }
+
+  public async checkBruinCliInstallation(): Promise<{
+    installed: boolean;
+    isWindows: boolean;
+    gitAvailable: boolean;
+  }> {
+    let installed = false;
+    let gitAvailable = false;
+
+    try {
+      // Check if Bruin CLI is installed
+      await execAsync("bruin --version");
+      installed = true;
+    } catch {
+      installed = false;
+    }
+
+    if (this.platform === "win32") {
+      try {
+        // Check if Git is available on Windows
+        await execAsync("git --version");
+        gitAvailable = true;
+      } catch {
+        gitAvailable = false;
+      }
+    } else {
+      // On non-Windows platforms, assume Git is available if Bruin CLI is installed
+      gitAvailable = true;
+    }
+
+    return {
+      installed,
+      isWindows: this.platform === "win32",
+      gitAvailable,
+    };
+  }
+} */
+
+  import * as vscode from "vscode";
+import { exec } from "child_process";
+import * as os from "os";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+export class BruinInstallCLI {
+  private platform: string;
+  private scriptPath =
+    "curl -LsSf https://raw.githubusercontent.com/bruin-data/bruin/refs/heads/main/install.sh | sh";
+
+  constructor() {
+    this.platform = os.platform();
+  }
+
+  private async executeCommand(command: string): Promise<void> {
+    const terminalName = "Bruin Terminal";
+    let terminal = vscode.window.terminals.find((t) => t.name === terminalName);
+    if (!terminal) {
+      terminal = vscode.window.createTerminal({ name: terminalName });
+    }
+    terminal.show(true);
+    terminal.sendText(command);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  private async getCommand(isUpdate: boolean): Promise<string> {
+    let command = this.scriptPath;
+
+    // Check for curl, fall back to wget if not available
+    try {
+      await execAsync("which curl");
+    } catch {
+      command = command.replace("curl", "wget -qO-");
+    }
+
+    return command;
+  }
+
+  public async installBruinCli(): Promise<void> {
+    const installCommand = await this.getCommand(false);
+    console.log("installBruinCli:", { installCommand });
+    await this.executeCommand(installCommand);
+  }
+
+  public async updateBruinCli(): Promise<void> {
+    const updateCommand = await this.getCommand(true);
     console.log("updateBruinCli:", { updateCommand });
     await this.executeCommand(updateCommand);
   }


### PR DESCRIPTION
# PR Overview 

This PR updates the Bruin Cli install method to use only the shell script on all the platforms 