### PR TITLE
Improve YAML Editing Experience by Reducing Immediate Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.40.1] - [2025-03-28]
+- Implement debounce mechanism for rendering command in BruinPanel.
+
 ## [0.40.0] - [2025-03-28]
 - Enable adding, removing, and editing custom checks in asset columns.
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 
 ## Release Notes
-### Latest Release: 0.40.0
-- Enable adding, removing, and editing custom checks in asset columns.
+### Latest Release: 0.40.1
+- Implement debounce mechanism for rendering command in BruinPanel.
 
 ### Recent Updates
+- **0.40.0**: Enable adding, removing, and editing custom checks in asset columns.
 - **0.39.8**: Fix flickering issue, optimize data loading in LineagePanel, and improve cleanup.
 - **0.39.7**: Sorted connection types alphabetically and refactored their formatting to use title case.
 - **0.39.6**: Added  `Toggle Folding` Command, enabling users to manage custom foldable regions in Bruin directly from the command palette.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -10,7 +10,6 @@ import {
 import { getDefaultBruinExecutablePath } from "../extension/configuration";
 import * as vscode from "vscode";
 import { renderCommandWithFlags } from "../extension/commands/renderCommand";
-import { lineageCommand } from "../extension/commands/lineageCommand";
 import { parseAssetCommand, patchAssetCommand } from "../extension/commands/parseAssetCommand";
 import { getEnvListCommand } from "../extension/commands/getEnvListCommand";
 import { BruinInstallCLI } from "../bruin/bruinInstallCli";
@@ -76,7 +75,6 @@ export class BruinPanel {
 
           //renderCommand(extensionUri);
           renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
-          lineageCommand(this._lastRenderedDocumentUri);
           parseAssetCommand(this._lastRenderedDocumentUri);
         }
       }),
@@ -95,7 +93,6 @@ export class BruinPanel {
 
           //renderCommand(extensionUri);
           renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
-          lineageCommand(this._lastRenderedDocumentUri);
           parseAssetCommand(this._lastRenderedDocumentUri);
         }
       })
@@ -397,12 +394,6 @@ export class BruinPanel {
                 message: "",
               });
             }, 1500);
-            break;
-          case "bruin.getAssetLineage":
-            if (!this._lastRenderedDocumentUri) {
-              return;
-            }
-            lineageCommand(this._lastRenderedDocumentUri);
             break;
 
           case "bruin.getAssetDetails":

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -40,7 +40,7 @@ export class BruinPanel {
   private _disposables: Disposable[] = [];
   private _lastRenderedDocumentUri: Uri | undefined;
   private _flags: string = "";
-
+  private _debounceTimeout: NodeJS.Timeout | undefined;
   /**
    * The BruinPanel class private constructor (called only from the render method).
    *
@@ -59,6 +59,10 @@ export class BruinPanel {
 
     this._disposables.push(
       workspace.onDidChangeTextDocument((editor) => {
+        if (this._debounceTimeout) {
+          clearTimeout(this._debounceTimeout);
+        }
+
         if (editor && editor.document.uri.fsPath.endsWith(".bruin.yml")) {
           getEnvListCommand(this._lastRenderedDocumentUri);
           getConnections(this._lastRenderedDocumentUri);
@@ -72,13 +76,17 @@ export class BruinPanel {
           )
             ? this._lastRenderedDocumentUri
             : editor.document.uri;
-
-          //renderCommand(extensionUri);
-          renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
           parseAssetCommand(this._lastRenderedDocumentUri);
+
+          this._debounceTimeout = setTimeout(() => {
+            renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
+          }, 2000);
         }
       }),
       window.onDidChangeActiveTextEditor((editor) => {
+        if (this._debounceTimeout) {
+          clearTimeout(this._debounceTimeout);
+        }
         if (editor && editor.document.uri) {
           if (editor.document.uri.fsPath === "tasks") {
             return;
@@ -162,6 +170,11 @@ export class BruinPanel {
 
     // Dispose of the current webview panel
     this._panel.dispose();
+
+    // Clear the timeout
+    if (this._debounceTimeout) {
+      clearTimeout(this._debounceTimeout);
+    }
 
     // Dispose of all disposables (i.e. commands) for the current webview panel
     while (this._disposables.length) {

--- a/webview-ui/src/LineageApp.vue
+++ b/webview-ui/src/LineageApp.vue
@@ -19,8 +19,7 @@
 
 <script setup lang="ts">
 import AssetLineageFlow from "@/components/lineage-flow/asset-lineage/AssetLineage.vue";
-import { vscode } from "@/utilities/vscode";
-import { ref, onMounted, onUnmounted, computed } from "vue";
+import { ref, onUnmounted, computed } from "vue";
 import { updateValue } from "./utilities/helper";
 import { getAssetDataset } from "@/components/lineage-flow/asset-lineage/useAssetLineage";
 
@@ -84,28 +83,11 @@ const tabs = ref([
   },
 ]);
 
-onMounted(() => {
-  loadLineageData();
-});
 
 onUnmounted(() => {
   window.removeEventListener("message", handleMessage);
 });
 
-
-
-/**
- * Refreshes the lineage graph by sending a message to the VSCode extension.
- * 
- * @param {Event} event - The click event that triggered the refresh.
- */
-
-/**
- * Loads lineage data by sending a message to the VSCode extension.
- */
-function loadLineageData() {
-  vscode.postMessage({ command: "bruin.getAssetLineage" });
-}
 </script>
 <style>
 vscode-panel-view {


### PR DESCRIPTION
# PR Overview
This PR resolves the issue where the VS Code extension validates YAML content on every keystroke, causing disruptive flashing of errors and warnings. Now, validation is delayed (2 seconds) to prevent unnecessary error displays while users are actively editing.

## Changes 
- Implemented a debounce mechanism for rendering commands in `BruinPanel` to delay the render command.
- Removed the lineage command and related functionality from `BruinPanel`.  
- Update README and CHANGELOG for a new patch release.
