### PR TITLE
Improve Asset Validation Error Display

### DIFF
--- a/webview-ui/src/components/ui/alerts/ErrorAlert.vue
+++ b/webview-ui/src/components/ui/alerts/ErrorAlert.vue
@@ -3,49 +3,42 @@
   <div
     v-if="processedErrors.length"
     class="rounded-md bg-red-50 p-4 my-4 overflow-hidden transition-all duration-300"
-    :class="{ 'h-16': !isExpanded, 'max-h-64': isExpanded }"
+    :class="{ 'h-16':!isExpanded, 'max-h-64': isExpanded }"
   >
-    <!-- Header section -->
+    <!-- Header section with error icon, title, and control buttons -->
     <div class="flex justify-between items-center">
       <div class="flex items-center flex-grow">
         <XCircleIcon class="h-5 w-5 text-red-500 mr-2" aria-hidden="true" />
         <h3 class="text-lg font-medium text-red-800">{{ errorPhase }} Error</h3>
       </div>
       <div class="flex items-center">
+        <!-- Toggle button for expanding/collapsing the error details -->
         <button @click="isExpanded = !isExpanded" class="text-red-500 mr-2">
-          <component :is="isExpanded ? ChevronUpIcon : ChevronDownIcon" class="h-5 w-5" />
+          <component :is="isExpanded ? ChevronUpIcon : ChevronDownIcon" class="h-5 w-5" aria-hidden="true" />
         </button>
+        <!-- Button to close the error alert -->
         <button @click="$emit('errorClose')" class="text-red-700">
-          <XMarkIcon class="h-5 w-5" />
+          <XMarkIcon class="h-5 w-5" aria-hidden="true" />
         </button>
       </div>
     </div>
-
-    <!-- Error content -->
+    <!-- Expanded section to display detailed error messages -->
     <div v-if="isExpanded" class="overflow-y-auto" style="max-height: 200px">
       <template v-for="(errorMessage, index) in processedErrors" :key="index">
         <!-- Single Asset Validation Display -->
         <div v-if="isSingleAsset" class="mt-4">
           <h4 class="text-md font-semibold text-gray-900">Asset: {{ singleAssetName }}</h4>
-          <div
-            v-for="(issue, issueIndex) in errorMessage.issues"
-            :key="issueIndex"
-            class="mb-2 ml-2"
-          >
+          <div v-for="(issue, issueIndex) in errorMessage.issues" :key="issueIndex" class="mb-2 ml-2">
             <p class="text-sm text-red-600">{{ issue.description }}</p>
             <div v-if="issue.context.length" class="flex items-center space-x-1 mt-2 justify-end">
-              <button
-                @click="toggleIssueExpansion(index, issueIndex)"
-                class="text-xs text-red-700 flex items-center"
-              >
+              <!-- Button to toggle the expansion of issue details -->
+              <button @click="toggleIssueExpansion(index, issueIndex)" class="text-xs text-red-700 flex items-center">
                 <span class="mr-1">Details</span>
-                <component :is="issue.expanded ? ChevronUpIcon : ChevronDownIcon" class="h-4 w-4" />
+                <component :is="issue.expanded ? ChevronUpIcon : ChevronDownIcon" class="h-4 w-4" aria-hidden="true" />
               </button>
             </div>
             <div v-if="issue.expanded" class="text-sm text-gray-700 ml-1 mt-1 w-full">
-              <pre class="whitespace-pre-wrap bg-red-100 rounded p-2">{{
-                issue.context.join("\n")
-              }}</pre>
+              <pre class="whitespace-pre-wrap bg-red-100 rounded p-2">{{ issue.context.join('\n') }}</pre>
             </div>
           </div>
         </div>
@@ -53,35 +46,21 @@
         <!-- Full Pipeline Validation Display -->
         <div v-else>
           <div @click="toggleExpansion(index)" class="flex items-center cursor-pointer mt-4">
-            <component
-              :is="errorMessage.expanded ? ChevronDownIcon : ChevronRightIcon"
-              class="h-5 w-5 text-red-500"
-            />
+            <component :is="errorMessage.expanded? ChevronDownIcon : ChevronRightIcon" class="h-5 w-5 text-red-500" aria-hidden="true" />
             <span class="ml-2 text-red-700">Pipeline: {{ errorMessage.pipeline }}</span>
           </div>
           <div v-if="errorMessage.expanded" class="ml-5 mt-2">
             <div v-for="(issue, issueIndex) in errorMessage.issues" :key="issueIndex" class="mb-2">
