### PR TITLE
Refactor QueryPreview to set 'tab-1' as default and add reset panel functionality  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.39.5] - [2025-03-20]
+- Set 'tab-1' as the default tab in QueryPreview and added a reset panel functionality.
+
 ## [0.39.4] - [2025-03-18]
 - Enable state persistence in `Query Preview` to retain query output when switching between VS Code panels.
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 
-### Latest Release: 0.39.4
-- Enable state persistence in `Query Preview` to retain query output when switching between VS Code panels.
+### Latest Release: 0.39.5
+- Set 'tab-1' as the default tab in QueryPreview and added a reset panel functionality.
+
 
 ### Recent Updates
+- **0.39.4**: Enable state persistence in `Query Preview` to retain query output when switching between VS Code panels.
 - **0.39.3**: Added environment display to the query preview panel, showing the selected environment from the side panel dropdown.
 - **0.39.2**: Added expandable cells in Query Preview for long text, with `copy` support and `ESC` to close all expanded cells.
 - **0.39.1**: Adjust column layout to set primary key as a separate column.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.39.4",
+      "version": "0.39.5",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -272,25 +272,25 @@ const hoveredTab = ref("");
 
 // State for expanded cells
 const expandedCells = ref(new Set<string>());
-
+const defaultTab = {
+  id: "tab-1",
+  label: "Tab 1",
+  parsedOutput: undefined,
+  error: null,
+  isLoading: false,
+  searchInput: "",
+  limit: 100,
+  filteredRows: [],
+  totalRowCount: 0,
+  filteredRowCount: 0,
+  isEditing: false,
+  environment: currentEnvironment.value,
+};
 const tabs = shallowRef<TabData[]>([
-  {
-    id: "tab-1", 
-    label: "Tab 1", 
-    parsedOutput: undefined,
-    error: null,
-    isLoading: false,
-    searchInput: "",
-    limit: 100,
-    filteredRows: [],
-    totalRowCount: 0,
-    filteredRowCount: 0,
-    isEditing: false,
-    environment: currentEnvironment.value,
-  },
+  defaultTab,
 ]);
 
-const activeTab = ref<string>("tab-1"); 
+const activeTab = ref<string>("tab-1");
 const tabCounter = ref(2); // Start from 2 since we already have "Tab 1"
 
 // Get current active tab
@@ -334,37 +334,24 @@ const addTab = () => {
 // Reset the entire panel
 const resetPanel = () => {
   // Clear all tabs except the first one
-  tabs.value = [
-    {
-      id: "tab-1",
-      label: "Tab 1",
-      parsedOutput: undefined,
-      error: null,
-      isLoading: false,
-      searchInput: "",
-      limit: 100,
-      filteredRows: [],
-      totalRowCount: 0,
-      filteredRowCount: 0,
-      isEditing: false,
-      environment: currentEnvironment.value,
-    },
-  ];
-  
+  tabs.value = [defaultTab];
+
   // Reset tab counter
   tabCounter.value = 2;
-  
+
   // Set active tab to the first tab
   activeTab.value = "tab-1";
-  
+
   // Reset expanded cells
   expandedCells.value.clear();
-  
+
+  // Hide search input
+  showSearchInput.value = false;
   // Clear state from storage
   vscode.postMessage({
     command: "bruin.resetState",
   });
-  
+
   // Force UI update
   nextTick(() => {
     triggerRef(tabs);
@@ -453,7 +440,7 @@ window.addEventListener("message", (event) => {
         filteredRows: t.parsedOutput?.rows || [],
       }));
 
-      activeTab.value = state.activeTab || "tab-1"; 
+      activeTab.value = state.activeTab || "tab-1";
       expandedCells.value = new Set(state.expandedCells || []);
       showSearchInput.value = state.showSearchInput || false;
     }
@@ -508,16 +495,16 @@ const closeTab = (tabId: string) => {
       }
       // If no tabs left, default to "tab-1"
       else {
-        activeTab.value = "tab-1"; 
+        activeTab.value = "tab-1";
       }
     }
 
     // Remove tab
     tabs.value.splice(tabIndex, 1);
 
-    if (tabs.value.length === 1 && tabs.value[0].id === "tab-1") { 
+    if (tabs.value.length === 1 && tabs.value[0].id === "tab-1") {
       // Reset the counter when all custom tabs are closed
-      tabCounter.value = 2; 
+      tabCounter.value = 2;
     }
 
     // Clear editing state if closing edited tab


### PR DESCRIPTION
# PR Overview
This PR refactors the QueryPreview component by:  
- Setting 'tab-1' as the default tab for consistency.  
- Adding a reset panel functionality to clear the state and restore defaults.