### PR TITLE
Add Unit Tests and Debug Messages for Validate, Connections and Render Commands 

### DIFF
--- a/src/bruin/bruinValidate.ts
+++ b/src/bruin/bruinValidate.ts
@@ -65,9 +65,11 @@ export class BruinValidate extends BruinCommand {
       }
     } catch (error) {
       // Handle the error and notify the user
+      const errorMessage = error instanceof Error ? error.message : "An unknown error occurred";
+
       BruinPanel.postMessage("validation-message", {
         status: "error",
-        message: error || "An error occurred while validating the asset.",
+        message: errorMessage,
       });
       console.error("Validation error:", error);
     } finally {


### PR DESCRIPTION
# PR Overview
This PR introduces unit tests and console debug messages for the following:
- Render Command.
- Bruin Connections management sub-commands: operations like delete, add, ..
- Validate Command.
