### PR TITLE
Enhance Lineage Nodes with Expandable Labels and Dynamic Styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [0.43.2] - [2025-04-17]
+- Added expandable labels for truncated asset names in lineage view.
+
 ## [0.43.1] - [2025-04-16]
 - Handle file renaming in BruinPanel to update last rendered document URI.
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 
 ## Release Notes
-### Latest Release: 0.43.1
-- Handle file renaming in BruinPanel to update last rendered document URI.
+### Latest Release: 0.43.2
+- Added expandable labels for truncated asset names in lineage view.
 
 ### Recent Updates
+- **0.43.1**: Handle file renaming in BruinPanel to update last rendered document URI.
 - **0.43.0**: Automatically refresh the CLI status after update.
 - **0.42.3**: Added support for `bq.seed` type in asset yaml schema.
 - **0.42.2**: Support multiline input for column and custom check fields.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.43.1",
+  "version": "0.43.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.43.1",
+      "version": "0.43.2",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.43.1",
+  "version": "0.43.2",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
+++ b/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
@@ -23,6 +23,8 @@
 
       <template #node-custom="nodeProps">
         <CustomNode
+          :expanded-nodes="expandedNodes"
+          @toggle-node-expand="toggleNodeExpand"
           :data="nodeProps.data"
           :node-props="nodeProps"
           :label="nodeProps.data.label"
@@ -165,11 +167,14 @@ const expandAllDownstreams = ref(false);
 const expandAllUpstreams = ref(false);
 const isUpdating = ref(false);
 const graphInitialized = ref(false);
-const initialLayoutComplete = ref(false); 
+const initialLayoutComplete = ref(false);
 const showLoading = ref(false);
 let loadingTimeout: ReturnType<typeof setTimeout>;
 let fitViewTimeout: ReturnType<typeof setTimeout>;
 const { viewport, setViewport } = useVueFlow();
+
+// State to track expanded nodes
+const expandedNodes = ref<{ [key: string]: boolean }>({});
 
 const onNodeClick = (nodeId: string, event: MouseEvent) => {
   console.log("Node clicked:", nodeId);
@@ -214,7 +219,6 @@ const updateNodePositions = (layout: any) => {
   });
   setNodes(updatedNodes);
 };
