### PR TITLE
Enable Asset Name and Type Editing and Add Documentation Link

### DIFF
--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -417,6 +417,7 @@ export class BruinPanel {
               message: this._lastRenderedDocumentUri?.fsPath,
             });
             break;
+
           case "bruin.editConnection":
             const { oldConnection, newConnection } = message.payload;
             try {
@@ -467,6 +468,9 @@ export class BruinPanel {
             await getConnections(this._lastRenderedDocumentUri);
             break;
 
+          case "bruin.openDocumentationLink":
+            vscode.env.openExternal(vscode.Uri.parse(message.payload));
+            break;
         }
       },
       undefined,

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -6,7 +6,7 @@
         <vscode-button
           appearance="icon"
           @click="toggleEditMode"
-          class="text-sm font-semibold"
+          class="text-xs"
           :title="isEditMode ? 'Preview Mode' : 'Edit Mode'"
         >
           <component :is="isEditMode ? EyeIcon : PencilIcon" class="h-4 w-4 text-editor-fg" />
@@ -15,14 +15,14 @@
           appearance="icon"
           @click="openBruinDocumentation"
           title="Bruin Documentation"
-          class="text-sm font-semibold group relative"
+          class="text-xs group relative"
         >
           <QuestionMarkCircleIcon class="h-4 w-4 text-editor-fg" />
         </vscode-button>
       </div>
 
       <div class="">
-        <div class="flex items-center space-x-2 w-full justify-between pt-2">
+        <div class="flex items-center space-x-2 w-full justify-between">
           <!-- Name editing -->
           <div class="flex items-baseline w-3/4 font-md text-editor-fg text-lg font-mono">
             <div class="pipeline-name max-w-[40%] text-xs opacity-50 truncate inline-block">
@@ -128,8 +128,7 @@ import CustomChecks from "@/components/asset/columns/custom-checks/CustomChecks.
 import BruinSettings from "@/components/bruin-settings/BruinSettings.vue";
 import DescriptionItem from "./components/ui/description-item/DescriptionItem.vue";
 import { badgeStyles, defaultBadgeStyle } from "./components/ui/badges/CustomBadgesStyle";
-import { PencilIcon, CheckIcon, XMarkIcon } from "@heroicons/vue/24/outline";
-import { EyeIcon } from "@heroicons/vue/20/solid";
+import { PencilIcon, EyeIcon } from "@heroicons/vue/24/outline";
 import { QuestionMarkCircleIcon } from "@heroicons/vue/24/solid";
 
 const connectionsStore = useConnectionsStore();
@@ -276,9 +275,12 @@ const saveTypeEdit = () => {
   }
 };
 
-const openBruinDocumentation = () => {
-  vscode.postMessage({ command: "openBruinDocumentation" });
-};
+  const openBruinDocumentation = () => {
+  vscode.postMessage({
+    command: "bruin.openDocumentationLink",
+    payload: "https://bruin-data.github.io/bruin/"
+  });
+  };
 // Computed property for asset columns
 const columnsProps = computed(() => {
   if (!data.value) return [];

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -233,12 +233,7 @@ const focusName = () => {
     nameInput.value?.focus();
   });
 };
