### PR TITLE
Remove Debounce from BruinPanel and Add Timeout for Rendering Errors Only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to the Bruin extension will be documented in this file.
+## [0.40.5] - [2025-04-07]
+- Remove Debounce from BruinPanel and Add Timeout for Rendering Errors Only.
+
 ## [0.40.4] - [2025-03-31]
 - Remove `downstream` flag from `runWholetPipeline` command.
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 
 ## Release Notes
-### Latest Release: 0.40.4
-- Remove `downstream` flag from `runWholetPipeline` command.
+### Latest Release: 0.40.5
+- Remove Debounce from BruinPanel and Add Timeout for Rendering Errors Only.
 
 ### Recent Updates
-
+- **0.40.4**: Remove `downstream` flag from `runWholetPipeline` command.
 - **0.40.3**: Added support for `emr_serverless.spark` type in asset yaml schema.
 - **0.40.2**: Displayed connection name in QueryPreview.
 - **0.40.1**: Implement debounce mechanism for rendering command in BruinPanel.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.40.4",
+      "version": "0.40.5",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/bruin/bruinRender.ts
+++ b/src/bruin/bruinRender.ts
@@ -9,6 +9,7 @@ import {
   isYamlBruinAsset,
 } from "../utilities/helperUtils";
 import { QueryPreviewPanel } from "../panels/QueryPreviewPanel";
+import { time } from "console";
 
 /**
  * Extends the BruinCommand class to implement the rendering process specific to Bruin assets.
@@ -71,30 +72,34 @@ export class BruinRender extends BruinCommand {
     }
 
     await this.run([...flags, filePath], { ignoresErrors })
-      .then(
-        (sqlRendered) => {
+      .then((sqlRendered) => {
+        setTimeout(() => {
           BruinPanel?.postMessage("render-message", {
             status: "success",
             message: JSON.parse(sqlRendered).query,
           });
           console.log("SQL rendered successfully");
-        },
-        (error) => {
-          console.error("Error rendering SQL asset in the reject", this.parseError(error));
+        }, 0);
+        console.log("SQL rendered successfully", sqlRendered);
+      })
+      .catch((error) => {
+        console.error("Error rendering SQL asset", this.parseError(error));
+        setTimeout(() => {
           BruinPanel?.postMessage("render-message", {
             status: "error",
-            message: this.parseError(error),
+            message: this.parseError(error)
           });
-        }
-      )
-      .catch((err) => {
-        if (err.toString().includes("Incorrect")) {
+        }, 1000);
+    
+        if (error.toString().includes("Incorrect")) {
           this.runWithoutJsonFlag(filePath, ignoresErrors);
         } else {
-          console.error("Error rendering SQL asset from catch", err);
+          console.error("Error rendering SQL asset from catch", error);
         }
       });
   }
+
+
 
   private parseError(error: string): string {
     if (error.startsWith("{")) {

--- a/src/bruin/bruinRender.ts
+++ b/src/bruin/bruinRender.ts
@@ -99,15 +99,17 @@ export class BruinRender extends BruinCommand {
       });
   }
 
-
-
-  private parseError(error: string): string {
-    if (error.startsWith("{")) {
-      return error;
-    } else {
-      return JSON.stringify({ error: error });
+  private parseError(error: unknown): string {
+    if (typeof error === 'object' && error !== null) {
+      const err = error as Error;
+      return JSON.stringify({ error: err.message });
     }
+    if (typeof error === 'string') {
+      return error.startsWith("{") ? error : JSON.stringify({ error });
+    }
+    return JSON.stringify({ error: String(error) });
   }
+  
   private async isBruinPipeline(filePath: string): Promise<boolean> {
     return await isBruinPipeline(filePath);
   }

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -40,7 +40,6 @@ export class BruinPanel {
   private _disposables: Disposable[] = [];
   private _lastRenderedDocumentUri: Uri | undefined;
   private _flags: string = "";
-  private _debounceTimeout: NodeJS.Timeout | undefined;
   /**
    * The BruinPanel class private constructor (called only from the render method).
    *
@@ -59,10 +58,6 @@ export class BruinPanel {
 
     this._disposables.push(
       workspace.onDidChangeTextDocument((editor) => {
-        if (this._debounceTimeout) {
-          clearTimeout(this._debounceTimeout);
-        }
-
         if (editor && editor.document.uri.fsPath.endsWith(".bruin.yml")) {
           getEnvListCommand(this._lastRenderedDocumentUri);
           getConnections(this._lastRenderedDocumentUri);
@@ -77,16 +72,10 @@ export class BruinPanel {
             ? this._lastRenderedDocumentUri
             : editor.document.uri;
           parseAssetCommand(this._lastRenderedDocumentUri);
-
-          this._debounceTimeout = setTimeout(() => {
-            renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
-          }, 2000);
+          renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
         }
       }),
       window.onDidChangeActiveTextEditor((editor) => {
-        if (this._debounceTimeout) {
-          clearTimeout(this._debounceTimeout);
-        }
         if (editor && editor.document.uri) {
           if (editor.document.uri.fsPath === "tasks") {
             return;
@@ -170,11 +159,6 @@ export class BruinPanel {
 
     // Dispose of the current webview panel
     this._panel.dispose();
-
-    // Clear the timeout
-    if (this._debounceTimeout) {
-      clearTimeout(this._debounceTimeout);
-    }
 
     // Dispose of all disposables (i.e. commands) for the current webview panel
     while (this._disposables.length) {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -552,10 +552,13 @@ suite("BruinRender Tests", () => {
   let isBruinYamlStub: sinon.SinonStub;
   const bruinExecutablePath = "path/to/bruin/executable";
   const workingDirectory = "path/to/working/directory";
-
   setup(() => {
     bruinRender = new BruinRender(bruinExecutablePath, workingDirectory);
-    runStub = sinon.stub(bruinRender as any, "run").resolves("SQL rendered successfully");
+    runStub = sinon
+    .stub(bruinRender as any, "run")
+    .resolves(JSON.stringify({ query: "SELECT * FROM table" }));
+    runStub.rejects(new Error("Error rendering asset"));
+
     runWithoutJsonFlagStub = sinon
       .stub(bruinRender as any, "runWithoutJsonFlag")
       .resolves("Non-SQL rendered successfully");


### PR DESCRIPTION
# PR Overview
​
This PR removes the debounce logic from the event handlers in the BruinPanel, enabling immediate rendering. Additionally, it introduces a timeout mechanism within the BruinRender class to debounce error rendering for a better UX.


