### PR TITLE
Release/v0.33.2 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.33.2] - [2024-02-14]
+- Improve description editing by adding clear Save and Cancel buttons.
+
 ## [0.33.1] - [2024-02-07]
 - Display render button for all file extensions, ensuring Bruin render is always visible.
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ Access the Bruin CLI management tab `Settings` in the side panel for easy instal
 
 ## Release Notes
 
-### Latest Release: 0.33.1
-- Display render button for all file extensions, ensuring Bruin render is always visible.
+### Latest Release: 0.33.2
+- Improve description editing by adding clear Save and Cancel buttons.
 
 ### Recent Updates
+- **0.33.1**: Display render button for all file extensions, ensuring Bruin render is always visible.
 - **0.33.0**: Added a Control panel with zoom, view fit, and lock buttons and reduced top gap in the lineage flow.
 - **0.32.13**: Resolved an issue where terminal commands occasionally missed the first letter, causing execution failures.
 - **0.32.12**: Format the rendering error message to display differently based on the phase (rendering or validation).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.33.1",
+      "version": "0.33.2",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -33,7 +33,8 @@
             "rs.sql",
             "ms.sql",
             "synapse.sql",
-            "ingestr"
+            "ingestr",
+            "duckdb.seed"
           ],
           "description": "The type of the asset"
         },


### PR DESCRIPTION
# PR Overview

This PR updates the README and CHANGELOG files and modifies the YAML schema to include `duckdb.seed` as a valid asset type.