### PR TITLE
Add System Info Display to Bruin Settings Tab  

### DIFF
--- a/src/bruin/bruinInstallCli.ts
+++ b/src/bruin/bruinInstallCli.ts
@@ -38,6 +38,25 @@ export class BruinInstallCLI {
     return command;
   }
 
+  public async getBruinCliVersion (): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const bruinExecutable = getDefaultBruinExecutablePath();
+      exec(`${bruinExecutable} version -o json`, (error, stdout, stderr) => {
+        if (error) {
+          reject(`Error executing command getBruinCliVersion ${stderr}`);
+          return;
+        }
+
+        try {
+          const output = JSON.parse(stdout.trim());
+          const currentVersion = output.version;
+          resolve(currentVersion);
+        } catch (parseError) {
+          reject("Failed to parse version information");
+        }
+      });
+    });
+  }
   public async checkBruinCLIVersion(): Promise<boolean> {
     return new Promise((resolve, reject) => {
       const bruinExecutable = getDefaultBruinExecutablePath();

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -432,7 +432,9 @@ export class BruinPanel {
           case "checkBruinCliInstallation":
             this.checkAndUpdateBruinCliStatus();
             break;
-
+          case "checkInstallationsInfo":
+            this.checkInstallationsInfo();
+            break;
           case "bruinInstallOrUpdateCLI":
             await this.installOrUpdateBruinCli();
             break;
@@ -588,6 +590,23 @@ export class BruinPanel {
       this._disposables
     );
   }
+
+  // check the OS if its windows or mac or linux
+  private async checkInstallationsInfo() {
+    const platform = process.platform;
+    const packageJson = require("../../package.json");
+    const extensionVersion = packageJson.version;
+
+    const bruinInstaller = new BruinInstallCLI();
+    const cliVersion = await bruinInstaller.getBruinCliVersion();
+    this._panel.webview.postMessage({
+      command: "installationInfo",
+      platform,
+      cliVersion,
+      extensionVersion,
+    });
+  }
+
   private async checkAndUpdateBruinCliStatus() {
     const bruinInstaller = new BruinInstallCLI();
     const { installed, isWindows, gitAvailable } = await bruinInstaller.checkBruinCliInstallation();

--- a/webview-ui/src/components/bruin-settings/BruinCLI.vue
+++ b/webview-ui/src/components/bruin-settings/BruinCLI.vue
@@ -20,14 +20,45 @@
         >
           {{ isBruinCliInstalled ? "Update" : "Install" }} Bruin CLI
         </vscode-button>
-        <vscode-button
-          appearance="icon"
-          @click="openBruinDocumentation"
-          title="Bruin Documentation"
-          class="text-md font-semibold"
-        >
-          <QuestionMarkCircleIcon class="h-5 w-5 text-editor-fg" />
-        </vscode-button>
+        <div class="flex space-x-1">
+          <vscode-button
+            appearance="icon"
+            @click="openBruinDocumentation"
+            title="Bruin Documentation"
+            class="text-md font-semibold"
+          >
+            <QuestionMarkCircleIcon class="h-5 w-5 text-editor-fg" />
+          </vscode-button>
+
+          <vscode-button
+            appearance="icon"
+            @click="CheckInstallationsInfo"
+            title="Check Bruin CLI/system Versions"
+            class="text-md font-semibold"
+          >
+            <ChevronUpIcon v-if="showInfoCard" class="h-5 w-5 text-editor-fg" />
+            <ChevronDownIcon v-else class="h-5 w-5 text-editor-fg" />
+          </vscode-button>
+        </div>
+      </div>
+      <div v-if="showInfoCard" class="bg-editorWidget-bg shadow sm:rounded-lg mt-4 p-4">
+        <h4 class="text-lg font-semibold leading-6 text-editor-fg">System Info</h4>
+        <div class="mt-2 max-w-xl text-sm">
+          <ul class="list-none m-0 p-0">
+            <li class="flex items-center mb-2">
+              <span class="text-editor-fg-secondary font-medium mr-2">Platform:</span>
+              <span class="text-editor-fg">{{ currentPlatform }}</span>
+            </li>
+            <li class="flex items-center mb-2">
+              <span class="text-editor-fg-secondary font-medium mr-2">Bruin CLI:</span>
+              <span class="text-editor-fg">{{ bruinCliVersion }}</span>
+            </li>
+            <li class="flex items-center">
+              <span class="text-editor-fg-secondary font-medium mr-2">Bruin Extension:</span>
+              <span class="text-editor-fg">{{ bruinVscodeVersion }}</span>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>
@@ -36,21 +67,33 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
 import { vscode } from "@/utilities/vscode";
-import { QuestionMarkCircleIcon } from "@heroicons/vue/20/solid";
+import { ChevronUpIcon, QuestionMarkCircleIcon, ChevronDownIcon } from "@heroicons/vue/20/solid";
 
 const isBruinCliInstalled = ref(false);
 const isWindows = ref(false);
-const gitAvailble = ref(false);
-
+const gitAvailable = ref(false);
+const currentPlatform = ref("");
+const bruinCliVersion = ref("");
+const showInfoCard = ref(false);
+const bruinVscodeVersion = ref("");
 onMounted(() => {
   checkBruinCliInstallation();
-
   window.addEventListener("message", (event) => {
     const message = event.data;
-    if (message.command === "bruinCliInstallationStatus") {
-      isBruinCliInstalled.value = message.installed;
-      isWindows.value = message.isWindows;
-      gitAvailble.value = message.gitAvailble;
+    switch (message.command) {
+      case "bruinCliInstallationStatus":
+        isBruinCliInstalled.value = message.installed;
+        isWindows.value = message.isWindows;
+        gitAvailable.value = message.gitAvailable;
+        break;
+
+      case "installationInfo":
+        console.log("Updating currentPlatform:", message.platform);
+        currentPlatform.value = message.platform;
+        console.log("Updating bruinCliVersion:", message.cliVersion);
+        bruinCliVersion.value = message.cliVersion;
+        bruinVscodeVersion.value = message.extensionVersion;
+        break;
     }
   });
 });
@@ -65,6 +108,10 @@ function checkBruinCliInstallation() {
   vscode.postMessage({ command: "checkBruinCliInstallation" });
 }
 
+function CheckInstallationsInfo() {
+  vscode.postMessage({ command: "checkInstallationsInfo" });
+  showInfoCard.value = !showInfoCard.value;
+}
 function installOrUpdateBruinCli() {
   vscode.postMessage({ command: "bruinInstallOrUpdateCLI" });
 }


### PR DESCRIPTION
# PR Overview 
This PR updates the **BruinCLI** component to display system information, including:  
- Bruin CLI version.  
- Bruin Vscode Extension Version.  
- Platform details.  
