### PR TITLE
Update Connection Fields in Config Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Bruin extension will be documented in this file.
 
+## [0.32.7] - [2024-01-20]
+- Updated config schema to support more SSL modes and revised Athena schema.
+
 ## [0.32.6] - [2024-01-16]
 - Update the pipeline autocomplete schema to make name the only required field.
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ Access the Bruin CLI management tab `Settings` in the side panel for easy instal
 
 ## Release Notes
 
-### Latest Release: 0.32.6
-- Update the pipeline autocomplete schema to make name the only required field.
+### Latest Release: 0.32.7
+- Updated config schema to support more SSL modes and revised Athena schema.
 
 ### Previous Highlights
+- **0.32.6**: Update the pipeline autocomplete schema to make name the only required field.
 - **0.32.5**: Added system information display to show Bruin CLI and extension versions, along with OS name.
 - **0.32.4**: Increase maxBuffer limit.
 - **0.32.3**: Added support for running pipeline from last failure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.32.6",
+  "version": "0.32.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.32.6",
+      "version": "0.32.7",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.32.6",
+  "version": "0.32.7",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/schemas/config-schema.json
+++ b/schemas/config-schema.json
@@ -276,11 +276,6 @@
                 },
                 "ssl_mode": {
                     "type": "string",
-                    "enum": [
-                        "enable",
-                        "disable",
-                        ""
-                    ],
                     "default": "disable"
                 }
             },
@@ -512,7 +507,7 @@
             ],
             "additionalProperties": false
         },
-        "aws":{
+        "aws": {
             "type": "object",
             "properties": {
                 "name": {
@@ -547,10 +542,13 @@
                 "name": {
                     "type": "string"
                 },
-                "access_key": {
+                "access_key_id": {
                     "type": "string"
                 },
-                "secret_key": {
+                "secret_access_key": {
+                    "type": "string"
+                },
+                "query_results_path": {
                     "type": "string"
                 },
                 "region": {
@@ -558,15 +556,13 @@
                 },
                 "database": {
                     "type": "string"
-                },
-                "output_bucket": {
-                    "type": "string"
                 }
             },
             "required": [
                 "name",
-                "access_key",
-                "secret_key",
+                "access_key_id",
+                "secret_access_key",
+                "query_results_path",
                 "region"
             ],
             "additionalProperties": true


### PR DESCRIPTION
# PR Overview

This PR updates the config autocomplete schema to make `ssl` mode accept more string values and updated `Athena` schema.