### PR TITLE
Fix Asset Name Falling to Default Value After Editing Description 

### DIFF
--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -406,7 +406,7 @@ const updateDescription = (newDescription) => {
       command: "bruin.setAssetDetails",
       payload: {
         ...assetDetailsProps.value,
-        name: editingName.value || assetDetailsProps.value?.name,
+        name: assetDetailsProps.value.name, 
         description: newDescription,
       },
     });


### PR DESCRIPTION
# PR Overview 

This PR fixes the issue where updating a description change the asset name to be 'Asset Name' 