### PR TITLE
Ensure ConnectionForm Resets When Switching Between Edit and New Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.32.11] - [2024-01-30]
+- Fixed ConnectionForm not resetting when switching between edit and new connection.
 
 ## [0.32.10] - [2024-01-30]
 - Improved truncation behavior for pipeline and asset names and ensured asset name edit mode closes on mouse leave.

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ Access the Bruin CLI management tab `Settings` in the side panel for easy instal
 
 ## Release Notes
 
-### Latest Release: 0.32.10
-- Improved truncation behavior for pipeline and asset names and ensured asset name edit mode closes on mouse leave.
+### Latest Release: 0.32.11
+- Fixed ConnectionForm not resetting when switching between edit and new connection.
 
 ### Previous Highlights
+- **0.32.10**: Improved truncation behavior for pipeline and asset names and ensured asset name edit mode closes on mouse leave.
 - **0.32.9**: Asset validation errors now expand for single assets and pipelines, while multiple pipeline errors stay collapsed.
 - **0.32.8**: Fixed an issue where new files opened in the side panel's group, causing confusion; the panel now locks by default.
 - **0.32.7**: Updated config schema to support more SSL modes and revised Athena schema.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.32.10",
+  "version": "0.32.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.32.10",
+      "version": "0.32.11",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.32.10",
+  "version": "0.32.11",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -18,6 +18,7 @@
 
     <div v-if="showForm" class="mt-6 bg-editorWidget-bg shadow sm:rounded-lg p-6" ref="formRef">
       <ConnectionForm
+        :key="connectionFormKey"
         :connection="connectionToEdit"
         :isEditing="isEditing"
         :environments="environments"
@@ -38,7 +39,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, nextTick } from "vue";
 import BruinCLI from "@/components/bruin-settings/BruinCLI.vue";
 import ConnectionsList from "@/components/connections/ConnectionList.vue";
 import ConnectionForm from "@/components/connections/ConnectionsForm.vue";
@@ -63,6 +64,10 @@ const showDeleteAlert = ref(false);
 const connectionToDelete = ref(null);
 const formError = ref(null);
 const formRef = ref(null);
+
+const connectionFormKey = computed(() => {
+  return connectionToEdit.value?.id ? `edit-${connectionToEdit.value.id}` : "new-connection";
+});
 
 onMounted(() => {
   window.addEventListener("message", handleMessage);
@@ -156,44 +161,47 @@ const handleConnectionEdited = (payload) => {
 };
 
 const showConnectionForm = (connection = null, duplicate = false) => {
-  if (connection) {
-    const duplicatedName = duplicate ? `${connection.name} (Copy)` : connection.name;
-    if (connection.type === "google_cloud_platform") {
-      console.log("Connection to edit:--------", connection.service_account_file);
-      connectionToEdit.value = {
-        ...connection,
-        name: duplicatedName,
-        credentials: {
-          service_account_file: connection.service_account_file || "",
-          service_account_json: connection.service_account_json || "",
+  // Reset form state before showing new data
+  closeConnectionForm();
+  nextTick(() => {
+    if (connection) {
+      const duplicatedName = duplicate ? `${connection.name} (Copy)` : connection.name;
+      if (connection.type === "google_cloud_platform") {
+        console.log("Connection to edit:--------", connection.service_account_file);
+        connectionToEdit.value = {
           ...connection,
-        },
-      };
+          name: duplicatedName,
+          credentials: {
+            service_account_file: connection.service_account_file || "",
+            service_account_json: connection.service_account_json || "",
+            ...connection,
+          },
+        };
+      } else {
+        connectionToEdit.value = {
+          ...connection,
+          name: duplicatedName,
+          // Ensure credentials and other fields are preserved
+          credentials: { ...connection },
+        };
+      }
+
+      // Set isEditing to true only if not duplicating
+      isEditing.value = !duplicate;
     } else {
+      // Default empty connection object if creating a new connection
       connectionToEdit.value = {
-        ...connection,
-        name: duplicatedName,
-        // Ensure credentials and other fields are preserved
-        credentials: { ...connection },
+        name: "",
+        type: "",
+        environment: "",
+        credentials: {},
       };
+      isEditing.value = false;
     }
 
-    // Set isEditing to true only if not duplicating
-    isEditing.value = !duplicate;
-  } else {
-    // Default empty connection object if creating a new connection
-    connectionToEdit.value = {
-      name: "",
-      type: "",
-      environment: "",
-      credentials: {},
-    };
-    isEditing.value = false;
-  }
-
-  // Show the form
-  showForm.value = true;
-
+    // Show the form
+    showForm.value = true;
+  });
   // Scroll to form
   setTimeout(() => {
     if (formRef.value) {

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -123,8 +123,6 @@ const handleConnectionDeleted = async (payload) => {
   }
 };
 
-
-
 const handleConnectionCreated = (payload) => {
   if (payload.status === "success") {
     try {
@@ -237,8 +235,6 @@ const handleConnectionSubmit = async (connectionData) => {
     formError.value = { field: "connection_name", message: error.message };
   }
 };
-
-
 
 const closeConnectionForm = () => {
   showForm.value = false;


### PR DESCRIPTION
# PR Overview

This PR ensures the connection form resets properly when switching from editing a connection to creating a new one.

## Key Changes:
- A dynamic key was added to force reactivity.
- Used `nextTick` to ensure the form updates correctly.