-              <h4 v-if="issue.asset" class="text-md font-semibold text-gray-900">
-                Asset: {{ issue.asset }}
-              </h4>
+              <h4 v-if="issue.asset" class="text-md font-semibold text-gray-900">Asset: {{ issue.asset }}</h4>
               <p class="text-sm text-red-600">{{ issue.description }}</p>
               <div v-if="issue.context.length" class="flex items-center space-x-1 mt-2 justify-end">
-                <button
-                  @click="toggleIssueExpansion(index, issueIndex)"
-                  class="text-xs text-red-700 flex items-center"
-                >
+                <button @click="toggleIssueExpansion(index, issueIndex)" class="text-xs text-red-700 flex items-center">
                   <span class="mr-1">Details</span>
-                  <component
-                    :is="issue.expanded ? ChevronUpIcon : ChevronDownIcon"
-                    class="h-4 w-4"
-                    aria-hidden="true"
-                  />
+                  <component :is="issue.expanded? ChevronUpIcon : ChevronDownIcon" class="h-4 w-4" aria-hidden="true" />
                 </button>
               </div>
               <div v-if="issue.expanded" class="text-sm text-gray-700 ml-1 mt-1 w-full">
-                <pre class="whitespace-pre-wrap bg-red-100 rounded p-2">{{
-                  issue.context.join("\n")
-                }}</pre>
+                <pre class="whitespace-pre-wrap bg-red-100 rounded p-2">{{ issue.context.join("\n") }}</pre>
               </div>
             </div>
           </div>
@@ -100,126 +79,131 @@ import {
   ChevronUpIcon,
   XMarkIcon,
 } from "@heroicons/vue/20/solid";
-import type {
-  FormattedErrorMessage,
-  ParsedValidationErrorMessage,
-  Issue,
-  FormattedIssue,
-} from "@/types";
+import type { FormattedErrorMessage, ParsedValidationErrorMessage, Issue, FormattedIssue } from "@/types";
 
+// Define the props for the component
 const props = defineProps<{
-  errorMessage: string | any | null;
-  errorPhase: "Validation" | "Rendering" | "Unknown";
+  errorMessage: string | any | null; // The error message to display
+  errorPhase: "Validation" | "Rendering" | "Unknown"; // The phase of the error
 }>();
 
+// Define the events emitted by the component
 defineEmits(["errorClose"]);
 
-const isExpanded = ref(true);
-const processedErrors = ref<FormattedErrorMessage[]>([]);
+// State variables
+const isExpanded = ref(true); // Tracks whether the error details are expanded
+const processedErrors = ref<FormattedErrorMessage[]>([]); // Holds the formatted error messages
 
