### PR TITLE
Refactor Query Command Method to Use Environment and Asset Flags  

### DIFF
--- a/src/bruin/queryCommand.ts
+++ b/src/bruin/queryCommand.ts
@@ -27,46 +27,36 @@ export class BruinQueryOutput extends BruinCommand {
     environment: string,
     asset: string,
     limit: string,
-    {
-      flags = [
-        "-o", 
-        "json",
-        "-env", 
-        environment, 
-        "-asset", 
-        asset,
-        "-limit",
-        limit
-      ],
-      ignoresErrors = false,
-    }: BruinCommandOptions = {}
+    { flags = [], ignoresErrors = false }: BruinCommandOptions = {}
   ): Promise<void> {
-    if(!environment) {
-      flags = [
-        "-o", 
-        "json",
-        "-asset", 
-        asset,
-        "-limit",
-        limit
-      ]
+    // Construct base flags dynamically
+    const constructedFlags = ["-o", "json"];
+    if (environment) {
+      constructedFlags.push("-env", environment);
     }
-    await this.run([...flags], { ignoresErrors })
-      .then(
-        (result) => {
-          const output = result;
-          console.log("SQL query output:", output); // Debug message
-          this.postMessageToPanels("success", output);
-          return output;
-        },
-        (error) => {
-          console.error("Error occurred while running query:", error); // Debug message
-          this.postMessageToPanels("error", error);
-        }
-      )
-      .catch((err) => {
-        console.error("Query command error", err);
-      });
+    constructedFlags.push("-asset", asset, "-limit", limit);
+
+    // Use provided flags or fallback to constructed flags
+    const finalFlags = flags.length > 0 ? flags : constructedFlags;
+  
+    try {
+      const result = await this.run(finalFlags, { ignoresErrors });
+      if (result.includes("flag provided but not defined")) {
+        this.postMessageToPanels(
+          "error",
+          "This feature requires the latest Bruin CLI version. Please update your CLI."
+        );
+        return;
+      }
+      console.log("SQL query output:", result);
+
+      this.postMessageToPanels("success", result);
+    } catch (error: any) {
+      console.error("Error occurred while running query:", error);
+      const errorMessage = error.message || error.toString();
+
+      this.postMessageToPanels("error", errorMessage);
+    }
   }
 
   /**

--- a/src/bruin/queryCommand.ts
+++ b/src/bruin/queryCommand.ts
@@ -24,20 +24,33 @@ export class BruinQueryOutput extends BruinCommand {
    * @returns {Promise<void>} A promise that resolves when the execution is complete or an error is caught.
    */
   public async getOutput(
-    connection: string,
-    query: string,
+    environment: string,
+    asset: string,
+    limit: string,
     {
       flags = [
-        "-c", 
-        connection, 
-        "-q", 
-        query,
         "-o", 
-        "json"
+        "json",
+        "-env", 
+        environment, 
+        "-asset", 
+        asset,
+        "-limit",
+        limit
       ],
       ignoresErrors = false,
     }: BruinCommandOptions = {}
   ): Promise<void> {
+    if(!environment) {
+      flags = [
+        "-o", 
+        "json",
+        "-asset", 
+        asset,
+        "-limit",
+        limit
+      ]
+    }
     await this.run([...flags], { ignoresErrors })
       .then(
         (result) => {

--- a/src/extension/commands/queryCommand.ts
+++ b/src/extension/commands/queryCommand.ts
@@ -4,7 +4,7 @@ import { getDefaultBruinExecutablePath } from "../configuration";
 import { BruinQueryOutput } from "../../bruin/queryCommand";
 
 
-export const getQueryOutput = async (connection: string, query: string, lastRenderedDocumentUri: Uri | undefined) => {
+export const getQueryOutput = async (environment: string, limit: string, lastRenderedDocumentUri: Uri | undefined) => {
   if (!lastRenderedDocumentUri) {
     return;
   }
@@ -12,21 +12,7 @@ export const getQueryOutput = async (connection: string, query: string, lastRend
     getDefaultBruinExecutablePath(),
     await bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath)!! as string
   );
-  const queryResult = await output.getOutput(connection, query);
+  const queryResult = await output.getOutput(environment, lastRenderedDocumentUri.fsPath, limit);
   return queryResult;
 };
 
-
-export const getRenderedQuery = async (lastRenderedDocumentUri: Uri | undefined) => {
-  if (!lastRenderedDocumentUri) {
-    return undefined;
-  }
-
-  const render = new BruinRenderUnmaterliazed(
-    getDefaultBruinExecutablePath(),
-    await bruinWorkspaceDirectory(lastRenderedDocumentUri.fsPath)!! as string
-  );
-
-  const result = await render.getRenderedQuery(lastRenderedDocumentUri.fsPath);
-  return { query: result.query };
-};

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -60,7 +60,9 @@
       </div>
       <!-- Results Table -->
       <div v-if="parsedOutput && !error" class="overflow-auto h-[calc(100vh-33px)] w-full">
-        <table class="w-[calc(100vw-100px)] bg-editor-bg font-mono font-normal text-xs border-t-0 border-collapse">
+        <table
+          class="w-[calc(100vw-100px)] bg-editor-bg font-mono font-normal text-xs border-t-0 border-collapse"
+        >
           <thead class="bg-editor-bg border-y-0">
             <tr>
               <th
@@ -103,12 +105,17 @@
   </div>
 </template>
 
-
 <script setup lang="ts">
-import { computed, ref } from "vue";
-import { XMarkIcon, DocumentDuplicateIcon } from "@heroicons/vue/20/solid";
+import { computed, onMounted, ref } from "vue";
+import { XMarkIcon } from "@heroicons/vue/20/solid";
 import { PlayIcon, TableCellsIcon } from "@heroicons/vue/24/outline";
 import { vscode } from "@/utilities/vscode";
+import { storeToRefs } from "pinia";
+import { useConnectionsStore } from "@/store/bruinStore"; // Add this import
+
+const connectionsStore = useConnectionsStore();
+// Initialize the store
+const { defaultEnvironment } = storeToRefs(connectionsStore); // Use storeToRefs to maintain reactivity
 
 const props = defineProps<{
   output: any;
@@ -118,7 +125,6 @@ const props = defineProps<{
 const limit = ref(100);
 const tabs = ref([{ id: "output", label: "Output" }]);
 const activeTab = ref("output");
-
 const error = computed(() => {
   if (!props.error) return null;
 
@@ -153,7 +159,10 @@ const runQuery = () => {
   if (limit.value > 1000 || limit.value < 1) {
     limit.value = 1000;
   }
-  vscode.postMessage({ command: "bruin.getQueryOutput", payload: { limit: limit.value } });
+  vscode.postMessage({
+    command: "bruin.getQueryOutput",
+    payload: { environment: defaultEnvironment.value, limit: limit.value.toString() },
+  });
 };
 const clearQueryOutput = () => {
   vscode.postMessage({ command: "bruin.clearQueryOutput" });
@@ -178,7 +187,7 @@ thead th {
 }
 
 thead th::after {
-  content: '';
+  content: "";
   position: absolute;
   left: 0;
   bottom: 0;


### PR DESCRIPTION
# PR Description:

This PR:

- Refactors the query command method to utilize environment and asset flags.
- Adds a keyboard shortcut to run the query preview for improved usability.
- Fallback on outdated CLI versions

## Error on Outdated CLI versions (Test on version v0.11.142)
![Screenshot 2025-02-24 at 11 48 35](https://github.com/user-attachments/assets/de950594-74f3-456e-8f9d-73cdb5c5bec1)

## Next Steps:
Currently, only the default environment is used. Future updates will implement support for environment changes.

![query-preview-2](https://github.com/user-attachments/assets/99b86ad7-9ad0-47cc-b330-4d470e920e03)
