### PR TITLE
Add connectionName to QueryPreview with State Persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+
+## [0.40.2] - [2025-03-28]
+- Displayed connection name in QueryPreview.
+
 ## [0.40.1] - [2025-03-28]
-- Implement debounce mechanism for rendering command in BruinPanel.
+- Implemented debounce mechanism for rendering command in BruinPanel.
 
 ## [0.40.0] - [2025-03-28]
-- Enable adding, removing, and editing custom checks in asset columns.
+- Enabled adding, removing, and editing custom checks in asset columns.
 
 ## [0.39.8] - [2025-03-27]
-- Fix flickering issue, optimize data loading in LineagePanel, and improve cleanup.
+- Fixed flickering issue, optimize data loading in LineagePanel, and improve cleanup.
 
 ## [0.39.7] - [2025-03-21]
 - Sorted connection types alphabetically and refactored their formatting to use title case.

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 
 ## Release Notes
-### Latest Release: 0.40.1
-- Implement debounce mechanism for rendering command in BruinPanel.
+### Latest Release: 0.40.2
+- Displayed connection name in QueryPreview.
 
 ### Recent Updates
+- **0.40.1**: Implement debounce mechanism for rendering command in BruinPanel.
 - **0.40.0**: Enable adding, removing, and editing custom checks in asset columns.
 - **0.39.8**: Fix flickering issue, optimize data loading in LineagePanel, and improve cleanup.
 - **0.39.7**: Sorted connection types alphabetically and refactored their formatting to use title case.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.40.1",
+      "version": "0.40.2",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/QueryPreviewApp.vue
+++ b/webview-ui/src/QueryPreviewApp.vue
@@ -74,8 +74,9 @@ const selectedEnvironment = computed(() => {
   const selected = currentEnvironment.value;
   return selected || "";
 });
+
+
 const output = computed(() => {
-  console.log("QueryOutput.value in output", QueryOutput.value);
   if (!QueryOutput.value) return null;
   try {
     return typeof QueryOutput.value === "string"
@@ -113,13 +114,14 @@ const tabs = ref([
       error: errorValue.value,
       isLoading: isLoading.value,
       environment: selectedEnvironment.value,
+      connectionName:output.value?.connectionName || "",
     })),
   },
 ]);
 
 watch(output, (newValue) => {
   if (newValue) {
-    console.log("output changed", newValue);
+    //currentConnectionName.value = newValue?.connectionName || "";
   }
 });
 

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -71,10 +71,10 @@
           <!-- Search Component -->
           <div class="flex items-center space-x-2">
             <span class="text-2xs text-editor-fg opacity-65">Running in:</span>
-            <vscode-badge :class="badgeClass">
+            <vscode-badge :class="badgeClass" class="truncate">
               {{ currentEnvironment }}
             </vscode-badge>
-            <vscode-badge v-if="currentTab?.parsedOutput?.connectionName" :class="badgeClass">
+            <vscode-badge v-if="currentTab?.parsedOutput?.connectionName" :class="badgeClass" class="truncate">
               {{ currentTab?.parsedOutput.connectionName  }}
             </vscode-badge>
           </div>
@@ -878,6 +878,15 @@ thead th::after {
   border-bottom: 1px solid var(--vscode-commandCenter-border);
   z-index: 1;
 }
+vscode-badge {
+  min-width: 0;
+  flex-shrink: 1;
+}
+
+vscode-badge::part(control) {
+  max-width: 100%;
+  overflow: hidden;
+}
 </style>
 
 <style>
@@ -885,7 +894,6 @@ body {
   padding: 0 !important;
   margin: 0 !important;
 }
