### PR TITLE
Update Required Fields in Pipeline Autocomplete Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Bruin extension will be documented in this file.
 
+## [0.32.6] - [2024-01-16]
+- Update the pipeline autocomplete schema to make name the only required field.
+
 ## [0.32.5] - [2024-01-15]
 - Added system information display to show Bruin CLI and extension versions, along with OS name.
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ Access the Bruin CLI management tab `Settings` in the side panel for easy instal
 
 ## Release Notes
 
-### Latest Release: 0.32.5
-- Added system information display to show Bruin CLI and extension versions, along with OS name.
+### Latest Release: 0.32.6
+- Update the pipeline autocomplete schema to make name the only required field.
 
 ### Previous Highlights
+- **0.32.5**: Added system information display to show Bruin CLI and extension versions, along with OS name.
 - **0.32.4**: Increase maxBuffer limit.
 - **0.32.3**: Added support for running pipeline from last failure.
 - **0.32.2**: Made Full Path Usage Default for Bruin CLI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.32.5",
+  "version": "0.32.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.32.5",
+      "version": "0.32.6",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.32.5",
+  "version": "0.32.6",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/schemas/pipeline-schema.json
+++ b/schemas/pipeline-schema.json
@@ -119,9 +119,7 @@
     {
       "type": "object",
       "required": [
-        "name",
-        "schedule",
-        "default_connections"
+        "name"
       ],
       "not": {
         "required": [
@@ -132,9 +130,7 @@
     {
       "type": "object",
       "required": [
-        "id",
-        "schedule",
-        "default_connections"
+        "id"
       ],
       "not": {
         "required": [


### PR DESCRIPTION
# PR Overview 

This PR updates the pipeline autocomplete schema to make `name` the only required field.

