### PR TITLE
Improve CLI Update UX in Settings Tab

### DIFF
--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -183,7 +183,7 @@ window.addEventListener("message", (event) => {
 
       case "bruinCliVersionStatus":
         versionStatus.value = message.versionStatus;
-        console.log("Bruin update status updated:", versionStatus.value);
+        console.log("Bruin update status updated in App.vue:", versionStatus.value);
         break;
     }
   } catch (error) {
@@ -354,6 +354,7 @@ const tabs = ref([
     props: {
       isBruinInstalled: computed(() => isBruinInstalled.value),
       environments: computed(() => environmentsList.value),
+      versionStatus: computed(() => versionStatus.value),
     },
   },
 ]);

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col space-y-6">
     <div>
-      <BruinCLI />
+      <BruinCLI :versionStatus="versionStatus" />
     </div>
 
     <div class="bg-editorWidget-bg shadow sm:rounded-lg">
@@ -39,7 +39,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from "vue";
+import { ref, computed, onMounted, nextTick, watch } from "vue";
 import BruinCLI from "@/components/bruin-settings/BruinCLI.vue";
 import ConnectionsList from "@/components/connections/ConnectionList.vue";
 import ConnectionForm from "@/components/connections/ConnectionsForm.vue";
@@ -51,6 +51,7 @@ import { v4 as uuidv4 } from "uuid";
 const props = defineProps({
   isBruinInstalled: Boolean,
   environments: Array,
+  versionStatus: Object,
 });
 
 const connectionsStore = useConnectionsStore();

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -11,11 +11,11 @@
         </div>
       </div>
       <div class="flex items-center justify-end">
-        <vscode-button
-          @click="$emit('new-connection')"
-          class="mt-2 rounded-md px-1 py-2 text-sm font-semibold"
-        >
-          New connection
+        <vscode-button @click="$emit('new-connection')" class="mt-2 font-semibold">
+          <div class="flex items-center">
+            <span class="codicon codicon-plus"></span> 
+            <span class="ml-1">Connection</span>
+          </div>
         </vscode-button>
       </div>
     </div>
@@ -150,7 +150,7 @@ import {
 import AlertMessage from "@/components/ui/alerts/AlertMessage.vue";
 import { vscode } from "@/utilities/vscode";
 import TestStatus from "@/components/ui/alerts/TestStatus.vue";
-import { onClickOutside } from '@vueuse/core'
+import { onClickOutside } from "@vueuse/core";
 const connectionsStore = useConnectionsStore();
 const connections = computed(() => connectionsStore.connections);
 const error = computed(() => connectionsStore.error);
@@ -213,7 +213,7 @@ const getMenuPosition = (event) => {
 };
 
 onClickOutside(menuRef, () => {
-  activeMenu.value = null; 
+  activeMenu.value = null;
 });
 
 const testConnection = (connection) => {
@@ -247,10 +247,10 @@ const handleConnectionTested = (payload) => {
       loadingMessage.value = payload.message;
       break;
     case "unsupported":
-    console.log("Connection test :", payload.message);
+      console.log("Connection test :", payload.message);
       connectionTestStatus.value = "unsupported";
-      supportMessage.value = payload.message;  
-    break;
+      supportMessage.value = payload.message;
+      break;
     default:
       console.error("Failed to test connection:", payload.message);
       connectionTestStatus.value = "failure";
@@ -293,6 +293,12 @@ vscode-button::part(control) {
   border: none;
   outline: none;
 }
+
+.codicon.codicon-plus {
+  font-size: 1em;
+  font-weight: 500;
+}
+
 .divide-y-opacity {
   border: 0.5;
 }


### PR DESCRIPTION
# PR Overview 
This PR improves the CLI update/install section:
- Makes the update button appear visually less prominent ( secondary).
- Updates the message next to the update button based on the CLI status.


<img width="585" alt="Cli-up-todate" src="https://github.com/user-attachments/assets/af41df6e-3e0d-4b4e-9dd5-1de5a3abb112" />
<img width="729" alt="install-cli" src="https://github.com/user-attachments/assets/b0ecc45a-cd20-4932-add0-dda5b92a44da" />
<img width="601" alt="update-cli" src="https://github.com/user-attachments/assets/9bb131e9-e61b-40e6-861d-4a9252fcaaf0" />
