### PR TITLE
Add ToggleFoldingsCommand for Custom Bruin Folding Regions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -704,11 +704,11 @@
       "integrity": "sha512-AMy9i+nLXtIKix8o6ME6Q+WA+CBhHwtTzxegJ15Yq6FjHRwhvlUSIUwt0bacr/kPMYJ5KdttrXRHuNMOAo2N1A=="
     },
     "node_modules/@rudderstack/rudder-sdk-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@rudderstack/rudder-sdk-node/-/rudder-sdk-node-2.1.1.tgz",
-      "integrity": "sha512-Gp14dAXwB0PqfOYl1LyQJocp3lV8XOXiBG1sVKD/NtThLs2T+SJSOA/+9SqoIhOWEwfm7wuXvLNCDaTwsQP2Kg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@rudderstack/rudder-sdk-node/-/rudder-sdk-node-2.1.3.tgz",
+      "integrity": "sha512-8d7+QIQ0qyj/JtAxkL859zMUH+72p8GxFjlhoB+0/FHAUDi9iC7hwKR6C8HpD57NN5SO5dabTfD2njhIEDX2eg==",
       "dependencies": {
-        "axios": "1.7.7",
+        "axios": "1.8.2",
         "axios-retry": "4.5.0",
         "component-type": "2.0.0",
         "join-component": "1.1.0",
@@ -2128,9 +2128,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -193,6 +193,12 @@
         "title": "Install Bruin CLI",
         "category": "Bruin",
         "description": "Install the Bruin CLI."
+      }, 
+      {
+        "command": "bruin.toggleFoldings",
+        "title": "Toggle Folding",
+        "category": "Bruin",
+        "description": "Toggle the folding state of custom Bruin foldable regions in Python and SQL files."
       }
     ]
   },

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -92,7 +92,6 @@ export async function toggleFoldingsCommand(toggled: boolean): Promise<void> {
   } else {
     // Unfold only Bruin regions
     if (bruinRanges.length > 0) {
-      // For unfolding, we need to create text selections at each folded region
       const selections: vscode.Selection[] = bruinRanges.map(range => 
         new vscode.Selection(range.start, 0, range.start, 0)
       );

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -2,6 +2,7 @@ import path = require("path");
 import * as vscode from "vscode";
 import * as fs from "fs";
 import * as os from "os";
+import { bruinFoldingRangeProvider } from "../providers/bruinFoldingRangeProvider";
 
 /**
  * Gets the path to the Bruin executable specified by the workspace
@@ -67,6 +68,50 @@ export function getPathSeparator(): string {
 }
 
 let documentInitState = new Map();
+
+export async function toggleFoldingsCommand(toggled: boolean): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    return;
+  }
+  
+  const docUri = editor.document.uri.toString();
+  
+  // Get the Bruin-specific folding ranges using the provider
+  const bruinRanges = bruinFoldingRangeProvider(editor.document);
+  
+  if (toggled) {
+    // Fold only Bruin regions
+    if (bruinRanges.length > 0) {
+      await vscode.commands.executeCommand("editor.fold", {
+        selectionLines: bruinRanges.map(range => range.start),
+        levels: 1
+      });
+      console.log(`Folded ${bruinRanges.length} Bruin regions in ${editor.document.uri}`);
+    }
+  } else {
+    // Unfold only Bruin regions
+    if (bruinRanges.length > 0) {
+      // For unfolding, we need to create text selections at each folded region
+      const selections: vscode.Selection[] = bruinRanges.map(range => 
+        new vscode.Selection(range.start, 0, range.start, 0)
+      );
+      
+      editor.selections = selections;
+      await vscode.commands.executeCommand("editor.unfold");
+      
+      // Restore original selection
+      const originalSelection = editor.selection;
+      editor.selection = originalSelection;
+      
+      console.log(`Unfolded ${bruinRanges.length} Bruin regions in ${editor.document.uri}`);
+    }
+  }
+
+  // Mark this document as initialized
+  documentInitState.set(docUri, true);
+}
+
 
 /**
  * Applies the initial folding state to a document based on the user's configuration settings.


### PR DESCRIPTION
# PR Overview

This PR adds the toggleFoldingsCommand, enabling users to manage custom foldable regions in Bruin directly from the command palette.

![toggle-folding-command](https://github.com/user-attachments/assets/dd035665-6838-4ae1-bce9-fc8f094bae62)

