### PR TITLE
Refactor Date Handling and DateInput Components to Support UTC

### DIFF
--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -162,8 +162,7 @@
                   <div class="p-1 bg-editorWidget-bg rounded-sm border border-commandCenter-border">
                     <MenuItem key="run-with-downstream" v-slot="{ active }">
                       <vscode-button
-                        class="block text-editor-fg rounded-sm w-full text-left text-2xs hover:bg-editor-button-hover-bg 
-                        hover:text-editor-button-fg bg-editorWidget-bg"
+                        class="block text-editor-fg rounded-sm w-full text-left text-2xs hover:bg-editor-button-hover-bg hover:text-editor-button-fg bg-editorWidget-bg"
                         @click="runAssetWithDownstream"
                       >
                         Run with downstream
@@ -362,9 +361,7 @@ const selectedEnv = ref<string>("");
 /**
  * Date state
  */
-const timezone = new Date().getTimezoneOffset();
-const today = new Date(Date.now() - timezone * 60000);
-
+const today = new Date(Date.now());
 const startDate = ref(
   new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate() - 1, 0, 0, 0, 0))
     .toISOString()
@@ -376,7 +373,6 @@ const endDate = ref(
     .toISOString()
     .slice(0, -1)
 );
-
 const endDateExclusive = ref("");
 
 watch(

--- a/webview-ui/src/components/ui/date-inputs/DateInput.vue
+++ b/webview-ui/src/components/ui/date-inputs/DateInput.vue
@@ -1,21 +1,24 @@
 <template>
   <div class="flex flex-col w-full xs:w-32">
-    <label class="text-xs mb-1 font-medium">{{ label }}</label>
+    <label class="text-xs mb-1 font-medium">{{ label }}
+      <span class="text-3xs italic font-mono opacity-65 text-editor-fg">(UTC)</span>
+    </label>
     <div class="relative">
       <input
         type="datetime-local"
         class="w-full text-2xs px-1 border-0 py-0.5 bg-dropdown-bg"
-        :value="modelValue"
+        :value="displayValue"
         @input="updateValue($event)"
       />
-   </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineEmits } from "vue";
+import { defineProps, defineEmits, computed } from "vue";
+import { DateTime } from "luxon";
 
