### PR TITLE
Add bq.seed to yaml-assets-schema.json Asset Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
-## [0.42.1] - [2025-04-11]
+## [0.42.3] - [2025-04-16]
+- Added support for `bq.seed` type in asset yaml schema.
+
+## [0.42.2] - [2025-04-11]
 - Support multiline input for column and custom check fields.
 
 ## [0.42.1] - [2025-04-10]

--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 
 ## Release Notes
-### Latest Release: 0.42.2
-- Support multiline input for column and custom check fields.
-
+### Latest Release: 0.42.3
+- Added support for `bq.seed` type in asset yaml schema.
+    
 ### Recent Updates
+- **0.42.2**: Support multiline input for column and custom check fields.
 - **0.42.1**: Improved `CLI install` and `update` UX in Settings Tab.
 - **0.42.0**: Added export functionality to export query output to a CSV file.
 - **0.41.2**: Fixed Editing Behavior When Adding or Deleting Columns.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.42.2",
+  "version": "0.42.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.42.2",
+      "version": "0.42.3",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.42.2",
+  "version": "0.42.3",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -35,7 +35,8 @@
             "synapse.sql",
             "ingestr",
             "duckdb.seed",
-            "emr_serverless.spark"
+            "emr_serverless.spark",
+            "bq.seed"
           ],
           "description": "The type of the asset"
         },


### PR DESCRIPTION
# PR Overview 

This PR updates the asset schema to include `bq.seed` as a valid asset type in yaml-assets-schema.json.







