### PR TITLE
Add Tab Management Functionality to QueryPreview  

### DIFF
--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -37,9 +37,9 @@
                 <span
                   v-if="tab.id !== 'output' && (hoveredTab === tab.id || activeTab === tab.id)"
                   @click.stop="closeTab(tab.id)"
-                  class="ml-1 px-1 rounded hover:bg-editorWidget-bg"
+                  class="flex items-center hover:bg-editorWidget-bg"
                 >
-                  <span class="codicon codicon-close"></span>
+                  <span class="ml-1 text-center codicon codicon-close"></span>
                 </span>
               </button>
             </div>
@@ -168,7 +168,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { TableCellsIcon } from "@heroicons/vue/24/outline";
 import { vscode } from "@/utilities/vscode";
 import QuerySearch from "../ui/query-preview/QuerySearch.vue";
-import type { Tab } from "@/types";
+import type { TabData } from "@/types";
 
 const props = defineProps<{
   output: any;
@@ -180,17 +180,6 @@ const limit = ref(100);
 const showSearchInput = ref(false);
 const hoveredTab = ref("");
 const environment = ref("");
-
-// Tab system
-interface TabData extends Tab {
-  parsedOutput: any | undefined;
-  error: string | null;
-  isLoading: boolean;
-  searchInput: string;
-  filteredRows: any[];
-  totalRowCount: number;
-  filteredRowCount: number;
-}
 
 const tabs = ref<TabData[]>([
   {

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -18,7 +18,7 @@
               max="1000"
             />
           </div>
-          <div class="flex items-center space-x-2 opacity-50">
+          <div class="flex items-center space-x-1 opacity-50">
             <button
               v-for="tab in tabs"
               :key="tab.id"
@@ -34,6 +34,9 @@
                 <span> {{ tab.label }} </span>
               </div>
             </button>
+            <vscode-button title="Add Tab" appearance="icon" @click="addTab">
+              <span class="codicon codicon-add"></span>
+            </vscode-button>
           </div>
         </div>
 
@@ -62,7 +65,7 @@
       </div>
     </div>
     <!-- Query Output Tab -->
-    <div v-if="activeTab === 'output'" class="relative">
+    <div v-if="activeTab" class="relative">
       <div
         v-if="isLoading"
         class="fixed inset-0 flex items-center justify-center bg-editor-bg bg-opacity-50 z-50"
@@ -156,6 +159,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { TableCellsIcon } from "@heroicons/vue/24/outline";
 import { vscode } from "@/utilities/vscode";
 import QuerySearch from "../ui/query-preview/QuerySearch.vue";
+import type { Tab } from "@/types";
 const props = defineProps<{
   output: any;
   error: any;
@@ -163,14 +167,25 @@ const props = defineProps<{
 }>();
 
 const limit = ref(100);
-const tabs = ref([{ id: "output", label: "Output" }]);
-const activeTab = ref("output");
+const tabs = ref<Tab[]>([]);
+const activeTab = ref<string>("");
 const environment = ref("");
 const searchInput = ref("");
 const showSearchInput = ref(false);
 const filteredRowCount = ref(0);
 const totalRowCount = ref(0);
 
+const addTab = () => {
+  tabs.value.push({
+    id: `tab-${tabs.value.length}`, label: `Tab ${tabs.value.length + 1}`,
+    parsedOutput: undefined,
+    error: undefined,
+    isLoading: false,
+    searchInput: "",
+    totalRowCount: 0,
+    filteredRowCount: 0
+  });
+};
 const error = computed(() => {
   if (!props.error) return null;
 

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -143,3 +143,13 @@ export interface Tab {
   totalRowCount: number;
   filteredRowCount: number;
 }
+
+export interface TabData extends Tab {
+  parsedOutput: any | undefined;
+  error: string | null;
+  isLoading: boolean;
+  searchInput: string;
+  filteredRows: any[];
+  totalRowCount: number;
+  filteredRowCount: number;
+}

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -132,3 +132,14 @@ export interface CustomChecks {
 }
 
 export type ErrorPhase = "Validating" | "Rednering";
+
+export interface Tab {
+  id: string;
+  label: string;
+  parsedOutput: any;
+  error: any;
+  isLoading: boolean;
+  searchInput: string;
+  totalRowCount: number;
+  filteredRowCount: number;
+}


### PR DESCRIPTION
# PR Overview
- Introduced multi-tab support in the `QueryPreview` component, allowing users to manage multiple query results simultaneously.  
- Improved query execution flow to support switching between different query result tabs.
- Updated the `search` functionality to support multi-tab.

![query-preview-multi-tab](https://github.com/user-attachments/assets/631f638a-4eee-4f95-8624-f3976ae42b55)
