### PR TITLE
Enable Telemetry Data Collection by Default and Remove Consent Prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Bruin extension will be documented in this file.
 
+## [0.30.1] - [2024-12-12]
+- Enabled telemetry by default to improve performance monitoring and user experience.
+
 ## [0.30.0] - [2024-12-12]
 - Integrated RudderStack analytics to monitor extension performance, with support for user-controlled telemetry preferences.
 

--- a/README.md
+++ b/README.md
@@ -106,10 +106,11 @@ Use the new connections section from `Settings` tab to view, add, or delete conn
 Access the Bruin CLI management tab `Settings` in the side panel for easy installation and updates.
 
 ## Release Notes
-### Latest Release: 0.30.0
-- Integrated RudderStack analytics to monitor extension performance, with support for user-controlled telemetry preferences.
+### Latest Release: 0.30.1
+- Enabled telemetry by default to improve performance monitoring and user experience.
 
 ### Previous Highlights 
+- **0.30.0**: Integrated RudderStack analytics to monitor extension performance, with support for user-controlled telemetry preferences.
 - **0.29.4**: Improved layout and styling for inputs and buttons for better responsiveness and consistency.
 - **0.29.3**: Hid the file input when selecting `service_account_json` for GCP connections.
 - **0.29.2**: Refactored the DateInput component to handle dates in UTC rather than local time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
       "properties": {
         "bruin.telemetry.enabled": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enable anonymous usage data collection to help improve the extension."
         },
         "bruin.defaultFoldingState": {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -18,7 +18,6 @@ import * as os from "os";
 import { renderCommand } from "./commands/renderCommand";
 import { LineagePanel } from "../panels/LineagePanel";
 import { installOrUpdateCli } from "./commands/updateBruinCLI";
-import { promptForTelemetryConsent } from "../bruin/bruinTelemetry";
 //import { RudderTyperAnalytics } from '../analytics/index';
 console.log("RudderStack package:", Analytics);
 console.log("RudderStack keys:", Object.keys(Analytics));
@@ -26,7 +25,6 @@ console.log("RudderStack keys:", Object.keys(Analytics));
 const WRITE_KEY = "2q3zybBJRd9ErKIpkTRSdIahQ0C";
 const DATA_PLANE_URL = "https://getbruinbumlky.dataplane.rudderstack.com";
 export async function activate(context: ExtensionContext) {
-  promptForTelemetryConsent();
 
   const config = workspace.getConfiguration("bruin");
   const telemetryEnabled = config.get<boolean>('telemetry.enabled');


### PR DESCRIPTION
# PR Overview
This PR updates the extension's analytics behavior by:
- Enabling telemetry data collection by default.
- Removing the user consent prompt for telemetry preferences.