### PR TITLE
Fix Issue with Terminal Commands Missing Letters when Sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
-## [0.32.12] - [2024-02-04]
+## [0.32.12] - [2024-02-05]
+- Resolved an issue where terminal commands occasionally missed the first letter, causing execution failures.
+
+## [0.32.12] - [2024-02-05]
 - Format the rendering error message to display differently based on the phase (rendering or validation).
 
 ## [0.32.11] - [2024-01-30]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
-## [0.32.12] - [2024-02-05]
+## [0.32.13] - [2024-02-05]
 - Resolved an issue where terminal commands occasionally missed the first letter, causing execution failures.
 
 ## [0.32.12] - [2024-02-05]

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ Access the Bruin CLI management tab `Settings` in the side panel for easy instal
 
 ## Release Notes
 
-### Latest Release: 0.32.12
-- Format the rendering error message to display differently based on the phase (rendering or validation).
+### Latest Release: 0.32.13
+- Resolved an issue where terminal commands occasionally missed the first letter, causing execution failures.
 
 ### Previous Highlights
+- **0.32.12**: Format the rendering error message to display differently based on the phase (rendering or validation).
 - **0.32.11**: Fixed ConnectionForm not resetting when switching between edit and new connection.
 - **0.32.10**: Improved truncation behavior for pipeline and asset names and ensured asset name edit mode closes on mouse leave.
 - **0.32.9**: Asset validation errors now expand for single assets and pipelines, while multiple pipeline errors stay collapsed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.32.12",
+  "version": "0.32.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.32.12",
+      "version": "0.32.13",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.32.12",
+  "version": "0.32.13",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/bruin/bruinUtils.ts
+++ b/src/bruin/bruinUtils.ts
@@ -167,7 +167,13 @@ export const runInIntegratedTerminal = async (
     command = `${bruinExecutable} ${BRUIN_RUN_SQL_COMMAND} ${flags} ${escapedAssetPath}`;
   }
   terminal.show(true);
+  // send a dummy call to the terminal to ensure it is ready to accept the command
+  terminal.sendText(" ");
+  // send the command to the terminal after a delay
+  setTimeout(() => {
   terminal.sendText(command);
+}, 500);
+  // wait for the command to be executed 
   await new Promise((resolve) => setTimeout(resolve, 1000));
 };
 

--- a/src/ui-test/commands.test.ts
+++ b/src/ui-test/commands.test.ts
@@ -25,11 +25,24 @@ describe("Sample Command palette tests", function () {
     } else {
       await terminalView.executeCommand(`${bruinExecutable} --version`);
     }
-    //await terminalView.executeCommand("bruin --version");
+
     const terminalOutput = await terminalView.getText();
     console.log(terminalOutput);
     const versionAvailble =
       terminalOutput.includes("Current: ") && terminalOutput.includes("Latest: ");
-    //assert.strictEqual(versionAvailble, true);
+    assert.strictEqual(versionAvailble, true);
+  });
+
+  //test run command with dummy input and delay 
+  it("Testing run command with dummy call and delay", async () => {
+    const terminalView = await new TerminalView();
+    await terminalView.selectChannel("Bruin Terminal");
+    await terminalView.executeCommand(" ");
+    await sleep(1000);
+    await terminalView.executeCommand("bruin run --help");
+    const terminalOutput = await terminalView.getText();
+    console.log("terminal output", terminalOutput);
+    const helpAvailable = terminalOutput.includes("bruin run - run a Bruin pipeline");        
+    assert.strictEqual(helpAvailable, true);
   });
 });

--- a/src/ui-test/commands.test.ts
+++ b/src/ui-test/commands.test.ts
@@ -8,7 +8,7 @@ import * as os from "os";
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe("Sample Command palette tests", function () {
-  it("Testing install Bruin CLI command", async () => {
+  it("Testing install Bruin CLI command", async function () {
     await new Workbench().executeCommand("Install Bruin CLI");
     await sleep(5000);
     const terminalView = await new TerminalView();
@@ -21,8 +21,7 @@ describe("Sample Command palette tests", function () {
 
     // Use Git Bash on Windows
     if (process.platform === "win32") {
-      const bruinExecutableWindows = path.join(os.homedir(), ".local", "bin", "bruin.exe");
-      await terminalView.executeCommand(`"${bruinExecutableWindows}" --version`);
+      this.skip();
     } else {
       await terminalView.executeCommand(`${bruinExecutable} --version`);
     }

--- a/src/ui-test/commands.test.ts
+++ b/src/ui-test/commands.test.ts
@@ -21,7 +21,8 @@ describe("Sample Command palette tests", function () {
 
     // Use Git Bash on Windows
     if (process.platform === "win32") {
-      await terminalView.executeCommand(`"${bruinExecutable}" --version`);
+      const bruinExecutableWindows = path.join(os.homedir(), ".local", "bin", "bruin.exe");
+      await terminalView.executeCommand(`"${bruinExecutableWindows}" --version`);
     } else {
       await terminalView.executeCommand(`${bruinExecutable} --version`);
     }
@@ -33,16 +34,20 @@ describe("Sample Command palette tests", function () {
     assert.strictEqual(versionAvailble, true);
   });
 
-  //test run command with dummy input and delay 
-  it("Testing run command with dummy call and delay", async () => {
+  //test run command with dummy input and delay
+  it("Testing run command with dummy call and delay", async function () {
+    let bruinExecutable = 'bruin';
+    if(process.platform === "win32"){
+       bruinExecutable = path.join(os.homedir(), ".local", "bin", "bruin.exe");
+    }
     const terminalView = await new TerminalView();
     await terminalView.selectChannel("Bruin Terminal");
     await terminalView.executeCommand(" ");
     await sleep(1000);
-    await terminalView.executeCommand("bruin run --help");
+    await terminalView.executeCommand(`"${bruinExecutable}" run --help`);
     const terminalOutput = await terminalView.getText();
     console.log("terminal output", terminalOutput);
-    const helpAvailable = terminalOutput.includes("bruin run - run a Bruin pipeline");        
+    const helpAvailable = terminalOutput.includes("bruin run - run a Bruin pipeline");
     assert.strictEqual(helpAvailable, true);
   });
 });


### PR DESCRIPTION
# PR Overview

This PR fixes an issue where the `run` command sent to the terminal was sometimes missing the first letter, causing the terminal to display an incorrect command message or "command not found" errors.  

To resolve this, the fix:  
- Sends a dummy input to wake up the terminal before executing the command.  
- Adds a timeout to ensure the terminal is fully ready before sending the command.  
- Includes integration tests to validate the fix.
