### PR TITLE
Fix Rendering of Non-SQL Shopify Assets in SQL Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Bruin extension will be documented in this file.
 
+## [0.26.4] - [2024-11-14]
+- Fixed an issue where non-SQL Shopify assets were incorrectly displayed in the SQL preview.
+
 ## [0.26.3] - [2024-11-14]
 - Added delete column functionality with confirmation alert and expanded supported destinations in yaml-assets-schema.json.
 

--- a/README.md
+++ b/README.md
@@ -106,10 +106,11 @@ Use the new connections section from `Settings` tab to view, add, or delete conn
 Access the Bruin CLI management tab `Settings` in the side panel for easy installation and updates.
 
 ## Release Notes
-### Latest Release: 0.26.3
-- Added delete column functionality with confirmation alert and expanded supported destinations in yaml-assets-schema.json.
+### Latest Release: 0.26.4
+- Fixed an issue where non-SQL Shopify assets were incorrectly displayed in the SQL preview.
 
 ### Previous Highlights
+- **0.26.2**: Added delete column functionality with confirmation alert and expanded supported destinations in yaml-assets-schema.json.
 - **0.26.2**: Add version check for Bruin CLI to compare current and latest versions and notify the user if an update is available.
 - **0.26.1**: Adjusted the column checks' blocking property type to align with the CLI output.
 - **0.26.0**: Added functionality to add and update columns directly from the UI in the Columns tab.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.26.2",
+      "version": "0.26.3",
       "dependencies": {
         "@tailwindcss/forms": "^0.5.7",
         "@vue-flow/background": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.26.3",
+      "version": "0.26.4",
       "dependencies": {
         "@tailwindcss/forms": "^0.5.7",
         "@vue-flow/background": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -47,8 +47,8 @@ suite("Render Command Helper functions", () => {
   });
 
   test("getFileExtension should return the file extension", () => {
-    assert.strictEqual(getFileExtension("example.txt"), "txt");
-    assert.strictEqual(getFileExtension("example.sql"), "sql");
+    assert.strictEqual(getFileExtension("example.txt"), ".txt");
+    assert.strictEqual(getFileExtension("example.sql"), ".sql");
     assert.strictEqual(getFileExtension("example"), "");
   });
 

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -40,22 +40,27 @@ export const isFileExtensionSQL = (fileName: string): boolean => {
 };
 
 export const getFileExtension = (fileName: string) => {
-  const match = fileName.match(/\.(.+)/);
+  // If file starts with a dot, return everything
+  if (fileName.startsWith(".")) {
+    return fileName.toLowerCase();
+  }
+
+  const match = fileName.match(/(\.[^.]+(?:\.[^.]+)?$)/);
   return match ? match[1].toLowerCase() : "";
 };
 
 export const isPythonBruinAsset = async (fileName: string): Promise<boolean> =>
-  isBruinAsset(fileName, ["py"]);
+  isBruinAsset(fileName, [".py"]);
 
 export const isBruinPipeline = async (fileName: string): Promise<boolean> => {
   console.log("this is a pipleine" + path.basename(fileName) === "pipeline.yml" ? true : false);
   return path.basename(fileName) === "pipeline.yml" ? true : false;
 };
 export const isYamlBruinAsset = async (fileName: string): Promise<boolean> =>
-  isBruinAsset(fileName, ["asset.yml", "asset.yaml"]);
+  isBruinAsset(fileName, [".asset.yml", ".asset.yaml"]);
 
 export const isBruinYaml = async (fileName: string): Promise<boolean> => {
-  return getFileExtension(fileName) === "bruin.yml" ? true : false;
+  return getFileExtension(fileName) === ".bruin.yml" ? true : false;
 };
 
 export const isBruinAsset = async (
@@ -78,8 +83,8 @@ export const isBruinAsset = async (
     const assetContent = fs.readFileSync(fileName, "utf8");
     const bruinAsset =
       bruinPattern.test(assetContent) ||
-      fileExtension === "asset.yml" ||
-      fileExtension === "asset.yaml";
+      fileExtension === ".asset.yml" ||
+      fileExtension === ".asset.yaml";
 
     return bruinAsset;
   } catch (err) {


### PR DESCRIPTION
# PR Overview

This PR fixed an issue where Shopify assets, which are in YAML format, were incorrectly rendered in the SQL preview. Shopify assets are now excluded from the SQL preview.
