### PR TITLE
Update CustomChecks to Accept `0` as a Valid Check Value  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.37.1] - [2024-02-28]
+- Fixed CustomChecks to correctly recognize `0` as a valid check value instead `undefined`.
 
 ## [0.37.0] - [2024-02-28]
 - Added search functionality to the Query Preview Panel.

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ Access the Bruin CLI management tab `Settings` in the side panel for easy instal
 
 ## Release Notes
 
-### Latest Release: 0.37.0
-- Added search functionality to the Query Preview Panel.
+### Latest Release: 0.37.1
+- Fixed CustomChecks to correctly recognize `0` as a valid check value instead `undefined`.
 
 ### Recent Updates
+- **0.37.0**: Added search functionality to the Query Preview Panel.
 - **0.36.0**: Added support for executing `selected queries` in the Query Preview Panel. The selected queries should belong to a valid `bruin` asset.
 - **0.35.3**: Optimize payload size for description and asset name updates and improve error handling.
 - **0.35.2**: Adjust the styling of the save and cancel buttons in the description editing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.37.0",
+      "version": "0.37.1",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/asset/columns/custom-checks/CustomChecks.vue
+++ b/webview-ui/src/components/asset/columns/custom-checks/CustomChecks.vue
@@ -25,7 +25,7 @@
           </td>
           <!-- Value -->
           <td class="px-2 py-1 font-medium font-mono text-xs w-1/6 text-center">
-            <div v-if="check.value" class="truncate" :title="check.value">
+            <div v-if="check.value !== null && check.value !== undefined" class="truncate" :title="String(check.value)">
               {{ check.value }}
             </div>
             <div v-else class="italic opacity-70 truncate whitespace-normal">undefined</div>

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -127,7 +127,7 @@ export interface CustomChecks {
   description: string;
   id: string;
   name: string;
-  value: string;
+  value: string | number;
   query: string;
 }
 


### PR DESCRIPTION
# PR Overview 

This PR updates the `CustomChecks` logic to correctly handle `0` as a valid check value, ensuring it is not mistakenly considered `undefined`.