### PR TITLE
Add Unit Tests for  Language Delimiters, Folding, and Bruin Utils

### DIFF
--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -38,14 +38,26 @@ import {
   BruinGetAllBruinConnections,
 } from "../bruin/bruinConnections";
 import { BruinPanel } from "../panels/BruinPanel";
+import { LineagePanel } from "../panels/LineagePanel";
 import { BruinRender, BruinValidate } from "../bruin";
 import { renderCommand, renderCommandWithFlags } from "../extension/commands/renderCommand";
-import { createConnection, deleteConnection, getConnections, getConnectionsListFromSchema } from "../extension/commands/manageConnections";
+import {
+  createConnection,
+  deleteConnection,
+  getConnections,
+  getConnectionsListFromSchema,
+} from "../extension/commands/manageConnections";
 import { parseAssetCommand, patchAssetCommand } from "../extension/commands/parseAssetCommand";
 import { getEnvListCommand } from "../extension/commands/getEnvListCommand";
 import { lineageCommand } from "../extension/commands/lineageCommand";
 import { BruinInternalParse } from "../bruin/bruinInternalParse";
 import { BruinEnvList } from "../bruin/bruinSelectEnv";
+import { activate } from "../extension/extension";
+import { checkBruinCliVersion, installOrUpdateCli } from "../extension/commands/updateBruinCLI";
+import { getLanguageDelimiters } from "../utilities/delimiters";
+import { bruinDelimiterRegex } from "../constants";
+import { bruinFoldingRangeProvider } from "../providers/bruinFoldingRangeProvider";
+import { get } from "http";
 
 suite("Extension Initialization", () => {
   test("should set default path separator based on platform", async () => {
@@ -397,10 +409,10 @@ suite("Render Commands", () => {
   setup(() => {
     activeEditorStub.callsFake(() => ({
       document: {
-        fileName: "file/path/mock.sql"
-      }
+        fileName: "file/path/mock.sql",
+      },
     }));
-    activeEditorStub.value = activeEditorStub(); 
+    activeEditorStub.value = activeEditorStub();
     bruinRenderMock = sinon.createStubInstance(BruinRender);
     renderStub = sinon.stub(BruinRender.prototype, "render").resolves();
     sinon.stub(BruinPanel, "render").callsFake(() => {});
@@ -423,18 +435,18 @@ suite("Render Commands", () => {
       sinon.assert.calledOnce(renderStub);
       sinon.assert.calledWithExactly(renderStub, mockFileName, { flags: ["-o", "json"] });
     }); */
-  
+
     test("should not execute render if there is no active editor", async () => {
       activeEditorStub.callsFake(() => null);
-  
+
       await renderCommand(mockExtensionUri);
-  
+
       sinon.assert.notCalled(renderStub);
     });
   });
-  
+
   suite("renderCommandWithFlags", () => {
-   /*  test("should render the active editor file with flags", async () => {
+    /*  test("should render the active editor file with flags", async () => {
       const mockFileName = "file/path/mock.sql";
       const mockFlags = "--downstream";
       const mockTextEditor: vscode.TextEditor = { document: { fileName: mockFileName } } as vscode.TextEditor;
@@ -450,31 +462,29 @@ suite("Render Commands", () => {
       });
       sinon.assert.calledWith(renderStub, sinon.match.string, sinon.match.object);
     }); */
-  
-  
+
     test("should render the last rendered document if no active editor exists", async () => {
       const lastRenderedDocument = "file/path/last-rendered.sql";
       activeEditorStub.callsFake(() => null);
-  
+
       await renderCommandWithFlags("--push-metadata", lastRenderedDocument);
-  
+
       sinon.assert.calledOnce(renderStub);
       sinon.assert.calledWithExactly(renderStub, lastRenderedDocument, {
         flags: prepareFlags("--push-metadata", ["--downstream", "--push-metadata"]),
       });
     });
-  
+
     test("should not execute render if no file path is available", async () => {
       activeEditorStub.callsFake(() => ({
-        document: { fileName: undefined }
+        document: { fileName: undefined },
       }));
-  
+
       await renderCommandWithFlags("", undefined);
-  
+
       sinon.assert.notCalled(renderStub); // Verify renderStub is not called
     });
   });
-  
 });
 suite("BruinRender Tests", () => {
   let bruinRender: BruinRender;
@@ -490,7 +500,9 @@ suite("BruinRender Tests", () => {
   setup(() => {
     bruinRender = new BruinRender(bruinExecutablePath, workingDirectory);
     runStub = sinon.stub(bruinRender as any, "run").resolves("SQL rendered successfully");
-    runWithoutJsonFlagStub = sinon.stub(bruinRender as any, "runWithoutJsonFlag").resolves("Non-SQL rendered successfully");
+    runWithoutJsonFlagStub = sinon
+      .stub(bruinRender as any, "runWithoutJsonFlag")
+      .resolves("Non-SQL rendered successfully");
     isValidAssetStub = sinon.stub(bruinRender as any, "isValidAsset");
     detectBruinAssetStub = sinon.stub(bruinRender as any, "detectBruinAsset");
     isBruinPipelineStub = sinon.stub(bruinRender as any, "isBruinPipeline");
@@ -597,38 +609,44 @@ suite("BruinValidate Tests", () => {
     const filePath = "path/to/asset";
     const error = new Error("Validation command failed");
     runStub.rejects(error);
-  
+
     await bruinValidate.validate(filePath);
-  
+
     sinon.assert.calledTwice(postMessageStub);
-  
+
     sinon.assert.calledWithExactly(postMessageStub.firstCall, "validation-message", {
       status: "loading",
       message: "Validating asset...",
     });
-  
+
     sinon.assert.calledWithExactly(postMessageStub.secondCall, "validation-message", {
       status: "error",
       message: error.message,
     });
   });
-  
-  
+
   test("validate should indicate loading state when validation is in progress", async () => {
     const filePath = "path/to/asset";
     runStub.resolves("{}");
-  
+
     const validatePromise = bruinValidate.validate(filePath);
-  
+
     // Assert loading state before completion
-    assert.strictEqual(bruinValidate.isLoading, true, "Loading state should be true during validation");
-  
+    assert.strictEqual(
+      bruinValidate.isLoading,
+      true,
+      "Loading state should be true during validation"
+    );
+
     await validatePromise;
-  
+
     // Assert loading state after completion
-    assert.strictEqual(bruinValidate.isLoading, false, "Loading state should be false after validation");
+    assert.strictEqual(
+      bruinValidate.isLoading,
+      false,
+      "Loading state should be false after validation"
+    );
   });
-  
 
   test("validate should handle multiple validation results", async () => {
     const filePath = "path/to/asset";
@@ -637,12 +655,11 @@ suite("BruinValidate Tests", () => {
       { issues: { error: "Error message 2" } },
     ]);
     runStub.resolves(validationResults);
-  
+
     await bruinValidate.validate(filePath);
     // Assert the expected behavior
     sinon.assert.calledTwice(postMessageStub);
   });
-
 
   test("validate should reset loading state after validation completes", async () => {
     const filePath = "path/to/asset";
@@ -650,7 +667,11 @@ suite("BruinValidate Tests", () => {
 
     await bruinValidate.validate(filePath);
 
-    assert.strictEqual(bruinValidate.isLoading, false, "Loading state should be false after validation");
+    assert.strictEqual(
+      bruinValidate.isLoading,
+      false,
+      "Loading state should be false after validation"
+    );
   });
 });
 suite("patch asset testing", () => {
@@ -778,12 +799,22 @@ suite("Connection Management Tests", () => {
   let createConnectionStub: sinon.SinonStub;
 
   setup(() => {
-    getDefaultBruinExecutablePathStub = sinon.stub(configuration, "getDefaultBruinExecutablePath").returns("path/to/executable");
-    bruinWorkspaceDirectoryStub = sinon.stub(bruinUtils, "bruinWorkspaceDirectory").resolves("path/to/workspace");
+    getDefaultBruinExecutablePathStub = sinon
+      .stub(configuration, "getDefaultBruinExecutablePath")
+      .returns("path/to/executable");
+    bruinWorkspaceDirectoryStub = sinon
+      .stub(bruinUtils, "bruinWorkspaceDirectory")
+      .resolves("path/to/workspace");
     getConnectionsStub = sinon.stub(BruinConnections.prototype, "getConnections").resolves();
-    getConnectionsListFromSchemaStub = sinon.stub(BruinGetAllBruinConnections.prototype, "getConnectionsListFromSchema").resolves();
-    deleteConnectionStub = sinon.stub(BruinDeleteConnection.prototype, "deleteConnection").resolves();
-    createConnectionStub = sinon.stub(BruinCreateConnection.prototype, "createConnection").resolves();
+    getConnectionsListFromSchemaStub = sinon
+      .stub(BruinGetAllBruinConnections.prototype, "getConnectionsListFromSchema")
+      .resolves();
+    deleteConnectionStub = sinon
+      .stub(BruinDeleteConnection.prototype, "deleteConnection")
+      .resolves();
+    createConnectionStub = sinon
+      .stub(BruinCreateConnection.prototype, "createConnection")
+      .resolves();
   });
 
   teardown(() => {
@@ -798,7 +829,10 @@ suite("Connection Management Tests", () => {
 
       sinon.assert.calledOnce(getConnectionsStub);
       sinon.assert.calledOnceWithExactly(getDefaultBruinExecutablePathStub);
-      sinon.assert.calledOnceWithExactly(bruinWorkspaceDirectoryStub, lastRenderedDocumentUri.fsPath);
+      sinon.assert.calledOnceWithExactly(
+        bruinWorkspaceDirectoryStub,
+        lastRenderedDocumentUri.fsPath
+      );
     });
 
     test("should handle error when getting connections", async () => {
@@ -822,12 +856,17 @@ suite("Connection Management Tests", () => {
 
       sinon.assert.calledOnce(getConnectionsListFromSchemaStub);
       sinon.assert.calledOnceWithExactly(getDefaultBruinExecutablePathStub);
-      sinon.assert.calledOnceWithExactly(bruinWorkspaceDirectoryStub, lastRenderedDocumentUri.fsPath);
+      sinon.assert.calledOnceWithExactly(
+        bruinWorkspaceDirectoryStub,
+        lastRenderedDocumentUri.fsPath
+      );
     });
 
     test("should handle error when getting connections list from schema", async () => {
       const lastRenderedDocumentUri = vscode.Uri.file("path/to/file");
-      getConnectionsListFromSchemaStub.rejects(new Error("Error getting connections list from schema"));
+      getConnectionsListFromSchemaStub.rejects(
+        new Error("Error getting connections list from schema")
+      );
 
       try {
         await getConnectionsListFromSchema(lastRenderedDocumentUri);
@@ -848,7 +887,10 @@ suite("Connection Management Tests", () => {
 
       sinon.assert.calledOnceWithExactly(deleteConnectionStub, env, connectionName);
       sinon.assert.calledOnceWithExactly(getDefaultBruinExecutablePathStub);
-      sinon.assert.calledOnceWithExactly(bruinWorkspaceDirectoryStub, lastRenderedDocumentUri.fsPath);
+      sinon.assert.calledOnceWithExactly(
+        bruinWorkspaceDirectoryStub,
+        lastRenderedDocumentUri.fsPath
+      );
     });
 
     test("should handle error when deleting connection", async () => {
@@ -874,11 +916,26 @@ suite("Connection Management Tests", () => {
       const credentials = {};
       const lastRenderedDocumentUri = vscode.Uri.file("path/to/file");
 
-      await createConnection(env, connectionName, connectionType, credentials, lastRenderedDocumentUri);
+      await createConnection(
+        env,
+        connectionName,
+        connectionType,
+        credentials,
+        lastRenderedDocumentUri
+      );
 
-      sinon.assert.calledOnceWithExactly(createConnectionStub, env, connectionName, connectionType, credentials);
+      sinon.assert.calledOnceWithExactly(
+        createConnectionStub,
+        env,
+        connectionName,
+        connectionType,
+        credentials
+      );
       sinon.assert.calledOnceWithExactly(getDefaultBruinExecutablePathStub);
-      sinon.assert.calledOnceWithExactly(bruinWorkspaceDirectoryStub, lastRenderedDocumentUri.fsPath);
+      sinon.assert.calledOnceWithExactly(
+        bruinWorkspaceDirectoryStub,
+        lastRenderedDocumentUri.fsPath
+      );
     });
 
     test("should handle error when creating connection", async () => {
@@ -890,7 +947,13 @@ suite("Connection Management Tests", () => {
       createConnectionStub.rejects(new Error("Error creating connection"));
 
       try {
-        await createConnection(env, connectionName, connectionType, credentials, lastRenderedDocumentUri);
+        await createConnection(
+          env,
+          connectionName,
+          connectionType,
+          credentials,
+          lastRenderedDocumentUri
+        );
         assert.fail("Expected promise to be rejected");
       } catch (err: any) {
         assert.strictEqual(err.message, "Error creating connection");
@@ -1240,27 +1303,26 @@ suite("Bruin Connections Tests", () => {
   // BruinGetAllBruinConnections Tests
   test("BruinGetAllBruinConnections getConnectionsListFromSchema should return connections on success", async () => {
     const connections = {
-      "$schema":
+      $schema:
         "https://github.com/bruin-data/bruin/blob/main/integration-tests/expected_connections_schema.json",
-        "Connections": {
-          "properties": {
-            "aws": {
-              "items": {
-                "$ref": "#/$defs/AwsConnection"
-              },
-              "type": "array"
+      Connections: {
+        properties: {
+          aws: {
+            items: {
+              $ref: "#/$defs/AwsConnection",
             },
-            "google_cloud_platform": {
-              "items": {
-                "$ref": "#/$defs/GcpConnection"
-              },
-              "type": "array"
-            },
+            type: "array",
           },
-          "additionalProperties": false,
-          "type": "object"
+          google_cloud_platform: {
+            items: {
+              $ref: "#/$defs/GcpConnection",
+            },
+            type: "array",
+          },
         },
-    
+        additionalProperties: false,
+        type: "object",
+      },
     };
     const stdout = JSON.stringify(connections);
     execFileStub.yields(null, stdout, "");
@@ -1284,7 +1346,7 @@ suite("Bruin Connections Tests", () => {
   });
 });
 
-suite('BruinPanel Tests', () => {
+suite("BruinPanel Tests", () => {
   let windowCreateWebviewPanelStub: sinon.SinonStub;
   let windowActiveTextEditorStub: sinon.SinonStub;
   let workspaceWorkspaceFoldersStub: sinon.SinonStub;
@@ -1302,58 +1364,66 @@ suite('BruinPanel Tests', () => {
   let getConnectionsListFromSchemaStub: sinon.SinonStub;
   let deleteConnectionStub: sinon.SinonStub;
   let createConnectionStub: sinon.SinonStub;
-  const mockExtensionUri = vscode.Uri.file('/mock/extension/path');
-  const mockDocumentUri = vscode.Uri.file('/mock/document.sql');
+  const mockExtensionUri = vscode.Uri.file("/mock/extension/path");
+  const mockDocumentUri = vscode.Uri.file("/mock/document.sql");
 
   setup(() => {
     // Stub VSCode window and workspace methods
-    windowCreateWebviewPanelStub = sinon.stub(vscode.window, 'createWebviewPanel').returns({
+    windowCreateWebviewPanelStub = sinon.stub(vscode.window, "createWebviewPanel").returns({
       webview: {
         postMessage: sinon.stub(),
         onDidReceiveMessage: sinon.stub(),
-        html: '',
-        cspSource: 'default-src',
-        asWebviewUri: sinon.stub()
+        html: "",
+        cspSource: "default-src",
+        asWebviewUri: sinon.stub(),
       },
       iconPath: {},
       onDidDispose: sinon.stub(),
       dispose: sinon.stub(),
-      reveal: sinon.stub()
+      reveal: sinon.stub(),
     } as any);
 
-    windowActiveTextEditorStub = sinon.stub(vscode.window, 'activeTextEditor').value({
+    windowActiveTextEditorStub = sinon.stub(vscode.window, "activeTextEditor").value({
       document: {
         uri: mockDocumentUri,
-        fsPath: mockDocumentUri.fsPath
-      }
+        fsPath: mockDocumentUri.fsPath,
+      },
     });
 
-    workspaceWorkspaceFoldersStub = sinon.stub(vscode.workspace, 'workspaceFolders').value([
-      { uri: vscode.Uri.file('/mock/workspace') }
-    ]);
+    workspaceWorkspaceFoldersStub = sinon
+      .stub(vscode.workspace, "workspaceFolders")
+      .value([{ uri: vscode.Uri.file("/mock/workspace") }]);
 
-    pathExistsStub = sinon.stub(fs, 'existsSync').returns(true);
-    bruinWorkspaceDirectoryStub = sinon.stub(bruinUtils, 'bruinWorkspaceDirectory').resolves('/mock/workspace');
-    getCurrentPipelinePathStub = sinon.stub(bruinUtils, 'getCurrentPipelinePath').callsFake(async () => '/mock/pipeline.yml');
+    pathExistsStub = sinon.stub(fs, "existsSync").returns(true);
+    bruinWorkspaceDirectoryStub = sinon
+      .stub(bruinUtils, "bruinWorkspaceDirectory")
+      .resolves("/mock/workspace");
+    getCurrentPipelinePathStub = sinon
+      .stub(bruinUtils, "getCurrentPipelinePath")
+      .callsFake(async () => "/mock/pipeline.yml");
 
     // Stub BruinValidate
-    bruinValidateStub = sinon.stub(BruinValidate.prototype, 'validate');
-    parseAssetCommandStub = sinon.stub(BruinInternalParse.prototype, 'parseAsset');
-    patchAssetCommandStub = sinon.stub(BruinInternalPatch.prototype, 'patchAsset');
-    getConnectionsStub = sinon.stub(BruinConnections.prototype, 'getConnections');
-    getEnvListCommandStub = sinon.stub(BruinEnvList.prototype, 'getEnvironmentsList');
-    getConnectionsListFromSchemaStub = sinon.stub(BruinGetAllBruinConnections.prototype, 'getConnectionsListFromSchema').resolves();
-    deleteConnectionStub = sinon.stub(BruinDeleteConnection.prototype, 'deleteConnection');
-    createConnectionStub = sinon.stub(BruinCreateConnection.prototype, 'createConnection');
+    bruinValidateStub = sinon.stub(BruinValidate.prototype, "validate");
+    parseAssetCommandStub = sinon.stub(BruinInternalParse.prototype, "parseAsset");
+    patchAssetCommandStub = sinon.stub(BruinInternalPatch.prototype, "patchAsset");
+    getConnectionsStub = sinon.stub(BruinConnections.prototype, "getConnections");
+    getEnvListCommandStub = sinon.stub(BruinEnvList.prototype, "getEnvironmentsList");
+    getConnectionsListFromSchemaStub = sinon
+      .stub(BruinGetAllBruinConnections.prototype, "getConnectionsListFromSchema")
+      .resolves();
+    deleteConnectionStub = sinon.stub(BruinDeleteConnection.prototype, "deleteConnection");
+    createConnectionStub = sinon.stub(BruinCreateConnection.prototype, "createConnection");
     // Stub runInIntegratedTerminal
-    runInTerminalStub = sinon.stub(bruinUtils, 'runInIntegratedTerminal');
+    runInTerminalStub = sinon.stub(bruinUtils, "runInIntegratedTerminal");
 
     // Stub BruinInstallCLI
-    bruinInstallCliStub = sinon.stub(BruinInstallCLI.prototype, 'checkBruinCliInstallation').resolves({
-      installed: false,
-      isWindows: true,
-      gitAvailable: true
-    });
+    bruinInstallCliStub = sinon
+      .stub(BruinInstallCLI.prototype, "checkBruinCliInstallation")
+      .resolves({
+        installed: false,
+        isWindows: true,
+        gitAvailable: true,
+      });
   });
 
   teardown(() => {
@@ -1361,122 +1431,136 @@ suite('BruinPanel Tests', () => {
     BruinPanel.currentPanel = undefined;
   });
 
-  suite('Render Tests', () => {
-    test('creates a new webview panel if no current panel exists', () => {
+  suite("Render Tests", () => {
+    test("creates a new webview panel if no current panel exists", () => {
       BruinPanel.render(mockExtensionUri);
 
-      assert.ok(windowCreateWebviewPanelStub.calledOnce, 'Webview panel should be created');
-      assert.ok(BruinPanel.currentPanel, 'Current panel should be set');
+      assert.ok(windowCreateWebviewPanelStub.calledOnce, "Webview panel should be created");
+      assert.ok(BruinPanel.currentPanel, "Current panel should be set");
     });
 
-    test('reveals existing panel if already created', () => {
+    test("reveals existing panel if already created", () => {
       // First render creates the panel
       BruinPanel.render(mockExtensionUri);
       const firstPanel = BruinPanel.currentPanel;
 
       // Second render should reveal the existing panel
       BruinPanel.render(mockExtensionUri);
-      assert.strictEqual(BruinPanel.currentPanel, firstPanel, 'Should use existing panel');
+      assert.strictEqual(BruinPanel.currentPanel, firstPanel, "Should use existing panel");
     });
 
-    test('renders with non-existing extension URI', async () => {
-      const invalidUri = vscode.Uri.file('/invalid/path');      
+    test("renders with non-existing extension URI", async () => {
+      const invalidUri = vscode.Uri.file("/invalid/path");
       try {
         await BruinPanel.render(invalidUri);
-        assert.fail('Expected an error to be thrown');
+        assert.fail("Expected an error to be thrown");
       } catch (error) {
-        assert.ok(windowCreateWebviewPanelStub.calledOnce, 'Webview panel creation should have been attempted');
+        assert.ok(
+          windowCreateWebviewPanelStub.calledOnce,
+          "Webview panel creation should have been attempted"
+        );
       }
-      
+
       windowCreateWebviewPanelStub.restore();
     });
-    
-    test('handles multiple consecutive render calls', async () => {
+
+    test("handles multiple consecutive render calls", async () => {
       await BruinPanel.render(mockExtensionUri);
       const initialPanel = BruinPanel.currentPanel;
       await BruinPanel.render(mockExtensionUri);
-      assert.strictEqual(BruinPanel.currentPanel, initialPanel, 'Should use the same panel instance');
+      assert.strictEqual(
+        BruinPanel.currentPanel,
+        initialPanel,
+        "Should use the same panel instance"
+      );
     });
   });
 
-  suite('Message Handling', () => {
+  suite("Message Handling", () => {
     let panel: BruinPanel;
     let messageHandler: (message: any) => void;
     setup(() => {
       BruinPanel.render(mockExtensionUri);
       panel = BruinPanel.currentPanel!;
-      messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
+      messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
     });
 
-    test('handles unknown commands', async () => {
-      const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const unknownMessage = { command: 'unknownCommand' };
-      
+    test("handles unknown commands", async () => {
+      const messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
+      const unknownMessage = { command: "unknownCommand" };
+
       await messageHandler(unknownMessage);
       // Assert no error was thrown or expect a specific handling behavior (e.g., logging)
     });
 
-    test('validateCurrentPipeline with no active document', async () => {
+    test("validateCurrentPipeline with no active document", async () => {
       windowActiveTextEditorStub.value(undefined); // Simulate no active text editor
-      const message = { command: 'bruin.validateCurrentPipeline' };
-      
+      const message = { command: "bruin.validateCurrentPipeline" };
+
       await messageHandler(message);
-      const consoleErrorStub = sinon.stub(console, 'error');
-      assert.ok(consoleErrorStub.notCalled, 'No error should be logged');
+      const consoleErrorStub = sinon.stub(console, "error");
+      assert.ok(consoleErrorStub.notCalled, "No error should be logged");
       consoleErrorStub.restore();
     });
 
-    test('validateCurrentPipeline with pipeline file', async () => {
-      const message = { command: 'bruin.validateCurrentPipeline' };
+    test("validateCurrentPipeline with pipeline file", async () => {
+      const message = { command: "bruin.validateCurrentPipeline" };
       await messageHandler(message);
 
-      assert.ok(bruinValidateStub.calledOnce, 'Validate method should be called');
+      assert.ok(bruinValidateStub.calledOnce, "Validate method should be called");
     });
 
-    test('handles bruin.validateAll command', async () => {
+    test("handles bruin.validateAll command", async () => {
       const webviewPanel = windowCreateWebviewPanelStub.returnValues[0];
-      const messageHandler = (webviewPanel.webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const message = { command: 'bruin.validateAll' };
+      const messageHandler = (webviewPanel.webview.onDidReceiveMessage as sinon.SinonStub).firstCall
+        .args[0];
+      const message = { command: "bruin.validateAll" };
 
       await messageHandler(message);
 
-      assert.ok(bruinValidateStub.calledOnce, 'Validate method should be called');
+      assert.ok(bruinValidateStub.calledOnce, "Validate method should be called");
     });
-    
-    test('handles bruin.runSql command', async () => {
-      const message = { 
-        command: 'bruin.runSql', 
-        payload: { sqlCommand: 'SELECT * FROM users' } 
+
+    test("handles bruin.runSql command", async () => {
+      const message = {
+        command: "bruin.runSql",
+        payload: { sqlCommand: "SELECT * FROM users" },
       };
 
       await messageHandler(message);
 
-      assert.ok(runInTerminalStub.calledOnce, 'Run in terminal should be called');
-      assert.ok(bruinWorkspaceDirectoryStub.calledOnce, 'Workspace directory should be resolved');
+      assert.ok(runInTerminalStub.calledOnce, "Run in terminal should be called");
+      assert.ok(bruinWorkspaceDirectoryStub.calledOnce, "Workspace directory should be resolved");
     });
 
-    test('bruin.runSql error handling', async () => {
-      const message = { command: 'bruin.runSql', payload: { sqlCommand: 'SELECT * FROM users' } };
-      
+    test("bruin.runSql error handling", async () => {
+      const message = { command: "bruin.runSql", payload: { sqlCommand: "SELECT * FROM users" } };
+
       try {
         await messageHandler(message);
-        assert.fail('Expected an error to be thrown');
+        assert.fail("Expected an error to be thrown");
       } catch (error) {
-        assert.ok(runInTerminalStub.calledOnce, 'Terminal command should have been attempted');
+        assert.ok(runInTerminalStub.calledOnce, "Terminal command should have been attempted");
       }
-      
+
       runInTerminalStub.restore();
     });
 
-    test('handles checkBruinCliInstallation command', async () => {
-      const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const message = { command: 'checkBruinCliInstallation' };
+    test("handles checkBruinCliInstallation command", async () => {
+      const messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
+      const message = { command: "checkBruinCliInstallation" };
 
       await messageHandler(message);
 
-      assert.ok(bruinInstallCliStub.calledOnce, 'CLI installation check should be performed');
+      assert.ok(bruinInstallCliStub.calledOnce, "CLI installation check should be performed");
     });
-/*     test('handles bruin.getAssetLineage command', async () => {
+    /*     test('handles bruin.getAssetLineage command', async () => {
       const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
       const message = { command: 'bruin.getAssetLineage' };
   
@@ -1484,88 +1568,122 @@ suite('BruinPanel Tests', () => {
   
       assert.ok(lineageCommandStub.calledOnce, 'Lineage command should be called once');
     }); */
-  
-    test('handles bruin.getAssetDetails command', async () => {
-      const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const message = { command: 'bruin.getAssetDetails' };
-  
+
+    test("handles bruin.getAssetDetails command", async () => {
+      const messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
+      const message = { command: "bruin.getAssetDetails" };
+
       await messageHandler(message);
-  
-      assert.ok(parseAssetCommandStub.calledOnce, 'Parse asset command should be called once');
+
+      assert.ok(parseAssetCommandStub.calledOnce, "Parse asset command should be called once");
       parseAssetCommandStub.restore();
     });
-  
-    test('handles bruin.setAssetDetails command', async () => {
-      const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const message = { command: 'bruin.setAssetDetails', payload: { key: 'value' } };
-  
+
+    test("handles bruin.setAssetDetails command", async () => {
+      const messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
+      const message = { command: "bruin.setAssetDetails", payload: { key: "value" } };
+
       await messageHandler(message);
-  
-      assert.ok(patchAssetCommandStub.calledOnce, 'Patch asset command should be called once');
+
+      assert.ok(patchAssetCommandStub.calledOnce, "Patch asset command should be called once");
       patchAssetCommandStub.restore();
     });
-  
-    test('handles bruin.getEnvironmentsList command', async () => {
-      const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const message = { command: 'bruin.getEnvironmentsList' };
-  
+
+    test("handles bruin.getEnvironmentsList command", async () => {
+      const messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
+      const message = { command: "bruin.getEnvironmentsList" };
+
       await messageHandler(message);
-  
-      assert.ok(getEnvListCommandStub.calledOnce, 'Get environments list command should be called once');
+
+      assert.ok(
+        getEnvListCommandStub.calledOnce,
+        "Get environments list command should be called once"
+      );
       getEnvListCommandStub.restore();
     });
-  
-    test('handles bruin.getConnectionsList command', async () => {
-      const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const message = { command: 'bruin.getConnectionsList' };
-  
+
+    test("handles bruin.getConnectionsList command", async () => {
+      const messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
+      const message = { command: "bruin.getConnectionsList" };
+
       await messageHandler(message);
-  
-      assert.ok(getConnectionsStub.calledOnce, 'Get connections list command should be called once');
+
+      assert.ok(
+        getConnectionsStub.calledOnce,
+        "Get connections list command should be called once"
+      );
       getConnectionsStub.restore();
     });
-  
-    test('handles bruin.getConnectionsSchema command', async () => {
-      const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const message = { command: 'bruin.getConnectionsSchema' };
+
+    test("handles bruin.getConnectionsSchema command", async () => {
+      const messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
+      const message = { command: "bruin.getConnectionsSchema" };
       await messageHandler(message);
-  
-      assert.ok(getConnectionsListFromSchemaStub.calledOnce, 'Get connections schema command should be called once');
+
+      assert.ok(
+        getConnectionsListFromSchemaStub.calledOnce,
+        "Get connections schema command should be called once"
+      );
       getConnectionsListFromSchemaStub.restore();
     });
-  
-    test('handles bruin.editConnection command', async () => {
-      const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const message = { command: 'bruin.editConnection', payload: { oldConnection: {}, newConnection: {} } };
+
+    test("handles bruin.editConnection command", async () => {
+      const messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
+      const message = {
+        command: "bruin.editConnection",
+        payload: { oldConnection: {}, newConnection: {} },
+      };
       await messageHandler(message);
-  
-      assert.ok(deleteConnectionStub.calledOnce, 'Delete connection should be called once');
-      assert.ok(createConnectionStub.calledOnce, 'Create connection should be called once');
+
+      assert.ok(deleteConnectionStub.calledOnce, "Delete connection should be called once");
+      assert.ok(createConnectionStub.calledOnce, "Create connection should be called once");
       deleteConnectionStub.restore();
       createConnectionStub.restore();
     });
-  
-    test('handles bruin.deleteConnection command', async () => {
-      const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const message = { command: 'bruin.deleteConnection', payload: { name: 'test', environment: 'test' } };
-  
+
+    test("handles bruin.deleteConnection command", async () => {
+      const messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
+      const message = {
+        command: "bruin.deleteConnection",
+        payload: { name: "test", environment: "test" },
+      };
+
       await messageHandler(message);
-  
-      assert.ok(deleteConnectionStub.calledOnce, 'Delete connection should be called once');
+
+      assert.ok(deleteConnectionStub.calledOnce, "Delete connection should be called once");
       deleteConnectionStub.restore();
     });
-  
-    test('handles bruin.createConnection command', async () => {
-      const messageHandler = (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0];
-      const message = { command: 'bruin.createConnection', payload: { environment: 'test', name: 'test', type: 'test', credentials: {} } };
+
+    test("handles bruin.createConnection command", async () => {
+      const messageHandler = (
+        windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub
+      ).firstCall.args[0];
+      const message = {
+        command: "bruin.createConnection",
+        payload: { environment: "test", name: "test", type: "test", credentials: {} },
+      };
       await messageHandler(message);
-  
-      assert.ok(createConnectionStub.calledOnce, 'Create connection should be called once');
+
+      assert.ok(createConnectionStub.calledOnce, "Create connection should be called once");
       createConnectionStub.restore();
     });
   });
 
-  suite('Checkbox and Flags Tests', () => {
+  suite("Checkbox and Flags Tests", () => {
     let panel: BruinPanel;
 
     setup(() => {
@@ -1573,45 +1691,319 @@ suite('BruinPanel Tests', () => {
       panel = BruinPanel.currentPanel!;
     });
 
-    test('getCheckboxFlags returns correct flags', () => {
+    test("getCheckboxFlags returns correct flags", () => {
       // Simulate checkbox state
       (panel as any)._checkboxState = {
-        'verbose': true,
-        'debug': false,
-        'trace': true
+        verbose: true,
+        debug: false,
+        trace: true,
       };
 
       const flags = panel.getCheckboxFlags();
-      assert.strictEqual(flags, '--verbose --trace', 'Should return only checked flags');
+      assert.strictEqual(flags, "--verbose --trace", "Should return only checked flags");
     });
- 
   });
 
-  suite('Dispose Tests', () => {
-    test('properly disposes of panel and resources', () => {
+  suite("Dispose Tests", () => {
+    test("properly disposes of panel and resources", () => {
       BruinPanel.render(mockExtensionUri);
       const panel = BruinPanel.currentPanel!;
 
       panel.dispose();
 
-      assert.strictEqual(BruinPanel.currentPanel, undefined, 'Current panel should be undefined');
+      assert.strictEqual(BruinPanel.currentPanel, undefined, "Current panel should be undefined");
       assert.ok(
-        windowCreateWebviewPanelStub.returnValues[0].dispose.calledOnce, 
-        'Panel should be disposed'
+        windowCreateWebviewPanelStub.returnValues[0].dispose.calledOnce,
+        "Panel should be disposed"
       );
     });
-    test('double dispose', () => {
+    test("double dispose", () => {
       const panel = BruinPanel.currentPanel;
       if (panel) {
         panel.dispose();
         panel.dispose(); // Second dispose should not throw
-        assert.ok(true, 'No error was thrown on double dispose');
+        assert.ok(true, "No error was thrown on double dispose");
       }
     });
-    
-    test('dispose with no current panel', () => {
+
+    test("dispose with no current panel", () => {
       BruinPanel.currentPanel = undefined;
-      assert.ok(true, 'An error was thrown when disposing without a panel');
+      assert.ok(true, "An error was thrown when disposing without a panel");
     });
   });
+});
+suite("getLanguageDelimiters Tests", () => {
+  test("should return default delimiters for unknown language", () => {
+    const languageId = "unknown";
+    const { startFoldingRegionDelimiter, endFoldingRegionDelimiter } =
+      getLanguageDelimiters(languageId);
+
+    assert.strictEqual(
+      startFoldingRegionDelimiter.toString(),
+      "/$^/",
+      "Expected default start delimiter"
+    );
+    assert.strictEqual(
+      endFoldingRegionDelimiter.toString(),
+      "/$^/",
+      "Expected default end delimiter"
+    );
+  });
+
+  test("should return Python delimiters for Python language", () => {
+    const languageId = "python";
+    const { startFoldingRegionDelimiter, endFoldingRegionDelimiter } =
+      getLanguageDelimiters(languageId);
+    const expectedStartDelimiter = bruinDelimiterRegex.pyStartDelimiter.toString();
+    const expectedEndDelimiter = bruinDelimiterRegex.pyEndDelimiter.toString();
+
+    assert.strictEqual(
+      startFoldingRegionDelimiter.toString(),
+      expectedStartDelimiter,
+      "Expected Python start delimiter"
+    );
+    assert.strictEqual(
+      endFoldingRegionDelimiter.toString(),
+      expectedEndDelimiter,
+      "Expected Python end delimiter"
+    );
+  });
+
+  test("should return SQL delimiters for SQL language", () => {
+    const languageId = "sql";
+    const { startFoldingRegionDelimiter, endFoldingRegionDelimiter } =
+      getLanguageDelimiters(languageId);
+    const expectedStartDelimiter = bruinDelimiterRegex.sqlStartDelimiter.toString();
+    const expectedEndDelimiter = bruinDelimiterRegex.sqlEndDelimiter.toString();
+
+    assert.strictEqual(
+      startFoldingRegionDelimiter.toString(),
+      expectedStartDelimiter,
+      "Expected SQL start delimiter"
+    );
+    assert.strictEqual(
+      endFoldingRegionDelimiter.toString(),
+      expectedEndDelimiter,
+      "Expected SQL end delimiter"
+    );
+  });
+
+  test("should return default delimiters for language ID with different casing", () => {
+    const languageId = "PYTHON";
+    const { startFoldingRegionDelimiter, endFoldingRegionDelimiter } =
+      getLanguageDelimiters(languageId);
+    const expectedStartDelimiter = bruinDelimiterRegex.pyStartDelimiter.toString();
+    const expectedEndDelimiter = bruinDelimiterRegex.pyEndDelimiter.toString();
+    assert.strictEqual(
+      startFoldingRegionDelimiter.toString(),
+      "/$^/",
+      "Expected default start delimiter"
+    );
+    assert.strictEqual(
+      endFoldingRegionDelimiter.toString(),
+      "/$^/",
+      "Expected default end delimiter"
+    );
+  });
+
+  test("should return default delimiters for empty language ID", () => {
+    const languageId = "";
+    const { startFoldingRegionDelimiter, endFoldingRegionDelimiter } =
+      getLanguageDelimiters(languageId);
+
+    assert.strictEqual(
+      startFoldingRegionDelimiter.toString(),
+      "/$^/",
+      "Expected default start delimiter"
+    );
+    assert.strictEqual(
+      endFoldingRegionDelimiter.toString(),
+      "/$^/",
+      "Expected default end delimiter"
+    );
+  });
+
+  test("should return default delimiters for null language ID", () => {
+    const languageId = null as unknown as string;
+    const { startFoldingRegionDelimiter, endFoldingRegionDelimiter } =
+      getLanguageDelimiters(languageId);
+
+    assert.strictEqual(
+      startFoldingRegionDelimiter.toString(),
+      "/$^/",
+      "Expected default start delimiter"
+    );
+    assert.strictEqual(
+      endFoldingRegionDelimiter.toString(),
+      "/$^/",
+      "Expected default end delimiter"
+    );
+  });
+
+  test("should return default delimiters for undefined language ID", () => {
+    const languageId = undefined as unknown as string;
+    const { startFoldingRegionDelimiter, endFoldingRegionDelimiter } =
+      getLanguageDelimiters(languageId);
+
+    assert.strictEqual(
+      startFoldingRegionDelimiter.toString(),
+      "/$^/",
+      "Expected default start delimiter"
+    );
+    assert.strictEqual(
+      endFoldingRegionDelimiter.toString(),
+      "/$^/",
+      "Expected default end delimiter"
+    );
+  });
+});
+suite("bruinFoldingRangeProvider Tests", () => {
+  let document: vscode.TextDocument;
+  let getLanguageDelimitersStub: sinon.SinonStub<
+    [languageId: string],
+    { startFoldingRegionDelimiter: RegExp; endFoldingRegionDelimiter: RegExp }
+  >;
+  setup(() => {
+    document = {
+      languageId: "python",
+      lineCount: 10,
+      lineAt: (lineNumber: number) => {
+        return {
+          text: `Line ${lineNumber}`,
+        };
+      },
+    } as any;
+
+    getLanguageDelimitersStub = sinon.stub<[string], { startFoldingRegionDelimiter: RegExp; endFoldingRegionDelimiter: RegExp }>().returns({
+      startFoldingRegionDelimiter: /$^/,
+      endFoldingRegionDelimiter: /$^/,
+    });
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test("should return empty ranges for unknown language", () => {
+    const ranges = bruinFoldingRangeProvider(document);
+    assert.deepStrictEqual(ranges, [], "Expected empty ranges");
+  });
+
+
+  test("should return empty ranges when no end delimiter is found", () => {
+    const { startFoldingRegionDelimiter, endFoldingRegionDelimiter } =
+    getLanguageDelimiters("python");
+    getLanguageDelimitersStub = sinon.stub<[string], { startFoldingRegionDelimiter: RegExp; endFoldingRegionDelimiter: RegExp }>().returns({
+      startFoldingRegionDelimiter: startFoldingRegionDelimiter,
+      endFoldingRegionDelimiter: /$^/,
+    });
+
+    (document as any).lineAt = (lineNumber: number) => {
+      switch (lineNumber) {
+        case 0:
+          return { text: startFoldingRegionDelimiter };
+        default:
+          return { text: `Line ${lineNumber}` };
+      }
+    };
+
+    const ranges = bruinFoldingRangeProvider(document);
+
+    assert.deepStrictEqual(ranges, [], "Expected empty ranges");
+  });
+
+  test("should return empty ranges when no start delimiter is found", () => {
+    const { startFoldingRegionDelimiter, endFoldingRegionDelimiter } =
+    getLanguageDelimiters("python");    getLanguageDelimitersStub = sinon.stub<[string], { startFoldingRegionDelimiter: RegExp; endFoldingRegionDelimiter: RegExp }>().returns({
+      startFoldingRegionDelimiter: /$^/,
+      endFoldingRegionDelimiter: endFoldingRegionDelimiter,
+    });
+
+    (document as any).lineAt = (lineNumber: number) => {
+      switch (lineNumber) {
+        case 0:
+          return { text: endFoldingRegionDelimiter };
+        default:
+          return { text: `Line ${lineNumber}` };
+      }
+    };
+
+    const ranges = bruinFoldingRangeProvider(document);
+
+    assert.deepStrictEqual(ranges, [], "Expected empty ranges");
+  });
+});
+
+suite("Activate Tests", () => {
+  let context: vscode.ExtensionContext;
+  let setupFoldingOnOpenStub: sinon.SinonStub;
+  let subscribeToConfigurationChangesStub: sinon.SinonStub;
+  let getDefaultBruinExecutablePathStub: sinon.SinonStub;
+  let vscodeWindowActiveTextEditorStub: sinon.SinonStub;
+  let vscodeCommandsExecuteCommandStub: sinon.SinonStub;
+  let vscodeLanguagesRegisterFoldingRangeProviderStub: sinon.SinonStub;
+  let vscodeWindowRegisterWebviewViewProviderStub: sinon.SinonStub;
+
+  setup(() => {
+    context = {
+      extensionUri: vscode.Uri.file(""),
+      subscriptions: [],
+    } as any;
+    setupFoldingOnOpenStub = sinon.stub(configuration, "setupFoldingOnOpen");
+    subscribeToConfigurationChangesStub = sinon.stub(
+      configuration,
+      "subscribeToConfigurationChanges"
+    );
+    getDefaultBruinExecutablePathStub = sinon.stub(configuration, "getDefaultBruinExecutablePath");
+    vscodeWindowActiveTextEditorStub = sinon.stub(vscode.window, "activeTextEditor").value(null);
+    vscodeCommandsExecuteCommandStub = sinon.stub(vscode.commands, "executeCommand");
+    vscodeLanguagesRegisterFoldingRangeProviderStub = sinon.stub(
+      vscode.languages,
+      "registerFoldingRangeProvider"
+    );
+    vscodeWindowRegisterWebviewViewProviderStub = sinon.stub(
+      vscode.window,
+      "registerWebviewViewProvider"
+    );
+  });
+
+  teardown(() => {
+    setupFoldingOnOpenStub.restore();
+    subscribeToConfigurationChangesStub.restore();
+    getDefaultBruinExecutablePathStub.restore();
+    vscodeWindowActiveTextEditorStub.restore();
+    vscodeCommandsExecuteCommandStub.restore();
+    vscodeLanguagesRegisterFoldingRangeProviderStub.restore();
+    vscodeWindowRegisterWebviewViewProviderStub.restore();
+  });
+
+  test("should focus active editor on activation", async () => {
+    const activeTextEditor = {
+      document: {
+        uri: vscode.Uri.file("file:///example.py"),
+      },
+    };
+    vscodeWindowActiveTextEditorStub.value(activeTextEditor);
+
+    await activate(context);
+
+    assert.ok(vscodeCommandsExecuteCommandStub.calledOnce, "Expected command to be executed");
+    assert.strictEqual(
+      vscodeCommandsExecuteCommandStub.firstCall.args[0],
+      "workbench.action.focusActiveEditorGroup",
+      "Expected focus active editor group command"
+    );
+  });
+
+  /*   test('should setup folding on open', async () => {
+    await activate(context);
+
+    assert.ok(setupFoldingOnOpenStub.calledOnce, 'Expected setupFoldingOnOpen to be called');
+  });
+
+  test('should subscribe to configuration changes', async () => {
+    await activate(context);
+
+    assert.ok(subscribeToConfigurationChangesStub.calledOnce, 'Expected subscribeToConfigurationChanges to be called');
+  }); */
 });


### PR DESCRIPTION
# PR Overview

This PR introduces unit tests for various functionalities:
- Language Delimiters and Folding: Tests language-specific delimiters and folding behavior to confirm accurate handling and parsing.
- Bruin Utils: Adds unit tests to cover more utility functions used in the Bruin commands.