-
 
 // Function to update the layout using ELK
 const updateLayout = async () => {
@@ -559,6 +563,7 @@ const handleReset = async (event: Event) => {
   expandedUpstreamEdges.value = [];
   expandedDownstreamNodes.value = [];
   expandedDownstreamEdges.value = [];
+  expandedNodes.value = {};
   await updateGraph();
   await updateLayout();
 };
@@ -609,7 +614,17 @@ watch([filterType, expandAllUpstreams, expandAllDownstreams], () => {
 onUnmounted(() => {
   clearTimeout(fitViewTimeout);
 });
+
+// Method to toggle the expanded state of a node
+const toggleNodeExpand = (nodeId: string) => {
+  if (expandedNodes.value[nodeId]) {
+    expandedNodes.value[nodeId] = false;
+  } else {
+    expandedNodes.value[nodeId] = true;
+  }
+};
 </script>
+
 
 <style>
 @import "@vue-flow/core/dist/style.css";

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -100,8 +100,9 @@ const props = defineProps<BruinNodeProps & {
   selectedNodeId: string | null;
   expandAllDownstreams: boolean;
   expandAllUpstreams: boolean;
+  expandedNodes: { [key: string]: boolean };
 }>();
-const emit = defineEmits(["add-upstream", "add-downstream", "node-click"]);
+const emit = defineEmits(["add-upstream", "add-downstream", "node-click", "toggle-node-expand"]);
 
 const selectedStyle = computed(() => styles[props.data?.asset?.type || "default"] || defaultStyle);
 const selectedStatusStyle = computed(() => statusStyles[props.status || ""]);
@@ -138,7 +139,7 @@ const handleGoToDetails = (asset: any) => {
 };
 
 const label = computed(() => props.data.asset?.name || '');
-const isExpanded = ref(false);
+const isExpanded = computed(() => props.expandedNodes[props.data.asset?.name || ''] || false);
 
 const truncatedLabel = computed(() => {
   const maxLength = 26;
@@ -147,12 +148,11 @@ const truncatedLabel = computed(() => {
 });
 
 const toggleExpand = () => {
-  isExpanded.value = !isExpanded.value;
+  emit("toggle-node-expand", props.data.asset?.name);
 };
 
 const handleClickOutside = (event: MouseEvent) => {
   if (showPopup.value) closePopup();
-  isExpanded.value = false; // Collapse the node on outside click
 };
 
 const computedFontSize = computed(() => {

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -44,6 +44,15 @@
             <div class="dynamic-text" :style="{ fontSize: computedFontSize }" @click.stop="toggleExpand">
               {{ isExpanded ? label : truncatedLabel }}
             </div>
+            <!-- Tooltip -->
+            <div
+              v-if="isTruncated && !isExpanded"
+              class="absolute left-0 top-0 w-max font-mono rounded opacity-0 whitespace-nowrap group-hover:opacity-100 transition-opacity duration-200 group-hover:cursor-pointer"
+              :class="selectedStyle.main"
+              @click.stop="toggleExpand"
+            >
+              {{ label }}
+            </div>
           </div>
         </div>
       </div>
@@ -141,6 +150,7 @@ const handleGoToDetails = (asset: any) => {
 const label = computed(() => props.data.asset?.name || '');
 const isExpanded = computed(() => props.expandedNodes[props.data.asset?.name || ''] || false);
 
+const isTruncated = computed(() => label.value.length > 26);
 const truncatedLabel = computed(() => {
   const maxLength = 26;
   const name = label.value;

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -10,7 +10,7 @@
       <PlusIcon class="h-4 w-4 fill-gray-300 text-gray-700/50 hover:text-gray-700" />
     </div>
 
-    <div class="node-content" :class="assetClass" @click="togglePopup">
+    <div class="node-content" :class="[assetClass, { expanded: isExpanded }]" @click="togglePopup">
       <div
         v-if="data.type === 'asset'"
         :class="assetHighlightClass"
@@ -40,18 +40,9 @@
           :class="[selectedStyle.main, status ? '' : 'rounded-tl']"
         >
           <div class="relative group">
-            <!-- Truncated Text -->
-            <div class="truncate">
-              {{ label }}
-            </div>
-
-            <!-- Tooltip -->
-            <div
-              v-if="isTruncated"
-              class="absolute left-0 top-0 w-max font-mono rounded opacity-0 whitespace-nowrap group-hover:opacity-100 transition-opacity duration-200 group-hover:cursor-pointer"
-              :class="selectedStyle.main"
-            >
-              {{ label }}
+            <!-- Truncated Text with Expand Option -->
+            <div class="dynamic-text" :style="{ fontSize: computedFontSize }" @click.stop="toggleExpand">
+              {{ isExpanded ? label : truncatedLabel }}
             </div>
           </div>
         </div>
@@ -90,8 +81,10 @@
   />
 </template>
 
+
+
 <script lang="ts" setup>
-import { computed, defineProps, defineEmits, onMounted, onUnmounted } from "vue";
+import { computed, defineProps, defineEmits, onMounted, onUnmounted, ref } from "vue";
 import { Handle, Position } from "@vue-flow/core";
 import { PlusIcon } from "@heroicons/vue/20/solid";
 import type { BruinNodeProps } from "@/types";
@@ -120,7 +113,6 @@ const assetHasDownstreams = computed(() => isAsset.value && props.data.asset?.ha
 const showUpstreamIcon = computed(() => isAsset.value && props.data?.hasUpstreamForClicking && !props.expandAllUpstreams);
 const showDownstreamIcon = computed(() => isAsset.value && props.data?.hasDownstreamForClicking && !props.expandAllDownstreams);
 
-const isTruncated = computed(() => (props.data.asset?.name?.length || 0) > 26);
 const assetClass = computed(() => `rounded w-56 ${props.status ? selectedStatusStyle.value : ''}`);
 
 const assetHighlightClass = computed(() => {
@@ -145,9 +137,35 @@ const handleGoToDetails = (asset: any) => {
   closePopup();
 };
 
+const label = computed(() => props.data.asset?.name || '');
+const isExpanded = ref(false);
+
+const truncatedLabel = computed(() => {
+  const maxLength = 26;
+  const name = label.value;
+  return name.length > maxLength ? `${name.slice(0, maxLength)}...` : name;
+});
+
+const toggleExpand = () => {
+  isExpanded.value = !isExpanded.value;
+};
+
 const handleClickOutside = (event: MouseEvent) => {
   if (showPopup.value) closePopup();
+  isExpanded.value = false; // Collapse the node on outside click
 };
+
+const computedFontSize = computed(() => {
+  const baseSize = 12; // px
+  const maxLength = 24;
+  const length = label.value?.length || 0;
+
+  if (length > maxLength) {
+    const scale = Math.max(0.85, 1 - (length - maxLength) * 0.015);
+    return `${baseSize * scale}px`;
+  }
+  return `${baseSize}px`;
+});
 
 onMounted(() => {
   document.addEventListener("click", handleClickOutside);
@@ -157,6 +175,10 @@ onUnmounted(() => {
   document.removeEventListener("click", handleClickOutside);
 });
 </script>
+
+
+
+
 <style scoped>
 .custom-node-wrapper {
   position: relative;
@@ -164,9 +186,22 @@ onUnmounted(() => {
   align-items: center;
   width: 100%;
 }
+.dynamic-text {
+  white-space: pre-wrap; /* Allow text to wrap */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+  transition: font-size 0.2s ease;
+  cursor: pointer;
+}
 
 .node-content {
-  width: 224px; /* 14rem */
+  width: 224px; /* Consistent width */
+  transition: height 0.3s ease;
+}
+
+.node-content.expanded {
+  height: auto; /* Allow height to adjust based on content */
 }
 
 .icon-wrapper {
@@ -196,3 +231,6 @@ onUnmounted(() => {
   right: -28px;
 }
 </style>
+
+
+


### PR DESCRIPTION
# PR Overview
This PR improves the readability and UX of the Lineage `Nodes` by:

- Adding a toggle feature to expand or collapse nodes with long labels.
- Persisting expanded node states within the AssetLineage component.
- Maintaining tooltips for truncated labels to display full text on hover.
- Resetting expanded node states when the filter reset action is triggered.

### Tooltip on hover
<img width="779" alt="hover-tooltip" src="https://github.com/user-attachments/assets/523440c6-6ebd-40ee-b413-5b583da3af5d" />

### Expand on click
<img width="710" alt="click-to-expand" src="https://github.com/user-attachments/assets/a98c497c-69c3-42a8-b2c2-f484c3dd3554" />

