### PR TITLE
Enable Tab Label Editing on Double-Click

### DIFF
--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -152,4 +152,11 @@ export interface TabData extends Tab {
   filteredRows: any[];
   totalRowCount: number;
   filteredRowCount: number;
+  isEditing: boolean;
+}
+
+export interface EditingState {
+  tabId: string;
+  originalLabel: string;
+  currentLabel: string;
 }


### PR DESCRIPTION
# PR Overview

This PR introduces functionality to allow users to edit tab labels in the `query preview` by double-clicking on them.

![tab-rename](https://github.com/user-attachments/assets/6ae1ed17-d886-444c-8af2-ce7370d26219)
