### PR TITLE
Update Keybinding Display Based on Platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.38.5] - [2025-03-10]
+- Update keybinding display for platforms and remove unused 'value' property in columns checks.
+
 ## [0.38.4] - [2025-03-07]
 - Improved columns checks Dropdown positioning and run button UI on windows.
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 
-### Latest Release: 0.38.4
-- Improved columns checks Dropdown positioning and run button UI on windows.
+### Latest Release: 0.38.5
+- Update keybinding display for platforms and remove unused 'value' property in columns checks.
 
 ### Recent Updates
-- **0.38.3** Replaced markdown-preview auto-lock workaround with a custom preview to fix serialization errors and enable auto-refresh.
+- **0.38.4**: Improved columns checks Dropdown positioning and run button UI on windows.
+- **0.38.3**: Replaced markdown-preview auto-lock workaround with a custom preview to fix serialization errors and enable auto-refresh.
 - **0.38.2**: Refactored command payload to handle undefined environment values.
 - **0.38.1**: Added support for tab label editing via double-click and refactored query data loading to prevent automatic execution on mount.
 - **0.38.0**: Added multi-tab support to the QueryPreview component, allowing users to manage multiple query results simultaneously.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.38.4",
+  "version": "0.38.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.38.4",
+      "version": "0.38.5",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.38.4",
+  "version": "0.38.5",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -501,7 +501,7 @@ const handleEnvironmentChange = (env) => {
   });
 };
 
-function buildCommandPayload(basePayload, options = {}) {
+function buildCommandPayload(basePayload, options: { downstream?: boolean; continue?: boolean } = {}) {
   const { downstream = false, continue: continueFlag = false } = options;
   let payload = basePayload;
 

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -492,8 +492,7 @@ const modifierKey = ref('⌘'); // Default to Mac symbol
 
 onMounted(() => {
   // Detect if running on Windows or macOS
-  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-  
+  const isMac = navigator.platform.toUpperCase().startsWith('MAC');  
   // Update the modifier key symbol based on platform
   modifierKey.value = isMac ? '⌘' : 'Ctrl';
 });

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -125,8 +125,8 @@
           </vscode-button>
           <span class="opacity-50">Run query preview</span>
           <div class="flex items-center">
-            <span class="keybinding"> ⌘ </span>
-            <span class="keybinding">Enter</span>
+            <span class="keybinding">{{ modifierKey }}</span>
+            <span class="keybinding"> Enter </span>
           </div>
         </div>
       </div>
@@ -488,7 +488,15 @@ onMounted(() => {
     tabs.value[0].isLoading = props.isLoading;
   }
 });
+const modifierKey = ref('⌘'); // Default to Mac symbol
 
+onMounted(() => {
+  // Detect if running on Windows or macOS
+  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  
+  // Update the modifier key symbol based on platform
+  modifierKey.value = isMac ? '⌘' : 'Ctrl';
+});
 onUnmounted(() => {
   window.removeEventListener("keydown", handleKeyDown);
   window.removeEventListener("message", postMessage);


### PR DESCRIPTION
# Pr Overview 

This PR adjusts keybinding display to dynamically show the appropriate symbols based on the user's platform (Windows/ macOS).
