### PR TITLE
Fix ConnectionsForm Reset Issue on GCP File Upload

### DIFF
--- a/webview-ui/src/components/connections/ConnectionsForm.vue
+++ b/webview-ui/src/components/connections/ConnectionsForm.vue
@@ -148,30 +148,26 @@ watch(
   () => props.connection,
   (newConnection) => {
     if (Object.keys(newConnection).length > 0) {
-      form.value = {
-        connection_type: newConnection.type || "",
-        connection_name: newConnection.name || "",
-        environment: newConnection.environment || defaultEnvironment.value,
-        ...newConnection.credentials,
-      };
+      // Only update form if not already populated
+      if (!form.value.connection_name) {
+        form.value = {
+          connection_type: newConnection.type || "",
+          connection_name: newConnection.name || "",
+          environment: newConnection.environment || defaultEnvironment.value,
+          ...newConnection.credentials,
+        };
+      }
+      
       // Set selectedFile if service_account_file is present in credentials
       if (newConnection.credentials.service_account_file) {
         selectedFile.value = { path: newConnection.credentials.service_account_file };
       }
-    } else {
-      // Reset form when creating a new connection
-      form.value = {
-        connection_type: "",
-        connection_name: "",
-        environment: defaultEnvironment.value,
-      };
     }
+    
     validationErrors.value = {};
-    selectedFile.value = null;
   },
   { immediate: true, deep: true }
 );
-
 
 watch(
   () => form.value.connection_type,

--- a/webview-ui/src/components/connections/FormField.vue
+++ b/webview-ui/src/components/connections/FormField.vue
@@ -199,6 +199,7 @@ const inputType = computed(() => {
 const triggerFileSelection = () => {
   vscode.postMessage({
     command: "bruinConnections.fileSelected",
+
   });
 };
 
@@ -290,7 +291,6 @@ const handleFileSelectionMessage = (event) => {
           name: payload.message.fileName,
           path: payload.message.filePath,
         };
-        internalValue.value = payload.message.fileName;
         emit("fileSelected", {
           name: payload.message.fileName,
           path: payload.message.filePath,
@@ -298,7 +298,6 @@ const handleFileSelectionMessage = (event) => {
         break;
     }
   }
-  internalValue.value = "";
 };
 const isValidInput = computed(() => {
   return !!internalValue.value || !!selectedFile.value;


### PR DESCRIPTION
# PR Overview

This PR fixes an issue in the ConnectionsForm where uploading a GCP Json file would reset other fields.