### PR TITLE
Add Version Selection for Bruin CLI Update

### DIFF
--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -599,6 +599,11 @@ export class BruinPanel {
           case "bruin.updateBruinCli":
             await this.updateBruinCli();
             break;
+          case "bruin.installSpecificVersion":
+            const version = message.version;
+            console.log("Installing specific version:", version);
+            await this.updateBruinCli(version);
+            break;
         }
       },
       undefined,
@@ -638,13 +643,14 @@ export class BruinPanel {
       .map(([name, _]) => `--${name.toLowerCase()}`)
       .join(" ");
   }
-  private async installBruinCli() {
+  private async installBruinCli(  ) {
     try {
       const bruinInstaller = new BruinInstallCLI();
-      await bruinInstaller.installBruinCli(() => {
+      await bruinInstaller.installBruinCli(async () => {
+        const versionStatus = await checkCliVersion();
         this._panel.webview.postMessage({
           command: "bruinCliVersionStatus",
-          versionStatus: "updated",
+          versionStatus,
         });
       });
       await this.checkAndUpdateBruinCliStatus();
@@ -653,14 +659,14 @@ export class BruinPanel {
       vscode.window.showErrorMessage("Failed to install/update Bruin CLI. Please try again.");
     }
   }
-  private async updateBruinCli() {
+  private async updateBruinCli(version?: string) {
     try {
       const bruinInstaller = new BruinInstallCLI();
-  
-      await bruinInstaller.updateBruinCli(() => {
+      await bruinInstaller.updateBruinCli(version ?? "", async () => {
+        const versionStatus = await checkCliVersion();
         this._panel.webview.postMessage({
           command: "bruinCliVersionStatus",
-          versionStatus: "updated",
+          versionStatus,
         });
       });
   

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -17,7 +17,7 @@
                 >
                   <template v-if="isEditingName">
                     <input
-                    id="asset-name-input"
+                      id="asset-name-input"
                       v-model="editingName"
                       @blur="saveNameEdit"
                       @keyup.enter="saveNameEdit"
@@ -71,8 +71,12 @@
           :id="`tab-${index}`"
           @click="activeTab = index"
         >
-          <div class="flex items-center justify-center">
+          <div class="flex items-center justify-center gap-1">
             <span>{{ tab.label }}</span>
+            <span
+              v-if="tab.label === 'Settings' && versionStatus.status === 'outdated'"
+              class="h-1 w-1 rounded-full bg-yellow-400 mt-0.5"
+            ></span>
           </div>
         </vscode-panel-tab>
 
@@ -317,12 +321,7 @@ const customChecksProps = computed(() => {
 });
 
 const customChecks = ref([...customChecksProps.value]); // Reactive reference for custom checks
-const settingsLabel = computed(() => {
-  if (versionStatus.value.status === "outdated") {
-    return "Settings ⚠️";
-  }
-  return "Settings";
-});
+
 // Define tabs for the application
 const tabs = ref([
   {
@@ -350,7 +349,7 @@ const tabs = ref([
     })),
   },
   {
-    label: settingsLabel,
+    label: "Settings",
     component: BruinSettings,
     props: {
       isBruinInstalled: computed(() => isBruinInstalled.value),

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -75,7 +75,7 @@
             <span>{{ tab.label }}</span>
             <span
               v-if="tab.label === 'Settings' && versionStatus.status === 'outdated'"
-              class="h-1 w-1 rounded-full bg-yellow-400 mt-0.5"
+              class="h-[3px] w-[3px] rounded-full bg-yellow-400 mt-0.5"
             ></span>
           </div>
         </vscode-panel-tab>

--- a/webview-ui/src/components/bruin-settings/BruinCLI.vue
+++ b/webview-ui/src/components/bruin-settings/BruinCLI.vue
@@ -54,7 +54,7 @@
                   ? 'primary'
                   : 'secondary'
               "
-              class="text-sm font-semibold rounded-r-none"
+              class="text-sm font-semibold rounded-r-none h-7"
             >
               {{ isBruinCliInstalled ? "Update" : "Install" }} CLI
             </vscode-button>
@@ -63,7 +63,7 @@
               appearance="icon"
               @click="toggleVersionOptions"
               title="Version Options"
-              class="border-l p-[1px] border-commandCenter-border text-sm font-semibold rounded-none bg-input-background text-input-foreground"
+              class="flex items-center justify-center h-7 w-7 border-l border-commandCenter-border text-sm font-semibold rounded-none bg-input-background text-input-foreground hover:bg-inputOption-hoverBackground"
             >
               <span class="codicon codicon-chevron-down"></span>
             </vscode-button>

--- a/webview-ui/src/components/bruin-settings/BruinCLI.vue
+++ b/webview-ui/src/components/bruin-settings/BruinCLI.vue
@@ -60,6 +60,7 @@
             </vscode-button>
 
             <vscode-button
+              v-if="isBruinCliInstalled"
               appearance="icon"
               @click="toggleVersionOptions"
               title="Version Options"
@@ -286,19 +287,5 @@ pre {
   word-break: break-word;
   font-size: 0.85rem;
   line-height: 1.4;
-}
-
-.rounded-r-none {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.rounded-l-none {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-
-.border-editor-fg {
-  border-color: var(--vscode-editor-foreground);
 }
 </style>


### PR DESCRIPTION
# PR Overview
This PR introduces support for managing specific versions of the Bruin CLI directly from the extension UI and improves the styling of the version status indicator in the settings label.

![install-cli-specific-version](https://github.com/user-attachments/assets/6361272f-c540-43a0-bed0-e0aee4ce9aed)