-
 .keybinding {
   background-color: var(--vscode-keybindingLabel-background);
   border-top: 1px solid transparent;

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -74,6 +74,9 @@
             <vscode-badge :class="badgeClass">
               {{ currentEnvironment }}
             </vscode-badge>
+            <vscode-badge v-if="currentTab?.parsedOutput?.connectionName" :class="badgeClass">
+              {{ currentTab?.parsedOutput.connectionName  }}
+            </vscode-badge>
           </div>
           <QuerySearch
             :visible="showSearchInput"
@@ -261,11 +264,12 @@ const props = defineProps<{
   error: any;
   isLoading: boolean;
   environment: string;
+  connectionName: string;
 }>();
 
 const currentEnvironment = ref<string>(props.environment);
 const modifierKey = ref("⌘"); // Default to Mac symbol
-
+const currentConnectionName = ref("");
 const limit = ref(100);
 const showSearchInput = ref(false);
 const hoveredTab = ref("");
@@ -285,10 +289,9 @@ const defaultTab = {
   filteredRowCount: 0,
   isEditing: false,
   environment: currentEnvironment.value,
+  connectionName: props.connectionName,
 };
-const tabs = shallowRef<TabData[]>([
-  defaultTab,
-]);
+const tabs = shallowRef<TabData[]>([defaultTab]);
 
 const activeTab = ref<string>("tab-1");
 const tabCounter = ref(2); // Start from 2 since we already have "Tab 1"
@@ -324,6 +327,7 @@ const addTab = () => {
     filteredRowCount: 0,
     isEditing: false,
     environment: currentEnvironment.value,
+    connectionName: currentConnectionName.value,
   });
 
   tabCounter.value++;
@@ -373,6 +377,7 @@ const saveState = () => {
     totalRowCount: tab.totalRowCount,
     filteredRowCount: tab.filteredRowCount,
     environment: currentEnvironment.value,
+    connectionName: tab.connectionName,
     tabCounter: tabCounter.value,
   }));
 
@@ -382,6 +387,7 @@ const saveState = () => {
     activeTab: activeTab.value,
     expandedCells: Array.from(expandedCells.value),
     environment: currentEnvironment.value,
+    connectionName: currentConnectionName.value,
     showSearchInput: showSearchInput.value,
     tabCounter: tabCounter.value,
   };
@@ -411,6 +417,7 @@ const reviveParsedOutput = (parsedOutput: any) => {
       ...parsedOutput,
       rows: parsedOutput.rows || [],
       columns: parsedOutput.columns || [],
+      connectionName: parsedOutput.connectionName || parsedOutput.meta?.connectionName || null,
     };
   } catch (e) {
     console.error("Error reviving parsed output:", e);
@@ -422,7 +429,6 @@ window.addEventListener("message", (event) => {
   const message = event.data;
   if (message.command === "bruin.restoreState") {
     const state = message.payload;
-
     if (state) {
       if (state.tabCounter) {
         tabCounter.value = state.tabCounter;
@@ -430,16 +436,20 @@ window.addEventListener("message", (event) => {
       if (state.environment) {
         currentEnvironment.value = state.environment;
       }
+
       // Revive complex objects
       tabs.value = (state.tabs || []).map((t) => ({
         ...t,
         parsedOutput: t.parsedOutput ? reviveParsedOutput(t.parsedOutput) : undefined,
+        connectionName: reviveParsedOutput(t.parsedOutput)?.connectionName || t.connectionName,
         error: t.error ? new Error(t.error.message) : null,
         isLoading: false,
         isEditing: false,
         filteredRows: t.parsedOutput?.rows || [],
       }));
 
+      currentConnectionName.value =
+        tabs.value.find((t) => t.id === state.activeTab)?.connectionName || state.connectionName;
       activeTab.value = state.activeTab || "tab-1";
       expandedCells.value = new Set(state.expandedCells || []);
       showSearchInput.value = state.showSearchInput || false;
@@ -601,6 +611,7 @@ watch(
       if (parsedData) {
         currentTab.value.parsedOutput = parsedData;
         currentTab.value.totalRowCount = parsedData.rows?.length || 0;
+        currentTab.value.connectionName = parsedData.connectionName;
         triggerRef(tabs);
         updateFilteredRows();
         saveState();

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -155,6 +155,7 @@ export interface TabData extends Tab {
   isEditing: boolean;
   limit: number;
   environment: string;
+  connectionName: string;
 }
 
 export interface EditingState {


### PR DESCRIPTION
# PR Overview

This PR introduces the connectionName to QueryPreview, ensuring it is displayed persistently across tabs. Additionally, it improves the styling of environment and connection badges for resizing.



![display-connection-name-queryPreview](https://github.com/user-attachments/assets/324a6656-5ea8-423b-adba-f867d548ad49)




