### PR TITLE
Update Terminal Creation to Default to Git Bash on Windows

### DIFF
--- a/src/bruin/bruinFlowLineage.ts
+++ b/src/bruin/bruinFlowLineage.ts
@@ -31,7 +31,7 @@ export class BruinLineageInternalParse extends BruinCommand {
 
     { flags = ["parse-pipeline"], ignoresErrors = false }: BruinCommandOptions = {}
   ): Promise<void> {
-    await this.run([...flags, getCurrentPipelinePath(filePath) as string], { ignoresErrors })
+    await this.run([...flags, await getCurrentPipelinePath(filePath) as string], { ignoresErrors })
       .then(
         (result) => {
           const pipelineData = JSON.parse(result);

--- a/src/bruin/bruinInstallCli.ts
+++ b/src/bruin/bruinInstallCli.ts
@@ -1,166 +1,35 @@
-/* import * as vscode from "vscode";
+import * as vscode from "vscode";
 import { exec } from "child_process";
 import * as os from "os";
 import { promisify } from "util";
-
-const execAsync = promisify(exec);
-
-export class BruinInstallCLI {
-  private platform: string;
-  private scriptPath =
-    "curl -LsSf https://raw.githubusercontent.com/bruin-data/bruin/refs/heads/main/install.sh | sh";
-
-  constructor() {
-    this.platform = os.platform();
-  }
-
-  private async executeCommand(command: string): Promise<void> {
-    const terminalName = "Bruin Terminal";
-    let terminal = vscode.window.terminals.find((t) => t.name === terminalName);
-    if (!terminal) {
-      terminal = vscode.window.createTerminal({ name: terminalName });
-    }
-    terminal.show(true);
-    terminal.sendText(command);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-
-  private async isBrewAvailable(): Promise<boolean> {
-    try {
-      await execAsync("brew --version");
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private async isBruinInstalledWithBrew(): Promise<boolean> {
-    const brewListOutput = await execAsync("brew list --versions");
-    return brewListOutput.stdout.includes("bruin");
-  }
-
-  private async getUpdateCommand(): Promise<string> {
-    if (this.platform === "darwin") {
-      if (await this.isBrewAvailable()) {
-        if (await this.isBruinInstalledWithBrew()) {
-          return "brew update && brew upgrade bruin";
-        } else {
-          throw new Error("Bruin not installed with Brew on Mac");
-        }
-      } else {
-        return this.scriptPath;
-      }
-    } else {
-      return this.scriptPath;
-    }
-  }
-
-  private async getInstallCommand(): Promise<string> {
-    if (this.platform === "darwin") {
-      if (await this.isBrewAvailable()) {
-        return "brew install bruin";
-      } else {
-        return this.scriptPath;
-      }
-    } else {
-      return this.scriptPath;
-    }
-  }
-
-  public async installBruinCli(): Promise<void> {
-    const installCommand = await this.getInstallCommand();
-    console.log("installBruinCli:", { installCommand });
-    await this.executeCommand(installCommand);
-  }
-
-  public async updateBruinCli(): Promise<void> {
-    const updateCommand = await this.getUpdateCommand();
-    console.log("updateBruinCli:", { updateCommand });
-    await this.executeCommand(updateCommand);
-  }
-
-  public async installOrUpdate(isInstalled: boolean): Promise<void> {
-    if (isInstalled) {
-      await this.updateBruinCli();
-    } else {
-      await this.installBruinCli();
-    }
-  }
-
-  public async checkBruinCliInstallation(): Promise<{
-    installed: boolean;
-    isWindows: boolean;
-    gitAvailable: boolean;
-  }> {
-    let installed = false;
-    let gitAvailable = false;
-
-    try {
-      // Check if Bruin CLI is installed
-      await execAsync("bruin --version");
-      installed = true;
-    } catch {
-      installed = false;
-    }
-
-    if (this.platform === "win32") {
-      try {
-        // Check if Git is available on Windows
-        await execAsync("git --version");
-        gitAvailable = true;
-      } catch {
-        gitAvailable = false;
-      }
-    } else {
-      // On non-Windows platforms, assume Git is available if Bruin CLI is installed
-      gitAvailable = true;
-    }
-
-    return {
-      installed,
-      isWindows: this.platform === "win32",
-      gitAvailable,
-    };
-  }
-} */
-
-  import * as vscode from "vscode";
-import { exec } from "child_process";
-import * as os from "os";
-import { promisify } from "util";
-import { get } from "http";
 import { getDefaultBruinExecutablePath } from "../extension/configuration";
+import { createIntegratedTerminal } from "./bruinUtils";
 
 const execAsync = promisify(exec);
 
 export class BruinInstallCLI {
   private platform: string;
-  private scriptPath =
-    "curl -LsSf https://raw.githubusercontent.com/bruin-data/bruin/refs/heads/main/install.sh | sh";
+  private scriptPath = "https://raw.githubusercontent.com/bruin-data/bruin/refs/heads/main/install.sh";
 
   constructor() {
     this.platform = os.platform();
   }
 
   private async executeCommand(command: string): Promise<void> {
-    const terminalName = "Bruin Terminal";
-    let terminal = vscode.window.terminals.find((t) => t.name === terminalName);
-    if (!terminal) {
-      terminal = vscode.window.createTerminal({ name: terminalName });
-    }
+    const workingDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const terminal = await createIntegratedTerminal(workingDir);
+    console.log("executeCommand:", { command });
+    console.log("terminal:", { terminal });
     terminal.show(true);
     terminal.sendText(command);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
   private async getCommand(isUpdate: boolean): Promise<string> {
-    let command = this.scriptPath;
-
-    // Check for curl, fall back to wget if not available
-    try {
-      await execAsync("which curl");
-    } catch {
-      command = command.replace("curl", "wget -qO-");
+    let command = "";
+    if(os.platform() === "win32") {
+      command = "curl -LsSf " + this.scriptPath + " | sh";
+    } else {
+      command = "curl -LsSL " + this.scriptPath + " | sh";
     }
 
     return command;

--- a/src/bruin/bruinUtils.ts
+++ b/src/bruin/bruinUtils.ts
@@ -3,9 +3,6 @@ import { BRUIN_RUN_SQL_COMMAND, BRUIN_WHERE_COMMAND, BRUIN_WHICH_COMMAND } from 
 import * as os from "os";
 import { exec } from "child_process";
 import { promisify } from "util";
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-import * as child_process from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
@@ -17,13 +14,13 @@ import { getDefaultBruinExecutablePath, getPathSeparator } from "../extension/co
  * @returns {boolean} Returns true if the Bruin binary is available, false otherwise.
  */
 
-export const isBruinBinaryAvailable = (): boolean => {
+export const isBruinBinaryAvailable = async (): Promise<boolean> => {
   try {
-    const command = process.platform === "win32" ? BRUIN_WHERE_COMMAND : BRUIN_WHICH_COMMAND;
-    let output = child_process.execSync(command);
-    console.log(output.toString());
+    const command = process.platform === "win32"? BRUIN_WHERE_COMMAND : BRUIN_WHICH_COMMAND;
+    const output = await promisify(exec)(command);
+    console.log(output.stdout);
 
-    if (!output) {
+    if (!output.stdout) {
       throw new Error("Bruin is not installed");
     }
   } catch (e) {
@@ -58,42 +55,51 @@ export const replacePathSeparator = (path: string): string => {
  * @returns {string | undefined} The directory path of the Bruin workspace if found, otherwise undefined.
  */
 
-export const bruinWorkspaceDirectory = (
+export const bruinWorkspaceDirectory = async (
   fsPath: string,
   bruinRootFileNames = [".bruin.yaml", ".bruin.yml"]
-): string | undefined => {
+): Promise<string | undefined> => {
   let dirname = fsPath;
   let iteration = 0;
   const maxIterations = 100;
 
-  if (fs.statSync(fsPath).isFile()) {
+  if ((await fs.promises.stat(fsPath)).isFile()) {
     dirname = path.dirname(dirname);
   }
   do {
     for (const fileName of bruinRootFileNames) {
       const bruinWorkspace = path.join(dirname, fileName);
       try {
-        fs.accessSync(bruinWorkspace, fs.constants.F_OK);
+        await fs.promises.access(bruinWorkspace, fs.constants.F_OK);
         return dirname.replace(/\\/g, "/");
       } catch (err) {
         // do nothing
       }
     }
     dirname = path.dirname(dirname);
-  } while (++iteration < maxIterations && dirname !== "" && dirname !== "/");
+  } while (++iteration < maxIterations && dirname!== "" && dirname!== "/");
 
   return undefined;
 };
 
+
 const escapeFilePath = (filePath: string): string => {
-  // Escape backslashes first (they need to be escaped as double backslashes)
-  // Then escape spaces (they need to be escaped with a backslash)
-  // Finally, wrap the path in quotes for safety
-  return `"${filePath.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  // Convert Windows-style paths to Unix-style paths for Git Bash
+  if (process.platform === 'win32' && process.env.SHELL?.includes('bash')) {
+    filePath = filePath.replace(/\\/g, '/');
+    if (filePath[1] === ':') {
+      filePath = `/${filePath[0].toLowerCase()}${filePath.slice(2)}`;
+    }
+  }
+  // Escape quotes
+  filePath = filePath.replace(/"/g, '\\"');
+
+  // Wrap the path in quotes for safety
+  return `"${filePath}"`;
 };
 
-export const getCurrentPipelinePath = (fsPath: string): string | undefined => {
-  return bruinWorkspaceDirectory(fsPath, ["pipeline.yaml", "pipeline.yml"]);
+export const getCurrentPipelinePath = async (fsPath: string): Promise<string | undefined> => {
+  return await bruinWorkspaceDirectory(fsPath, ["pipeline.yaml", "pipeline.yml"]);
 };
 /**
  * Runs the Bruin command "run" in the integrated terminal.
@@ -107,23 +113,66 @@ export const runInIntegratedTerminal = async (
   workingDir: string | undefined,
   assetPath?: string,
   flags?: string
-) => {
-  // we should open not a powershell terminal but a Git bash on windows 
-  const escapedAssetPath = assetPath ? escapeFilePath(assetPath) : "";
+): Promise<void> => {
+  const escapedAssetPath = assetPath? escapeFilePath(assetPath) : "";
   const bruinExecutable = getDefaultBruinExecutablePath();
-  const command = `${bruinExecutable} ${BRUIN_RUN_SQL_COMMAND} ${flags} ${escapedAssetPath}`;
-
-  const terminalName = "Bruin Terminal";
-  let terminal = vscode.window.terminals.find((t) => t.name === terminalName);
-  if (!terminal) {
-    terminal = vscode.window.createTerminal({ cwd: workingDir, name: terminalName });
+  let command = "";
+  const terminal = await createIntegratedTerminal(workingDir);
+  if((terminal.creationOptions as  vscode.TerminalOptions).shellPath?.includes("bash")){
+    command = `bruin ${BRUIN_RUN_SQL_COMMAND} ${flags} ${escapedAssetPath}`;
+  }
+  else{
+    command = `${bruinExecutable} ${BRUIN_RUN_SQL_COMMAND} ${flags} ${escapedAssetPath}`;
   }
   terminal.show(true);
   terminal.sendText(command);
   await new Promise((resolve) => setTimeout(resolve, 1000));
 };
 
+export const createIntegratedTerminal = async (workingDir: string | undefined): Promise<vscode.Terminal> => {
+  const terminalName = "Bruin Terminal";
+  let terminal = vscode.window.terminals.find((t) => t.name === terminalName);
+
+  if (!terminal) {
+    let shellPath: string | undefined;
+    let shellArgs: string[] | undefined;
+
+    // Check for Git Bash on Windows
+    if (process.platform === "win32") {
+      const gitBashPath = "C:\\Program Files\\Git\\bin\\bash.exe";
+      if (fs.existsSync(gitBashPath)) {
+        shellPath = gitBashPath;
+      } else {
+        // Check for WSL on Windows
+        const wslPath = "wsl.exe";
+        if (fs.existsSync(wslPath)) {
+          shellPath = wslPath;
+          shellArgs = ["-d", "Ubuntu"]; // Assuming Ubuntu as the default WSL distro
+        } else {
+          // Neither Git Bash nor WSL is found, display an alert to the user
+          vscode.window.showWarningMessage(
+            "Neither Git Bash nor Windows Subsystem for Linux (WSL) was found on your system. " +
+            "Please install one of them to use the integrated terminal. " +
+            "You can download Git Bash from <https://gitforwindows.org/> or enable WSL from Windows Features."
+          );
+          return vscode.window.createTerminal({ name: "Dummy Terminal" }); // Exit the function without creating a terminal
+        }
+      }
+    } else {
+      // For non-Windows platforms, use the default shell
+      shellPath = undefined;
+    }
+
+    const terminalOptions: vscode.TerminalOptions = {
+      name: terminalName,
+      cwd: workingDir,
+      shellPath,
+      shellArgs,
+    };
+    terminal = vscode.window.createTerminal(terminalOptions);
+  }
+  return terminal;
+};
+
 
 export { BruinInstallCLI } from './bruinInstallCli';
-
-

--- a/src/bruin/bruinUtils.ts
+++ b/src/bruin/bruinUtils.ts
@@ -152,10 +152,9 @@ export const createIntegratedTerminal = async (workingDir: string | undefined): 
           // Neither Git Bash nor WSL is found, display an alert to the user
           vscode.window.showWarningMessage(
             "Neither Git Bash nor Windows Subsystem for Linux (WSL) was found on your system. " +
-            "Please install one of them to use the integrated terminal. " +
-            "You can download Git Bash from <https://gitforwindows.org/> or enable WSL from Windows Features."
+            "Please install one of them to use the integrated terminal. " 
           );
-          return vscode.window.createTerminal({ name: "Dummy Terminal" }); // Exit the function without creating a terminal
+          return vscode.window.createTerminal({ name: terminalName }); // Exit the function without creating a terminal
         }
       }
     } else {

--- a/src/extension/commands/FlowLineageCommand.ts
+++ b/src/extension/commands/FlowLineageCommand.ts
@@ -9,7 +9,7 @@ export const flowLineageCommand = async (lastRenderedDocumentUri:  Uri | undefin
   }
   const flowLineage = new BruinLineageInternalParse(
     getDefaultBruinExecutablePath(),
-    bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath)!!
+    await bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath!) as string
   );
   await flowLineage.parseAssetLineage(lastRenderedDocumentUri.fsPath);
   };

--- a/src/extension/commands/getEnvListCommand.ts
+++ b/src/extension/commands/getEnvListCommand.ts
@@ -7,7 +7,7 @@ export const getEnvListCommand = async (lastRenderedDocumentUri:  Uri | undefine
 
   const getList = new BruinEnvList(
     getDefaultBruinExecutablePath(),
-    bruinWorkspaceDirectory(lastRenderedDocumentUri!.fsPath)!!
+    await bruinWorkspaceDirectory(lastRenderedDocumentUri!.fsPath)!! as string
   );
   await getList.getEnvironmentsList();
   };

--- a/src/extension/commands/lineageCommand.ts
+++ b/src/extension/commands/lineageCommand.ts
@@ -8,7 +8,7 @@ export const lineageCommand = async (lastRenderedDocumentUri:  Uri | undefined, 
   }
   const lineage = new BruinLineage(
     getDefaultBruinExecutablePath(),
-    bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath)!!
+    await bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath)!! as string
   );
   await lineage.diplayLineage(lastRenderedDocumentUri.fsPath, {flags: flags});
   };

--- a/src/extension/commands/manageConnections.ts
+++ b/src/extension/commands/manageConnections.ts
@@ -6,7 +6,7 @@ import { BruinConnections, BruinCreateConnection, BruinDeleteConnection } from "
 export const getConnections = async (lastRenderedDocumentUri: Uri | undefined) => {
   const bruinConnections = new BruinConnections(
     getDefaultBruinExecutablePath(),
-    bruinWorkspaceDirectory(lastRenderedDocumentUri!.fsPath)!!
+    await bruinWorkspaceDirectory(lastRenderedDocumentUri!.fsPath)!! as string
   );
   await bruinConnections.getConnections();
 };
@@ -16,7 +16,7 @@ export const deleteConnection = async (env: string, connectionName: string, last
   console.log('Deleting connection:', { env, connectionName });
   const bruinConnections = new BruinDeleteConnection(
     getDefaultBruinExecutablePath(),
-    bruinWorkspaceDirectory(lastRenderedDocumentUri!.fsPath)!!
+    await bruinWorkspaceDirectory(lastRenderedDocumentUri!.fsPath)!! as string
   );
   await bruinConnections.deleteConnection(env, connectionName);
 };
@@ -25,7 +25,7 @@ export const createConnection = async (env: string, connectionName: string, conn
   console.log('Creating connection');
   const bruinConnections = new BruinCreateConnection(
     getDefaultBruinExecutablePath(),
-    bruinWorkspaceDirectory(lastRenderedDocumentUri!.fsPath)!!
+    await bruinWorkspaceDirectory(lastRenderedDocumentUri!.fsPath)!! as string
   );
   await bruinConnections.createConnection(env, connectionName, connectionType, credentials);
 };

--- a/src/extension/commands/parseAssetCommand.ts
+++ b/src/extension/commands/parseAssetCommand.ts
@@ -10,7 +10,7 @@ export const parseAssetCommand = async (lastRenderedDocumentUri: Uri | undefined
   }
   const parsed = new BruinInternalParse(
     getDefaultBruinExecutablePath(),
-    bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath)!!
+    await bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath)!! as string
   );
   await parsed.parseAsset(lastRenderedDocumentUri.fsPath);
 };
@@ -21,7 +21,7 @@ export const patchAssetCommand = async (body: object, lastRenderedDocumentUri: U
   }
   const patched = new BruinInternalPatch(
     getDefaultBruinExecutablePath(),
-    bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath)!!
+    await bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath)!! as string
   );
   await patched.patchAsset(body, lastRenderedDocumentUri.fsPath);
 };

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -19,39 +19,34 @@ export function getDefaultBruinExecutablePath(): string {
     // If a path is provided, use it
     return bruinExecutable;
   } else {
-    // Attempt to find 'bruin' in the system's PATH
+    // Attempt to find 'bruin' in the system's PATH (works for Git Bash)
     const paths = (process.env.PATH || "").split(path.delimiter);
     for (const p of paths) {
-      const executablePath = path.join(p, process.platform === "win32" ? "bruin.exe" : "bruin");
+      const executablePath = path.join(p, process.platform === "win32"? "bruin.exe" : "bruin");
       try {
         // Test if the file exists and is executable
+        // NOTE: Git Bash's `which` command doesn't work as expected, so we use `fs.accessSync` instead
         fs.accessSync(executablePath, fs.constants.X_OK);
-        return executablePath;
+        return "bruin";
       } catch (err) {
         // Continue searching if not found or not executable
         continue;
       }
     }
+    // If all else fails, check in ~/.local/bin for Windows (Git Bash)
     if (process.platform === "win32") {
       const homePath = os.homedir();
       const localBinPath = path.join(homePath, ".local", "bin");
-      const executablePathLocal = path.join(
-        localBinPath,
-        "bruin.exe"
-      );
+      const executablePathLocal = path.join(localBinPath, "bruin.exe");
       try {
-        // Test if the file exists and is executable
         fs.accessSync(executablePathLocal, fs.constants.X_OK);
         return executablePathLocal;
       } catch (err) {
         // Continue searching if not found or not executable
       }
     }
-    return "";
     // If all else fails, provide a meaningful message or default
-  /*   throw new Error(
-      `Unable to find 'bruin' executable in system's PATH. Please set the 'bruin.executable' setting in VS Code.`
-    ); */
+    return "";
   }
 }
 export function getPathSeparator(): string {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -13,7 +13,6 @@ import * as os from "os";
 import { renderCommand } from "./commands/renderCommand";
 import { LineagePanel } from "../panels/LineagePanel";
 import { installOrUpdateCli } from "./commands/updateBruinCLI";
-import { runInIntegratedTerminal } from "../bruin";
 
 export function activate(context: ExtensionContext) {
   // Automatically focus editor when extension starts

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -283,16 +283,17 @@ export class BruinPanel {
               return;
             }
             const currAssetPath = this._lastRenderedDocumentUri.fsPath;
-            const currentPipelinePath = getCurrentPipelinePath(currAssetPath || "");
+            const currentPipelinePath = await getCurrentPipelinePath(currAssetPath || "");
 
             if (!currentPipelinePath) {
               console.error("No pipeline found for the current asset.");
               return;
             }
 
+            const bruinWorkspaceDirc = await bruinWorkspaceDirectory(currAssetPath || "");
             const pipelineValidator = new BruinValidate(
               getDefaultBruinExecutablePath(),
-              bruinWorkspaceDirectory(currAssetPath || "")!!
+              bruinWorkspaceDirc || ""
             );
 
             try {
@@ -316,7 +317,7 @@ export class BruinPanel {
             }
 
             const filePath = this._lastRenderedDocumentUri.fsPath;
-            const bruinWorkspaceDir = bruinWorkspaceDirectory(filePath || "");
+            const bruinWorkspaceDir = await bruinWorkspaceDirectory(filePath || "");
 
             const validator = new BruinValidate(
               getDefaultBruinExecutablePath(),
@@ -329,7 +330,7 @@ export class BruinPanel {
               return;
             }
             const fPath = this._lastRenderedDocumentUri?.fsPath;
-            runInIntegratedTerminal(bruinWorkspaceDirectory(fPath), fPath, message.payload);
+            runInIntegratedTerminal(await bruinWorkspaceDirectory(fPath), fPath, message.payload);
 
             setTimeout(() => {
               this._panel.webview.postMessage({
@@ -346,8 +347,8 @@ export class BruinPanel {
             const currentPipeline = getCurrentPipelinePath(currfilePath || "");
 
             runInIntegratedTerminal(
-              bruinWorkspaceDirectory(currfilePath),
-              currentPipeline,
+              await bruinWorkspaceDirectory(currfilePath),
+              await currentPipeline,
               message.payload
             );
 


### PR DESCRIPTION
# PR Overview 

- Set the default terminal to Git Bash on Windows for Bruin utilities.
- Update Workspace Directory and File Paths for Git Bash Compatibility on Windows

