### PR TITLE
Improve Lineage Panel Styling

### DIFF
--- a/webview-ui/src/LineageApp.vue
+++ b/webview-ui/src/LineageApp.vue
@@ -1,18 +1,6 @@
 <template>
   <vscode-panels :activeid="`tab-${activeTab}`" aria-label="Tabbed Content">
-    <!-- Tab Headers -->
-    <vscode-panel-tab :id="`tab-lineage`">
-      <div class="flex items-center justify-center">
-        <span> Lineage </span>
-        <ArrowPathIcon
-          @click="refreshGraphLineage"
-          class="ml-2 w-4 h-4 text-link-activeForeground hover:text-progressBar-bg focus:outline-none"
-          title="Refresh"
-        />
-      </div>
-    </vscode-panel-tab>
 
-    <!-- Tab Content -->
     <vscode-panel-view
       v-for="(tab, index) in tabs"
       :key="`view-${index}`"
@@ -35,7 +23,6 @@ import { vscode } from "@/utilities/vscode";
 import { ref, onMounted, onUnmounted, computed } from "vue";
 import { updateValue } from "./utilities/helper";
 import { getAssetDataset } from "@/components/lineage-flow/asset-lineage/useAssetLineage";
-import { ArrowPathIcon } from "@heroicons/vue/20/solid";
 
 /**
  * LineageApp Component
@@ -102,30 +89,13 @@ onUnmounted(() => {
   window.removeEventListener("message", handleMessage);
 });
 
-/**
- * Debounce function to limit the rate at which a function can fire.
- * 
- * @param {Function} func - The function to debounce.
- * @param {number} wait - The number of milliseconds to wait before calling the function.
- * @returns {Function} - A debounced version of the function.
- */
-const debounce = (func, wait) => {
-  let timeout;
-  return function executedFunction(...args) {
-    clearTimeout(timeout);
-    timeout = setTimeout(() => func(...args), wait);
-  };
-};
+
 
 /**
  * Refreshes the lineage graph by sending a message to the VSCode extension.
  * 
  * @param {Event} event - The click event that triggered the refresh.
  */
-const refreshGraphLineage = debounce((event: Event) => {
-  event.stopPropagation(); // Prevent event bubbling
-  vscode.postMessage({ command: "bruin.assetGraphLineage" });
-}, 300); // 300ms debounce time
 
 /**
  * Loads lineage data by sending a message to the VSCode extension.

--- a/webview-ui/tailwind.config.js
+++ b/webview-ui/tailwind.config.js
@@ -109,6 +109,7 @@ module.exports = {
         "commandCenter-bg":"var(--vscode-commandCenter-background)",
         "icon-forground": "var(--vscode-icon-foreground)",
         "dropdown-bg": "var(--vscode-dropdown-background)",
+        "notificationCenter-border": "var(--vscode-notificationCenter-border)",
 
         "primary": {
           DEFAULT: "hsl(var(--primary))",


### PR DESCRIPTION
# PR Overview

This PR improves the style of the lineage panel, key changes include :
- Move the option panel to the top right 
- Make the option panel collapsed by default and expandable on click 
- Remove the lineage tab and display the graph directly
- move the refresh button to the filter panel 