### PR TITLE
Implement Expandable Cells in Query Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.39.2] - [2025-03-11]
+- Added expandable cells in Query Preview for long text, with `copy` support and `ESC` to close all expanded cells.
+
 ## [0.39.1] - [2025-03-11]
 - Adjust column layout to set primary key as a separate column.
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 
-### Latest Release: 0.39.1
-- Adjust column layout to set primary key as a separate column.
+### Latest Release: 0.39.2
+- Added expandable cells in Query Preview for long text, with `copy` support and `ESC` to close all expanded cells.
 
 ### Recent Updates
+- **0.39.1**: Adjust column layout to set primary key as a separate column.
 - **0.39.0**: Added primary_key to column data with support for composite primary keys.
 - **0.38.5**: Update keybinding display for platforms and remove unused 'value' property in columns checks.
 - **0.38.4**: Improved columns checks Dropdown positioning and run button UI on windows.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.39.1",
+      "version": "0.39.2",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/asset/columns/AssetColumns.vue
+++ b/webview-ui/src/components/asset/columns/AssetColumns.vue
@@ -6,16 +6,16 @@
 
     <!-- Header Row -->
     <div
-      class="grid grid-cols-12 gap-2 px-2 py-1 font-semibold text-xs opacity-65 border-b-2 border-editor-fg items-center"
+      class="grid grid-cols-21 gap-2 px-2 py-1 font-semibold text-xs opacity-65 border-b-2 border-editor-fg items-center"
     >
-      <div class="col-span-1 flex justify-center" title="Primary key">
+      <div class="col-span-1" title="Primary key">
         <KeyIcon class="h-4 w-4 text-editor-fg opacity-60" />
       </div>
-      <div class="col-span-2">Name</div>
-      <div class="col-span-2">Type</div>
-      <div class="col-span-3">Description</div>
-      <div class="col-span-3">Checks</div>
-      <div class="col-span-1 text-center">Actions</div>
+      <div class="col-span-4">Name</div>
+      <div class="col-span-4">Type</div>
+      <div class="col-span-6">Description</div>
+      <div class="col-span-4">Checks</div>
+      <div class="col-span-2 text-center">Actions</div>
     </div>
 
     <!-- Column Rows -->
@@ -24,9 +24,9 @@
         v-if="localColumns.length"
         v-for="(column, index) in localColumns"
         :key="index"
-        class="grid grid-cols-12 gap-2 px-2 py-1 border-b items-center text-xs border-commandCenter-border"
+        class="grid grid-cols-21 gap-2 px-2 py-1 border-b items-center text-xs border-commandCenter-border"
       >
-        <div class="col-span-1 flex justify-center">
+        <div class="col-span-1">
           <vscode-checkbox
             :checked="column.primary_key"
             :disabled="editingIndex !== index"
@@ -36,7 +36,7 @@
           </vscode-checkbox>
         </div>
         <!-- Name -->
-        <div class="col-span-2 font-medium font-mono text-xs">
+        <div class="col-span-4 font-medium font-mono text-xs">
           <div v-if="editingIndex === index" class="flex flex-col gap-1">
             <input
               v-model="editingColumn.name"
@@ -65,7 +65,7 @@
         </div>
 
         <!-- Type -->
-        <div class="col-span-2 text-xs">
+        <div class="col-span-4 text-xs">
           <div v-if="editingIndex === index" class="flex flex-col gap-1">
             <div class="flex items-center">
               <input
@@ -82,7 +82,7 @@
         </div>
 
         <!-- Description -->
-        <div class="col-span-3 text-xs">
+        <div class="col-span-6 text-xs">
           <input
             v-if="editingIndex === index"
             v-model="editingColumn.description"
@@ -99,7 +99,7 @@
         </div>
 
         <!-- Checks -->
-        <div class="col-span-3">
+        <div class="col-span-4">
           <div class="flex flex-wrap gap-1">
             <template v-if="editingIndex === index">
               <div class="flex flex-wrap gap-1">
@@ -202,7 +202,7 @@
         </div>
 
         <!-- Actions -->
-        <div class="col-span-1">
+        <div class="col-span-2">
           <div class="flex justify-center items-center space-x-1">
             <vscode-button
               v-if="editingIndex === index"

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -176,7 +176,7 @@
                       'max-h-6 overflow-hidden': !isExpanded(index, colIndex),
                       'max-h-12 overflow-y-auto': isExpanded(index, colIndex),
                     }"
-                    class="transition-all duration-200 pr-6"
+                    class="transition-all duration-75 pr-6"
                   >
                     <!-- Cell content with word-wrapping when expanded -->
                     <div

--- a/webview-ui/tailwind.config.js
+++ b/webview-ui/tailwind.config.js
@@ -175,6 +175,11 @@ module.exports = {
         "collapsible-down": "collapsible-down 0.2s ease-in-out",
         "collapsible-up": "collapsible-up 0.2s ease-in-out",
       },
+      gridTemplateColumns: {
+        '16': 'repeat(16, minmax(0, 1fr))',
+        '24': 'repeat(24, minmax(0, 1fr))',
+        '21': 'repeat(21, minmax(0, 1fr))',
+      },
     },
   },
   plugins: [typography, animate, require("@tailwindcss/forms")],


### PR DESCRIPTION
# PR Overview  

This PR enhances the handling of long text in cells by introducing expandability.  
- Adds an expand arrow for truncated text.  
- Enables selecting and copying content directly.  
- Allows closing all expanded cells at once using `esc` key.

![expand-cells-query-preview](https://github.com/user-attachments/assets/53f95bf7-5e68-44c1-b210-df80794697be)