-defineProps({
+const props = defineProps({
   label: String,
   modelValue: {
     type: String,
@@ -25,12 +28,28 @@ defineProps({
 
 const emit = defineEmits(["update:modelValue"]);
 
+// Convert the modelValue (assumed to be in UTC) to a format suitable for display in a datetime-local input
+// The datetime-local input always expects a value in the format 'YYYY-MM-DDTHH:mm' without timezone info
+const displayValue = computed(() => {
+  const dt = DateTime.fromISO(props.modelValue, { zone: "utc" });
+  return dt.toFormat("yyyy-MM-dd'T'HH:mm");
+});
+
 const updateValue = (event: Event) => {
-  emit("update:modelValue", (event.target as HTMLInputElement).value);
+  const input = event.target as HTMLInputElement;
+  // Get the selected datetime in local timezone
+  const localDt = DateTime.fromISO(input.value);
+  
+  // Convert the local datetime to UTC
+  const utcDt = localDt.toUTC();
+  
+  // Emit the UTC datetime in ISO format
+  emit("update:modelValue", utcDt.toISO());
 };
 </script>
 
 <style scoped>
+/* Your styles remain the same */
 input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   opacity: 0;
   position: absolute;

--- a/webview-ui/src/components/ui/date-inputs/DateInput.vue
+++ b/webview-ui/src/components/ui/date-inputs/DateInput.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="flex flex-col w-full xs:w-32">
-    <label class="text-xs mb-1 font-medium">{{ label }}</label>
+    <label class="text-xs mb-1 font-medium">{{ label }}
+      <span class="text-3xs italic font-mono opacity-65 text-editor-fg">(UTC)</span>
+    </label>
     <div class="relative">
       <input
         type="datetime-local"

--- a/webview-ui/src/components/ui/date-inputs/DateInput.vue
+++ b/webview-ui/src/components/ui/date-inputs/DateInput.vue
@@ -1,14 +1,12 @@
 <template>
   <div class="flex flex-col w-full xs:w-32">
-    <label class="text-xs mb-1 font-medium">{{ label }}
-      <span class="text-3xs italic font-mono opacity-65 text-editor-fg">(UTC)</span>
-    </label>
+    <label class="text-xs mb-1 font-medium">{{ label }}</label>
     <div class="relative">
       <input
         type="datetime-local"
         class="w-full text-2xs px-1 border-0 py-0.5 bg-dropdown-bg"
-        :value="displayValue"
-        @input="updateValue($event)"
+        :value="utcModelValue"
+        @input="updateValue"
       />
     </div>
   </div>
@@ -28,21 +26,16 @@ const props = defineProps({
 
 const emit = defineEmits(["update:modelValue"]);
 
-// Convert the modelValue (assumed to be in UTC) to a format suitable for display in a datetime-local input
-// The datetime-local input always expects a value in the format 'YYYY-MM-DDTHH:mm' without timezone info
-const displayValue = computed(() => {
+// Treat the modelValue as UTC for display
+const utcModelValue = computed(() => {
   const dt = DateTime.fromISO(props.modelValue, { zone: "utc" });
   return dt.toFormat("yyyy-MM-dd'T'HH:mm");
 });
 
 const updateValue = (event: Event) => {
   const input = event.target as HTMLInputElement;
-  // Get the selected datetime in local timezone
-  const localDt = DateTime.fromISO(input.value);
-  
-  // Convert the local datetime to UTC
-  const utcDt = localDt.toUTC();
-  
+  // Treat the input value as UTC without converting
+  const utcDt = DateTime.fromISO(input.value, { zone: "utc" });
   // Emit the UTC datetime in ISO format
   emit("update:modelValue", utcDt.toISO());
 };

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -14,9 +14,7 @@ import {
   processAssetDependencies,
 } from "../utilities/getPipelineLineage";
 import * as pipelineData from "../utilities/pipeline.json";
-import AssetDetails from "../components/asset/AssetDetails.vue";
-import { mount } from '@vue/test-utils'
-import MarkdownIt from "markdown-it";
+
 
 vi.mock("markdown-it");
 
@@ -231,8 +229,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "hourly" schedule', () => {
     schedule = "hourly";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-07-08T04:00:00.000");
-    assert.strictEqual(endDate.value, "2024-07-08T05:00:00.000");
+    assert.strictEqual(startDate.value, "2024-07-08T04:00:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-08T05:00:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-07-08T04:59:59.999999999Z");
@@ -240,8 +238,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "daily" schedule', () => {
     schedule = "daily";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-07-07T00:00:00.000");
-    assert.strictEqual(endDate.value, "2024-07-08T00:00:00.000");
+    assert.strictEqual(startDate.value, "2024-07-07T00:00:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-08T00:00:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-07-07T23:59:59.999999999Z");
@@ -250,8 +248,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "weekly" schedule', () => {
     schedule = "weekly";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-07-01T00:00:00.000");
-    assert.strictEqual(endDate.value, "2024-07-08T00:00:00.000");
+    assert.strictEqual(startDate.value, "2024-07-01T00:00:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-08T00:00:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-07-07T23:59:59.999999999Z");
@@ -260,8 +258,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "monthly" schedule', () => {
     schedule = "monthly";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-06-01T00:00:00.000");
-    assert.strictEqual(endDate.value, "2024-07-01T00:00:00.000");
+    assert.strictEqual(startDate.value, "2024-06-01T00:00:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-01T00:00:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-06-30T23:59:59.999999999Z");
@@ -270,8 +268,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "2 17 * * *"', () => {
     schedule = "2 17 * * *";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-07-06T17:02:00.000");
-    assert.strictEqual(endDate.value, "2024-07-07T17:02:00.000");
+    assert.strictEqual(startDate.value, "2024-07-06T17:02:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-07T17:02:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-07-07T17:01:59.999999999Z");
@@ -280,8 +278,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "30 17 * * *"', () => {
     schedule = "30 17 * * *";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-07-06T17:30:00.000");
-    assert.strictEqual(endDate.value, "2024-07-07T17:30:00.000");
+    assert.strictEqual(startDate.value, "2024-07-06T17:30:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-07T17:30:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-07-07T17:29:59.999999999Z");
@@ -290,8 +288,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "0 18 * * *"', () => {
     schedule = "0 18 * * *";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-07-06T18:00:00.000");
-    assert.strictEqual(endDate.value, "2024-07-07T18:00:00.000");
+    assert.strictEqual(startDate.value, "2024-07-06T18:00:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-07T18:00:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-07-07T17:59:59.999999999Z");
@@ -300,8 +298,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "2 * * * *"', () => {
     schedule = "2 * * * *";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-07-08T04:02:00.000");
-    assert.strictEqual(endDate.value, "2024-07-08T05:02:00.000");
+    assert.strictEqual(startDate.value, "2024-07-08T04:02:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-08T05:02:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-07-08T05:01:59.999999999Z");
@@ -310,8 +308,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "0 19 * 6 *"', () => {
     schedule = "0 19 * 6 *"; // June
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-06-29T19:00:00.000");
-    assert.strictEqual(endDate.value, "2024-06-30T19:00:00.000");
+    assert.strictEqual(startDate.value, "2024-06-29T19:00:00.000Z");
+    assert.strictEqual(endDate.value, "2024-06-30T19:00:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-06-30T18:59:59.999999999Z");
@@ -320,8 +318,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "0 20 * * 1-5"', () => {
     schedule = "0 20 * * 1-5"; // Weekdays (Monday to Friday)
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-07-04T20:00:00.000");
-    assert.strictEqual(endDate.value, "2024-07-05T20:00:00.000");
+    assert.strictEqual(startDate.value, "2024-07-04T20:00:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-05T20:00:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-07-05T19:59:59.999999999Z");
@@ -330,8 +328,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "0 20 * * 6,7"', () => {
     schedule = "0 20 * * 6,7"; // Saturday and Sunday
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-07-06T20:00:00.000");
-    assert.strictEqual(endDate.value, "2024-07-07T20:00:00.000");
+    assert.strictEqual(startDate.value, "2024-07-06T20:00:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-07T20:00:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2024-07-07T19:59:59.999999999Z");
@@ -340,8 +338,8 @@ suite("testing webview", () => {
   test('test reset Start End Date for "0 20 10 7 *"', () => {
     schedule = "0 20 10 7 *"; // July 10th
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2022-07-10T20:00:00.000");
-    assert.strictEqual(endDate.value, "2023-07-10T20:00:00.000");
+    assert.strictEqual(startDate.value, "2022-07-10T20:00:00.000Z");
+    assert.strictEqual(endDate.value, "2023-07-10T20:00:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
     assert.strictEqual(endDateExclusive, "2023-07-10T19:59:59.999999999Z");

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -1,7 +1,6 @@
 import type { CheckboxItems } from "@/types";
 import { DateTime } from "luxon";
 import * as cronParser from "cron-parser";
-
 const isExclusiveChecked = (checkboxesItems: CheckboxItems[]): boolean => {
   return checkboxesItems.some((item) => item.name === "Exclusive-End-Date" && item.checked);
 };
@@ -161,8 +160,9 @@ export const resetStartEndDate = (schedule: string, today: number, startDate: { 
   console.log("start date:", startDate.value, "end date:", endDate.value);
   console.log("today", today, "start time:", startTime, "end time:", endTime);
 
-  startDate.value = new Date(startTime).toISOString().slice(0, -1);
-  endDate.value = new Date(endTime).toISOString().slice(0, -1);
+  startDate.value = DateTime.fromMillis(startTime).toUTC().toISO({ includeMillis: false });
+  endDate.value = DateTime.fromMillis(endTime).toUTC().toISO({ includeMillis: false });
+  
   console.log("start:", startDate.value, "end:", endDate.value);
 };
 

--- a/webview-ui/tailwind.config.js
+++ b/webview-ui/tailwind.config.js
@@ -66,6 +66,7 @@ module.exports = {
       }),
       fontSize: {
         "2xs": ["0.75rem", { lineHeight: "1rem" }],
+        "3xs": ["0.7rem", { lineHeight: "1rem" }],
       },
       colors: {
         "border": "hsl(var(--border))",


### PR DESCRIPTION
# PR Overview

This PR refactors date handling in AssetGeneral and DateInput components to use UTC instead of local time.