### PR TITLE
Fix tooltip alignment and styling in CustomNodes component

### DIFF
--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -48,7 +48,7 @@
             <!-- Tooltip -->
             <div
               v-if="isTruncated"
-              class="absolute left-0 top-0 w-max px-2 text-sm rounded opacity-0 py-1 group-hover:opacity-100 transition-opacity duration-200 group-hover:cursor-pointer"
+              class="absolute left-0 top-0 w-max font-mono rounded opacity-0 whitespace-nowrap group-hover:opacity-100 transition-opacity duration-200 group-hover:cursor-pointer"
               :class="selectedStyle.main"
             >
               {{ label }}


### PR DESCRIPTION
# PR Overview
This PR updates the tooltip styling in the CustomNodes component to resolve alignment issues. 

### Before
![tooltip-lineage-node-before](https://github.com/user-attachments/assets/c5293982-10ff-41ac-b5b0-4b105afdf505)

### After
![tooltip-lineage-node-after](https://github.com/user-attachments/assets/4f8087ce-9961-4eca-a676-c9b1f278553c)
