### PR TITLE
Set downstream Flag to False in runCurrentPipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.40.4] - [2025-03-31]
+- Remove `downstream` flag from `runWholetPipeline` command.
 
 ## [0.40.3] - [2025-03-31]
 - Added support for `emr_serverless.spark` type in asset yaml schema.

--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 
 ## Release Notes
-### Latest Release: 0.40.3
-- Added support for `emr_serverless.spark` type in asset yaml schema.
+### Latest Release: 0.40.4
+- Remove `downstream` flag from `runWholetPipeline` command.
 
 ### Recent Updates
 
+- **0.40.3**: Added support for `emr_serverless.spark` type in asset yaml schema.
 - **0.40.2**: Displayed connection name in QueryPreview.
 - **0.40.1**: Implement debounce mechanism for rendering command in BruinPanel.
 - **0.40.0**: Enable adding, removing, and editing custom checks in asset columns.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.40.3",
+  "version": "0.40.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.40.3",
+      "version": "0.40.4",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.40.3",
+  "version": "0.40.4",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -556,7 +556,7 @@ function runPipelineWithContinue() {
 }
 
 function runCurrentPipeline() {
-  const payload = buildCommandPayload(getCheckboxChangePayload(), { downstream: true });
+  const payload = buildCommandPayload(getCheckboxChangePayload(), { downstream: false });
 
   vscode.postMessage({
     command: "bruin.runCurrentPipeline",


### PR DESCRIPTION
# PR Overview

This PR updates the `run Whole Pipeline` function by setting the downstream flag to false by default. Additionally, it includes updates to the README and CHANGELOG for the new patch release (0.40.4).