-const isSingleAsset = computed(() => {
-  if (props.errorPhase !== "Validation") return false;
-  const firstError = processedErrors.value[0];
-  if (!firstError) return false;
-
-  const assets = new Set(firstError.issues.map((issue) => issue.asset));
-  return assets.size === 1;
-});
-
-const singleAssetName = computed(() => {
-  if (!isSingleAsset.value) return "";
-  return processedErrors.value[0].issues[0].asset || "Unknown Asset";
-});
-
+// Function to parse the error message and format it
 const parseErrorMessage = (): FormattedErrorMessage[] => {
-  if (!props.errorMessage) return [];
+  if (!props.errorMessage) return []; // Return empty if no error message
 
-  try {
-    const errorObject = JSON.parse(props.errorMessage);
-    if (errorObject.error) {
-      return createErrorMessage("Unknown", errorObject.error);
+    try {
+      const errorObject = JSON.parse(props.errorMessage); // Parse the error message
+      if (errorObject.error) {
+        return createErrorMessage("Unknown", errorObject.error); // Handle unknown errors
+      }
+      if (Array.isArray(errorObject)) {
+        // Process validation errors
+        const formattedErrors = errorObject
+         .map((validationError: ParsedValidationErrorMessage) => ({
+            pipeline: validationError.pipeline || null,
+            expanded: false, // Set initially to false, will be updated after processing
+            issues: extractCriticalIssues(validationError.issues), // Extract critical issues
+          }))
+         .filter((error) => error.issues.length > 0); // Filter out errors with no issues
+
+        // Set expansion state based on number of pipelines
+        const isOneError = formattedErrors.length === 1;
+        return formattedErrors.map((error) => ({
+         ...error,
+          expanded: isOneError, // Expand if there's only one pipeline
+          issues: error.issues.map((issue) => ({
+           ...issue,
+            expanded: isOneError && isSingleAsset.value, // Expand issues for single asset/pipeline
+          })),
+        }));
+      }
+      return [];
+    } catch (e) {
+      console.error("Failed to parse error message:", e); // Log parsing errors
+      return createErrorMessage("Error", String(props.errorMessage)); // Handle parsing errors
     }
-    if (Array.isArray(errorObject)) {
-      const formattedErrors = errorObject
-        .map((validationError: ParsedValidationErrorMessage) => ({
-          pipeline: validationError.pipeline || null,
-          expanded: false, // Set initially to false, will be updated after processing
-          issues: extractCriticalIssues(validationError.issues),
-        }))
-        .filter((error) => error.issues.length > 0);
+  };
 
-      // Set expansion state based on number of pipelines
-      const isOneError = formattedErrors.length === 1;
-      return formattedErrors.map(error => ({
-        ...error,
-        expanded: isOneError, // Expand if there's only one pipeline
-        issues: error.issues.map(issue => ({
-          ...issue,
-          expanded: isOneError && isSingleAsset.value // Expand issues for single asset/pipeline
-        }))
-      }));
-    }
-    return [];
-  } catch (e) {
-    console.error("Failed to parse error message:", e);
-    return createErrorMessage("Error", String(props.errorMessage));
-  }
-};
+  // Helper function to create a formatted error message
+  const createErrorMessage = (pipeline: string, description: string) => [
+    {
+      pipeline,
+      expanded: true,
+      issues: [
+        {
+          asset: null,
+          description,
+          context: [],
+          expanded: true,
+          severity: "critical",
+        },
+      ],
+    },
+  ];
 
-const createErrorMessage = (pipeline: string, description: string) => [
-  {
-    pipeline,
-    expanded: true,
-    issues: [
-      {
-        asset: null,
-        description,
-        context: [],
-        expanded: true,
-        severity: "critical",
-      },
-    ],
-  },
-];
+  // Helper function to extract critical issues from validation errors
+  const extractCriticalIssues = (issues: any) => {
+    return Object.entries(issues || {}).flatMap(([test, issueList]) =>
+      (issueList as Issue[])
+       .filter((issue: Issue) => issue.severity === "critical")
+       .map(
+          (issue: Issue): FormattedIssue => ({
+            asset: issue.asset || null,
+            description: issue.description,
+            context: issue.context || [],
+            expanded: false, // Will be updated after initial processing
+            severity: issue.severity,
+          })
+        )
+    );
+  };
 