-const openBruinDocumentation = () => {
-  vscode.postMessage({
-    command: "bruin.openDocumentationLink",
-    payload: "https://bruin-data.github.io/bruin/",
-  });
-};
+
 // Computed property for asset columns
 const columnsProps = computed(() => {
   if (!data.value) return [];

--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -3,11 +3,35 @@
     <div v-if="props !== null" class="flex flex-col text-editor-fg bg-editor-bg w-full">
       <div class="relative">
         <div
-          ref="descriptionRef"
-          class="text-xs text-editor-fg opacity-65 prose prose-sm max-w-none"
+          @mouseenter="showEditButton = true"
+          @mouseleave="!isEditingDescription ? (showEditButton = false) : null"
           :class="{ 'max-h-40 overflow-hidden': shouldTruncate && !isExpanded }"
-          v-html="markdownDescription"
-        ></div>
+        >
+          <div
+            v-if="!isEditingDescription"
+            ref="descriptionRef"
+            class="text-xs text-editor-fg opacity-65 prose prose-sm max-w-none"
+            :class="{ 'max-h-40 overflow-hidden': shouldTruncate && !isExpanded }"
+            v-html="markdownDescription"
+          ></div>
+
+          <vscode-button
+            v-if="!isEditingDescription && showEditButton"
+            appearance="icon"
+            @click.stop="startEditingDescription"
+            class="absolute top-0 right-0 mt-1 mr-1"
+          >
+            <PencilIcon class="h-4 w-4" aria-hidden="true" />
+          </vscode-button>
+          <textarea
+            v-if="isEditingDescription"
+            v-model="editableDescription"
+            class="w-full h-40 bg-input-background border-0 text-input-foreground text-xs"
+            ref="descriptionInput"
+            @blur="saveDescriptionEdit"
+            :class="{ 'truncate-description': shouldTruncate && !isExpanded }"
+          ></textarea>
+        </div>
 
         <button
           v-if="shouldShowButton"
@@ -46,7 +70,7 @@ import MessageAlert from "@/components/ui/alerts/AlertMessage.vue";
 import MarkdownIt from "markdown-it";
 import AssetGeneral from "./AssetGeneral.vue";
 import { vscode } from "@/utilities/vscode";
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/vue/20/solid";
+import {  ChevronDownIcon, ChevronUpIcon, PencilIcon } from "@heroicons/vue/20/solid";
 
 const props = defineProps<{
   name: string;
@@ -63,6 +87,10 @@ const descriptionRef = ref<HTMLElement | null>(null);
 const isExpanded = ref(false);
 const contentHeight = ref(0);
 const maxHeight = 160; // 40px * 4 lines
+const editableDescription = ref(props.description);
+const isEditingDescription = ref(false);
+const showEditButton = ref(false);
+const descriptionInput = ref<HTMLTextAreaElement | null>(null);
 
 // Update content height measurement
 const updateContentHeight = async () => {
@@ -100,6 +128,25 @@ onMounted(async () => {
   }
 });
 
+
+// Functions for editing description
+const startEditingDescription = () => {
+  isEditingDescription.value = true;
+  showEditButton.value = false; // Hide button in edit mode
+  nextTick(() => {
+    descriptionInput.value?.focus();
+  });
+};
+const emit = defineEmits(["update:description"]);
+const saveDescriptionEdit = () => {
+  if (editableDescription.value.trim() !== props.description) {
+    emit("update:description", editableDescription.value.trim());
+    console.log("Updating description:", editableDescription.value.trim());
+  }
+  isEditingDescription.value = false;
+  showEditButton.value = true; // Show button again after edit mode
+};
+
 // Watch for description changes and update height
 watch(
   () => props.description,
@@ -135,8 +182,6 @@ const markdownDescription = computed(() => {
 });
 
 // State for description editing
-const editableDescription = ref(props.description);
-
 watch(
   () => props.description,
   (newDescription) => {

--- a/webview-ui/src/components/bruin-settings/BruinCLI.vue
+++ b/webview-ui/src/components/bruin-settings/BruinCLI.vue
@@ -13,12 +13,20 @@
           }}
         </p>
       </div>
-      <div class="mt-5">
+      <div class="flex items-center justify-between mt-5">
         <vscode-button
           @click="installOrUpdateBruinCli"
           class="inline-flex items-center rounded-md px-3 py-2 text-lg font-semibold shadow-sm"
         >
           {{ isBruinCliInstalled ? "Update" : "Install" }} Bruin CLI
+        </vscode-button>
+        <vscode-button
+          appearance="icon"
+          @click="openBruinDocumentation"
+          title="Bruin Documentation"
+          class="text-md font-semibold"
+        >
+          <QuestionMarkCircleIcon class="h-5 w-5 text-editor-fg" />
         </vscode-button>
       </div>
     </div>
@@ -28,6 +36,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
 import { vscode } from "@/utilities/vscode";
+import { QuestionMarkCircleIcon } from "@heroicons/vue/20/solid";
 
 const isBruinCliInstalled = ref(false);
 const isWindows = ref(false);
@@ -46,6 +55,12 @@ onMounted(() => {
   });
 });
 
+const openBruinDocumentation = () => {
+  vscode.postMessage({
+    command: "bruin.openDocumentationLink",
+    payload: "https://bruin-data.github.io/bruin/",
+  });
+};
 function checkBruinCliInstallation() {
   vscode.postMessage({ command: "checkBruinCliInstallation" });
 }


### PR DESCRIPTION
# PR Overview

This PR introduces the following features:
- _Edit Name_: Enables asset name editing directly in the UI.
- _Edit Description_: Enables asset description editing.
- _Documentation Link_: Adds a clickable link to access Bruin documentation from the UI.

### Documentation Link

![documentation-link](https://github.com/user-attachments/assets/9f8c943b-ad55-4e67-9b7e-b0628062e639)


### Edit Name and Description
![name-description-update](https://github.com/user-attachments/assets/75592c13-6e5d-4180-8b24-a8c535cf1b6c)
