### PR TITLE
Improve Description Editing with Save, Cancel, and Click-Outside Functionality

### DIFF
--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -29,6 +29,7 @@
               v-model="editableDescription"
               class="w-full h-40 bg-input-background border-0 text-input-foreground text-xs"
               ref="descriptionInput"
+              @blur="cancelDescriptionEdit"
               :class="{ 'truncate-description': shouldTruncate && !isExpanded }"
             ></textarea>
             <div class="absolute top-0 right-0 mt-1 mr-1 flex gap-2">

--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -23,14 +23,23 @@
           >
             <PencilIcon class="h-4 w-4" aria-hidden="true" />
           </vscode-button>
-          <textarea
-            v-if="isEditingDescription"
-            v-model="editableDescription"
-            class="w-full h-40 bg-input-background border-0 text-input-foreground text-xs"
-            ref="descriptionInput"
-            @blur="saveDescriptionEdit"
-            :class="{ 'truncate-description': shouldTruncate && !isExpanded }"
-          ></textarea>
+
+          <div v-if="isEditingDescription" class="relative">
+            <textarea
+              v-model="editableDescription"
+              class="w-full h-40 bg-input-background border-0 text-input-foreground text-xs"
+              ref="descriptionInput"
+              :class="{ 'truncate-description': shouldTruncate && !isExpanded }"
+            ></textarea>
+            <div class="absolute top-0 right-0 mt-1 mr-1 flex gap-2">
+              <vscode-button title="cancel" appearance="icon" @click.stop="cancelDescriptionEdit">
+                <XIcon class="h-4 w-4" aria-hidden="true" />
+              </vscode-button>
+              <vscode-button title="save" appearance="icon" @click.stop="saveDescriptionEdit">
+                <CheckIcon class="h-4 w-4" aria-hidden="true" />
+              </vscode-button>
+            </div>
+          </div>
         </div>
 
         <button
@@ -70,7 +79,8 @@ import MessageAlert from "@/components/ui/alerts/AlertMessage.vue";
 import MarkdownIt from "markdown-it";
 import AssetGeneral from "./AssetGeneral.vue";
 import { vscode } from "@/utilities/vscode";
-import {  ChevronDownIcon, ChevronUpIcon, PencilIcon } from "@heroicons/vue/20/solid";
+import { ChevronDownIcon, ChevronUpIcon, PencilIcon } from "@heroicons/vue/20/solid";
+import { CheckIcon, XIcon } from "lucide-vue-next";
 
 const props = defineProps<{
   name: string;
@@ -86,13 +96,12 @@ const props = defineProps<{
 const descriptionRef = ref<HTMLElement | null>(null);
 const isExpanded = ref(false);
 const contentHeight = ref(0);
-const maxHeight = 160; // 40px * 4 lines
+const maxHeight = 160;
 const editableDescription = ref(props.description);
 const isEditingDescription = ref(false);
 const showEditButton = ref(false);
 const descriptionInput = ref<HTMLTextAreaElement | null>(null);
 
-// Update content height measurement
 const updateContentHeight = async () => {
   await nextTick();
   if (descriptionRef.value) {
@@ -100,12 +109,10 @@ const updateContentHeight = async () => {
   }
 };
 
-// Check if content height exceeds max-height
 const shouldTruncate = computed(() => {
   return contentHeight.value > maxHeight && props.description;
 });
 
-// Only show button if there's content that needs truncating
 const shouldShowButton = computed(() => {
   return shouldTruncate.value;
 });
@@ -119,7 +126,6 @@ onMounted(async () => {
   vscode.postMessage({ command: "bruin.getConnectionsList" });
   await updateContentHeight();
 
-  // Add resize observer to handle dynamic content changes
   if (descriptionRef.value) {
     const resizeObserver = new ResizeObserver(() => {
       updateContentHeight();
@@ -128,26 +134,32 @@ onMounted(async () => {
   }
 });
 
-
-// Functions for editing description
 const startEditingDescription = () => {
   isEditingDescription.value = true;
-  showEditButton.value = false; // Hide button in edit mode
+  showEditButton.value = false;
+  editableDescription.value = props.description; // Reset to original value when starting edit
   nextTick(() => {
     descriptionInput.value?.focus();
   });
 };
+
 const emit = defineEmits(["update:description"]);
+
 const saveDescriptionEdit = () => {
   if (editableDescription.value.trim() !== props.description) {
     emit("update:description", editableDescription.value.trim());
     console.log("Updating description:", editableDescription.value.trim());
   }
   isEditingDescription.value = false;
-  showEditButton.value = true; // Show button again after edit mode
+  showEditButton.value = false;
 };
 
-// Watch for description changes and update height
+const cancelDescriptionEdit = () => {
+  editableDescription.value = props.description; // Reset to original value
+  isEditingDescription.value = false;
+  showEditButton.value = false;
+};
+
 watch(
   () => props.description,
   async () => {
@@ -181,7 +193,6 @@ const markdownDescription = computed(() => {
   return md.render(props.description);
 });
 
-// State for description editing
 watch(
   () => props.description,
   (newDescription) => {

--- a/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
+++ b/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
@@ -33,7 +33,7 @@
           :selected-node-id="selectedNodeId"
         />
       </template>
-      <Panel position="top-right">
+      <!-- <Panel position="top-right">
         <div
           v-if="!expandPanel"
           @click="expandPanel = !expandPanel"
@@ -91,7 +91,7 @@
             </vscode-link>
           </div>
         </div>
-      </Panel>
+      </Panel> -->
       <Controls
         :position="PanelPosition.BottomLeft"
         showZoom


### PR DESCRIPTION
# PR Overview 
This PR updates the description editing by adding
- Save and Cancel buttons to explicitly confirm or discard changes.
- Click-outside detection to automatically cancel editing when clicking outside the textarea.

![description-editing](https://github.com/user-attachments/assets/faa50c50-0815-497a-bdeb-867b7cf5088d)