-const extractCriticalIssues = (issues: any) => {
-  return Object.entries(issues || {}).flatMap(([test, issueList]) =>
-    (issueList as Issue[])
-      .filter((issue: Issue) => issue.severity === "critical")
-      .map(
-        (issue: Issue): FormattedIssue => ({
-          asset: issue.asset || null,
-          description: issue.description,
-          context: issue.context || [],
-          expanded: false, // Will be updated after initial processing
-          severity: issue.severity,
-        })
-      )
+    // Computed properties
+    const isSingleAsset = computed(() => {
+    if (props.errorPhase!== "Validation") return false;
+    const firstError = processedErrors.value[0];
+    if (!firstError) return false;
+
+    const assets = new Set(firstError.issues.map((issue) => issue.asset));
+    return assets.size === 1;
+  });
+
+  const singleAssetName = computed(() => {
+    if (!isSingleAsset.value) return "";
+    return processedErrors.value[0].issues[0].asset || "Unknown Asset";
+  });
+  // Watch for changes in the errorMessage prop and reprocess the errors
+  watch(
+    () => props.errorMessage,
+    () => {
+      processedErrors.value = parseErrorMessage(); // Update processed errors on prop change
+    },
+    { immediate: true }
   );
-};
 
-watch(
-  () => props.errorMessage,
-  () => {
-    processedErrors.value = parseErrorMessage();
-  },
-  { immediate: true }
-);
+  // Function to toggle the expansion state of an error message
+  const toggleExpansion = (index: number) => {
+    processedErrors.value[index].expanded =!processedErrors.value[index].expanded; // Toggle expansion
+  };
 
-const toggleExpansion = (index: number) => {
-  processedErrors.value[index].expanded = !processedErrors.value[index].expanded;
-};
-
-const toggleIssueExpansion = (pipelineIndex: number, issueIndex: number) => {
-  processedErrors.value[pipelineIndex].issues[issueIndex].expanded =
-    !processedErrors.value[pipelineIndex].issues[issueIndex].expanded;
-};
+  // Function to toggle the expansion state of an issue within an error message
+  const toggleIssueExpansion = (pipelineIndex: number, issueIndex: number) => {
+    processedErrors.value[pipelineIndex].issues[issueIndex].expanded =
+     !processedErrors.value[pipelineIndex].issues[issueIndex].expanded; // Toggle issue expansion
+  };
 </script>
 
 <style scoped>
 pre {
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  line-height: 1.5;
+  white-space: pre-wrap; /* Allow text to wrap */
+  word-wrap: break-word; /* Break long words */
+  line-height: 1.5; /* Set line height for readability */
 }
 </style>

--- a/webview-ui/src/components/ui/alerts/ErrorAlert.vue
+++ b/webview-ui/src/components/ui/alerts/ErrorAlert.vue
@@ -5,55 +5,95 @@
     class="rounded-md bg-red-50 p-4 my-4 overflow-hidden transition-all duration-300"
     :class="{ 'h-16': !isExpanded, 'max-h-64': isExpanded }"
   >
-    <!-- Header section with error icon, title, and control buttons -->
+    <!-- Header section -->
     <div class="flex justify-between items-center">
       <div class="flex items-center flex-grow">
         <XCircleIcon class="h-5 w-5 text-red-500 mr-2" aria-hidden="true" />
         <h3 class="text-lg font-medium text-red-800">{{ errorPhase }} Error</h3>
       </div>
       <div class="flex items-center">
-        <!-- Toggle button for expanding/collapsing the error details -->
         <button @click="isExpanded = !isExpanded" class="text-red-500 mr-2">
-          <component :is="isExpanded ? ChevronUpIcon : ChevronDownIcon" class="h-5 w-5" aria-hidden="true" />
+          <component :is="isExpanded ? ChevronUpIcon : ChevronDownIcon" class="h-5 w-5" />
         </button>
-        <!-- Button to close the error alert -->
         <button @click="$emit('errorClose')" class="text-red-700">
-          <XMarkIcon class="h-5 w-5" aria-hidden="true" />
+          <XMarkIcon class="h-5 w-5" />
         </button>
       </div>
     </div>
-    <!-- Expanded section to display detailed error messages -->
+
+    <!-- Error content -->
     <div v-if="isExpanded" class="overflow-y-auto" style="max-height: 200px">
-      <div v-for="(errorMessage, index) in processedErrors" :key="index">
-        <div v-if="errorPhase === 'Validation' && errorMessage.pipeline !=='Error'" class="mt-4">
-          <div @click="toggleExpansion(index)" class="flex items-center cursor-pointer">
-            <component :is="errorMessage.expanded ? ChevronDownIcon : ChevronRightIcon" class="h-5 w-5 text-red-500" aria-hidden="true" />
-            <span class="ml-2 text-red-700">Pipeline: {{ errorMessage.pipeline }}</span>
-          </div>
-        </div>
-        <div v-if="errorMessage.expanded || errorPhase === 'Rendering'" class="ml-5 mt-2">
-          <div v-for="(issue, issueIndex) in errorMessage.issues" :key="issueIndex" class="mb-2">
-            <h4 v-if="issue.asset" class="text-md font-semibold text-gray-900">Asset: {{ issue.asset }}</h4>
+      <template v-for="(errorMessage, index) in processedErrors" :key="index">
+        <!-- Single Asset Validation Display -->
+        <div v-if="isSingleAsset" class="mt-4">
+          <h4 class="text-md font-semibold text-gray-900">Asset: {{ singleAssetName }}</h4>
+          <div
+            v-for="(issue, issueIndex) in errorMessage.issues"
+            :key="issueIndex"
+            class="mb-2 ml-2"
+          >
             <p class="text-sm text-red-600">{{ issue.description }}</p>
             <div v-if="issue.context.length" class="flex items-center space-x-1 mt-2 justify-end">
-              <!-- Button to toggle the expansion of issue details -->
-              <button @click="toggleIssueExpansion(index, issueIndex)" class="text-xs text-red-700 flex items-center">
+              <button
+                @click="toggleIssueExpansion(index, issueIndex)"
+                class="text-xs text-red-700 flex items-center"
+              >
                 <span class="mr-1">Details</span>
-                <component :is="issue.expanded ? ChevronUpIcon : ChevronDownIcon" class="h-4 w-4" aria-hidden="true" />
+                <component :is="issue.expanded ? ChevronUpIcon : ChevronDownIcon" class="h-4 w-4" />
               </button>
             </div>
             <div v-if="issue.expanded" class="text-sm text-gray-700 ml-1 mt-1 w-full">
-              <pre class="whitespace-pre-wrap bg-red-100 rounded p-2">{{ issue.context.join('\n') }}</pre>
+              <pre class="whitespace-pre-wrap bg-red-100 rounded p-2">{{
+                issue.context.join("\n")
+              }}</pre>
             </div>
           </div>
         </div>
-      </div>
+
+        <!-- Full Pipeline Validation Display -->
+        <div v-else>
+          <div @click="toggleExpansion(index)" class="flex items-center cursor-pointer mt-4">
+            <component
+              :is="errorMessage.expanded ? ChevronDownIcon : ChevronRightIcon"
+              class="h-5 w-5 text-red-500"
+            />
+            <span class="ml-2 text-red-700">Pipeline: {{ errorMessage.pipeline }}</span>
+          </div>
+          <div v-if="errorMessage.expanded" class="ml-5 mt-2">
+            <div v-for="(issue, issueIndex) in errorMessage.issues" :key="issueIndex" class="mb-2">
+              <h4 v-if="issue.asset" class="text-md font-semibold text-gray-900">
+                Asset: {{ issue.asset }}
+              </h4>
+              <p class="text-sm text-red-600">{{ issue.description }}</p>
+              <div v-if="issue.context.length" class="flex items-center space-x-1 mt-2 justify-end">
+                <!-- Button to toggle the expansion of issue details -->
+                <button
+                  @click="toggleIssueExpansion(index, issueIndex)"
+                  class="text-xs text-red-700 flex items-center"
+                >
+                  <span class="mr-1">Details</span>
+                  <component
+                    :is="issue.expanded ? ChevronUpIcon : ChevronDownIcon"
+                    class="h-4 w-4"
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+              <div v-if="issue.expanded" class="text-sm text-gray-700 ml-1 mt-1 w-full">
+                <pre class="whitespace-pre-wrap bg-red-100 rounded p-2">{{
+                  issue.context.join("\n")
+                }}</pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref, watch, computed } from "vue";
 import {
   XCircleIcon,
   ChevronRightIcon,
@@ -61,7 +101,12 @@ import {
   ChevronUpIcon,
   XMarkIcon,
 } from "@heroicons/vue/20/solid";
-import type { FormattedErrorMessage, ParsedValidationErrorMessage, Issue, FormattedIssue } from "@/types";
+import type {
+  FormattedErrorMessage,
+  ParsedValidationErrorMessage,
+  Issue,
+  FormattedIssue,
+} from "@/types";
 
 // Define the props for the component
 const props = defineProps<{
@@ -87,11 +132,13 @@ const parseErrorMessage = (): FormattedErrorMessage[] => {
     }
     if (Array.isArray(errorObject)) {
       // Process validation errors
-      return errorObject.map((validationError: ParsedValidationErrorMessage) => ({
-        pipeline: validationError.pipeline || null,
-        expanded: false,
-        issues: extractCriticalIssues(validationError.issues), // Extract critical issues
-      })).filter(error => error.issues.length > 0); // Filter out errors with no issues
+      return errorObject
+        .map((validationError: ParsedValidationErrorMessage) => ({
+          pipeline: validationError.pipeline || null,
+          expanded: false,
+          issues: extractCriticalIssues(validationError.issues), // Extract critical issues
+        }))
+        .filter((error) => error.issues.length > 0); // Filter out errors with no issues
     }
     return [];
   } catch (e) {
@@ -101,35 +148,60 @@ const parseErrorMessage = (): FormattedErrorMessage[] => {
 };
 
 // Helper function to create a formatted error message
-const createErrorMessage = (pipeline: string, description: string) => [{
-  pipeline,
-  expanded: true,
-  issues: [{
-    asset: null,
-    description,
-    context: [],
-    expanded: false,
-    severity: "critical"
-  }],
-}];
+const createErrorMessage = (pipeline: string, description: string) => [
+  {
+    pipeline,
+    expanded: true,
+    issues: [
+      {
+        asset: null,
+        description,
+        context: [],
+        expanded: false,
+        severity: "critical",
+      },
+    ],
+  },
+];
 
 // Helper function to extract critical issues from validation errors
 const extractCriticalIssues = (issues: any) => {
   return Object.entries(issues || {}).flatMap(([test, issueList]) =>
-    (issueList as Issue[]).filter((issue: Issue) => issue.severity === "critical").map((issue: Issue): FormattedIssue => ({
-      asset: issue.asset || null,
-      description: issue.description,
-      context: issue.context || [],
-      expanded: false,
-      severity: issue.severity
-    }))
+    (issueList as Issue[])
+      .filter((issue: Issue) => issue.severity === "critical")
+      .map(
+        (issue: Issue): FormattedIssue => ({
+          asset: issue.asset || null,
+          description: issue.description,
+          context: issue.context || [],
+          expanded: false,
+          severity: issue.severity,
+        })
+      )
   );
 };
+const isSingleAsset = computed(() => {
+  if (props.errorPhase !== "Validation") return false;
+  const firstError = processedErrors.value[0];
+  if (!firstError) return false;
+
+  const assets = new Set(firstError.issues.map((issue) => issue.asset));
+  return assets.size === 1;
+});
+
+const singleAssetName = computed(() => {
+  if (!isSingleAsset.value) return "";
+  return processedErrors.value[0].issues[0].asset || "Unknown Asset";
+});
 
 // Watch for changes in the errorMessage prop and reprocess the errors
-watch(() => props.errorMessage, () => {
-  processedErrors.value = parseErrorMessage(); // Update processed errors on prop change
-}, { immediate: true });
+watch(
+  () => props.errorMessage,
+  () => {
+    processedErrors.value = parseErrorMessage(); // Update processed errors on prop change
+  },
+  { immediate: true }
+);
 
 // Function to toggle the expansion state of an error message
 const toggleExpansion = (index: number) => {
@@ -138,7 +210,8 @@ const toggleExpansion = (index: number) => {
 
 // Function to toggle the expansion state of an issue within an error message
 const toggleIssueExpansion = (pipelineIndex: number, issueIndex: number) => {
-  processedErrors.value[pipelineIndex].issues[issueIndex].expanded = !processedErrors.value[pipelineIndex].issues[issueIndex].expanded; // Toggle issue expansion
+  processedErrors.value[pipelineIndex].issues[issueIndex].expanded =
+    !processedErrors.value[pipelineIndex].issues[issueIndex].expanded; // Toggle issue expansion
 };
 </script>
 

--- a/webview-ui/src/components/ui/alerts/ErrorAlert.vue
+++ b/webview-ui/src/components/ui/alerts/ErrorAlert.vue
@@ -118,7 +118,7 @@ const props = defineProps<{
 defineEmits(["errorClose"]);
 
 // State variables
-const isExpanded = ref(false); // Tracks whether the error details are expanded
+const isExpanded = ref(true); // Tracks whether the error details are expanded
 const processedErrors = ref<FormattedErrorMessage[]>([]); // Holds the formatted error messages
 
 // Function to parse the error message and format it


### PR DESCRIPTION
# Overview  
This PR improves the display of asset validation error messages for a more intuitive user experience.  

### Key Improvements  
- Previously, error messages were always collapsed by default, requiring multiple manual expansions to view details when validating a single asset, a single pipeline, or multiple pipelines.  
- Now, error messages for single asset and single pipeline validation are automatically expanded by default, reducing unnecessary clicks.  
- For multiple pipeline validations, the messages remain collapsed to prevent overwhelming the interface.  


![validation-error-expansion-behvior](https://github.com/user-attachments/assets/0e7253b0-0fb5-4f03-ad25-967215b2016a)
