### PR TITLE
Make Full Path Usage Default for Bruin CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Bruin extension will be documented in this file.
 
+## [0.32.2] - [2024-12-20]
+- Made Full Path Usage Default for Bruin CLI.
+
 ## [0.32.1] - [2024-12-20]
 - Added a link to Bruin documentation in the extension settings.
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,12 @@ Access the Bruin CLI management tab `Settings` in the side panel for easy instal
 
 ## Release Notes
 
-### Latest Release: 0.32.1
-- Added a link to Bruin documentation in the extension settings.
+### Latest Release: 0.32.2
+- Made Full Path Usage Default for Bruin CLI.
+
 
 ### Previous Highlights
+- **0.32.1**: Added a link to Bruin documentation in the extension settings.
 - **0.32.0**: Added a test connection feature to test existing connections.
 - **0.31.5**: Prevented form resets when uploading a GCP json file in the ConnectionsForm component.
 - **0.31.4**: Fixed an issue where updating an asset's name would reset its description, owner, and type fields.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.32.1",
+      "version": "0.32.2",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -110,11 +110,6 @@
           "default": "folded",
           "description": "Sets the default folding state for custom Bruin foldable regions in Python and SQL files."
         },
-        "bruin.useBruinFromPath": {
-          "type": "boolean",
-          "default": false,
-          "description": "Use the Bruin CLI from the full path"
-        },
         "bruin.pathSeparator": {
           "type": "string",
           "default": "/",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -13,8 +13,8 @@ import * as os from "os";
  */
 export function getDefaultBruinExecutablePath(): string {
   let bruinExecutable = "";
-  const useBruinFromPath = vscode.workspace.getConfiguration("bruin").get<boolean>("useBruinFromPath") || false;
-  const bruinConfig = vscode.workspace.getConfiguration("bruin") ;
+  //const useBruinFromPath = vscode.workspace.getConfiguration("bruin").get<boolean>("useBruinFromPath") || false;
+  const bruinConfig = vscode.workspace.getConfiguration("bruin");
   bruinExecutable = bruinConfig.get<string>("executable") || "";
 
   if (bruinExecutable.length > 0) {
@@ -25,12 +25,12 @@ export function getDefaultBruinExecutablePath(): string {
     // Attempt to find 'bruin' in the system's PATH (works for Git Bash)
     const paths = (process.env.PATH || "").split(path.delimiter);
     for (const p of paths) {
-      const executablePath = path.join(p, process.platform === "win32"? "bruin.exe" : "bruin");
+      const executablePath = path.join(p, process.platform === "win32" ? "bruin.exe" : "bruin");
       try {
         // Test if the file exists and is executable
         fs.accessSync(executablePath, fs.constants.X_OK);
         console.log(`Found 'bruin' at ${executablePath}`);
-        bruinExecutable = useBruinFromPath ? executablePath : "bruin";
+        bruinExecutable = executablePath;
         return bruinExecutable;
       } catch (err) {
         // Continue searching if not found or not executable
@@ -45,7 +45,7 @@ export function getDefaultBruinExecutablePath(): string {
       const executablePathLocal = path.join(localBinPath, "bruin.exe");
       try {
         fs.accessSync(executablePathLocal, fs.constants.X_OK);
-        bruinExecutable =  executablePathLocal ;
+        bruinExecutable = executablePathLocal;
         console.log(`Found 'bruin' in windows platform at ${bruinExecutable}`);
         return bruinExecutable;
       } catch (err) {
@@ -58,7 +58,7 @@ export function getDefaultBruinExecutablePath(): string {
     // look for bruin in the PATH
     const homePath = os.homedir();
     const localBinPath = path.join(homePath, ".local", "bin");
-    bruinExecutable = useBruinFromPath ? path.join(localBinPath, "bruin") : "bruin";
+    bruinExecutable = path.join(localBinPath, "bruin");
     console.log(`Using 'bruin' by joining the path: ${localBinPath}`);
     return bruinExecutable;
   }


### PR DESCRIPTION
# PR Overview
This PR removes the configuration option for using the full path to the Bruin CLI and makes it the default behavior. This simplifies configuration and ensures consistent execution of the CLI.