### PR TITLE
Display Bruin Render Button for all File Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
-## [0.33.0] - [2024-02-05]
+## [0.33.1] - [2024-02-07]
+- Display render button for all file extensions, ensuring Bruin render is always visible.
+
+## [0.33.0] - [2024-02-07]
 - Adde a Control panel with zoom, view fit, and lock buttons and reduced top gap in the lineage flow.
 
 ## [0.32.13] - [2024-02-05]

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ Access the Bruin CLI management tab `Settings` in the side panel for easy instal
 
 ## Release Notes
 
-### Latest Release: 0.33.0
-- Added a Control panel with zoom, view fit, and lock buttons and reduced top gap in the lineage flow.
+### Latest Release: 0.33.1
+- Display render button for all file extensions, ensuring Bruin render is always visible.
 
 ### Recent Updates
-
+- **0.33.0**: Added a Control panel with zoom, view fit, and lock buttons and reduced top gap in the lineage flow.
 - **0.32.13**: Resolved an issue where terminal commands occasionally missed the first letter, causing execution failures.
 - **0.32.12**: Format the rendering error message to display differently based on the phase (rendering or validation).
 - **0.32.11**: Fixed ConnectionForm not resetting when switching between edit and new connection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
       "editor/title": [
         {
           "command": "bruin.renderSQL",
-          "when": "resourceExtname == .sql || resourceExtname == .py  || resourceExtname == .yml || resourceExtname == .yaml",
           "group": "navigation"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "engines": {
     "vscode": "^1.87.0"
   },


### PR DESCRIPTION
# PR Overview 

Ensure the Bruin Render Button is always visible for all file extensions. This helps new users install the CLI directly from the extension, eliminating the previous issue where the button wouldn't appear unless there is a bruin project.