### PR TITLE
Fix Rendering for `pipeline.yml` and `.bruin.yml` in Side Panel

### DIFF
--- a/src/bruin/bruinFlowLineage.ts
+++ b/src/bruin/bruinFlowLineage.ts
@@ -9,6 +9,26 @@ import * as vscode from "vscode";
 
 export class BruinLineageInternalParse extends BruinCommand {
   /**
+   * Parses pipeline.yml and returns pipeline-level metadata (name, schedule, etc).
+   * Does NOT look for assets or post to LineagePanel.
+   */
+  public async parsePipelineConfig(
+    filePath: string,
+    { flags = ["parse-pipeline"], ignoresErrors = false }: BruinCommandOptions = {}
+  ): Promise<any> {
+    const result = await this.run([...flags, filePath], { ignoresErrors });
+    const pipelineData = JSON.parse(result);
+    console.log("Pipeline data from parsePipelineConfig", pipelineData);
+    return {
+      name: pipelineData.name || '',
+      type: 'pipeline',
+      schedule: pipelineData.schedule || '',
+      description: pipelineData.description || '',
+      raw: pipelineData
+    };
+  }
+
+  /**
    * Specifies the Bruin command string.
    *
    * @returns {string} Returns the 'run' command string.

--- a/src/bruin/bruinFlowLineage.ts
+++ b/src/bruin/bruinFlowLineage.ts
@@ -3,6 +3,7 @@ import { BruinCommand } from "./bruinCommand";
 import { LineagePanel } from "../panels/LineagePanel";
 import { getCurrentPipelinePath } from "./bruinUtils";
 import * as vscode from "vscode";
+import { isConfigFile } from "../utilities/helperUtils";
 /**
  * Extends the BruinCommand class to implement the bruin run command on Bruin assets.
  */
@@ -51,6 +52,9 @@ export class BruinLineageInternalParse extends BruinCommand {
     { flags = ["parse-pipeline"], ignoresErrors = false }: BruinCommandOptions = {}
   ): Promise<void> {
     try {
+      if(isConfigFile(filePath)) {
+        return;
+      }
       const result = await this.run([...flags, await getCurrentPipelinePath(filePath) as string], { ignoresErrors });
       const pipelineData = JSON.parse(result);
       const asset = pipelineData.assets.find(

--- a/src/bruin/bruinFlowLineage.ts
+++ b/src/bruin/bruinFlowLineage.ts
@@ -22,7 +22,6 @@ export class BruinLineageInternalParse extends BruinCommand {
     console.log("Pipeline data from parsePipelineConfig", pipelineData);
     return {
       name: pipelineData.name || '',
-      type: 'pipeline',
       schedule: pipelineData.schedule || '',
       description: pipelineData.description || '',
       raw: pipelineData

--- a/src/bruin/bruinInternalParse.ts
+++ b/src/bruin/bruinInternalParse.ts
@@ -35,6 +35,7 @@ export class BruinInternalParse extends BruinCommand {
         // Use the new parsePipelineConfig method for pipeline.yml
         const parser = new BruinLineageInternalParse(this.bruinExecutable, this.workingDirectory);
         const pipelineMeta = await parser.parsePipelineConfig(filePath);
+        console.log("Pipeline config parsed in BruinInternalParse:", pipelineMeta);
         this.postMessageToPanels("success", JSON.stringify({ type: "pipelineConfig", ...pipelineMeta, filePath }));
         return;
       }

--- a/src/bruin/bruinInternalParse.ts
+++ b/src/bruin/bruinInternalParse.ts
@@ -31,14 +31,14 @@ export class BruinInternalParse extends BruinCommand {
     { flags = ["parse-asset"], ignoresErrors = false }: BruinCommandOptions = {}
   ): Promise<void> {
     try {
-      if (filePath.endsWith("pipeline.yml")) {
+      if (filePath.endsWith("pipeline.yml") || filePath.endsWith("pipeline.yaml")) {
         // Use the new parsePipelineConfig method for pipeline.yml
         const parser = new BruinLineageInternalParse(this.bruinExecutable, this.workingDirectory);
         const pipelineMeta = await parser.parsePipelineConfig(filePath);
         this.postMessageToPanels("success", JSON.stringify({ type: "pipelineConfig", ...pipelineMeta, filePath }));
         return;
       }
-      if (filePath.endsWith(".bruin.yml")) {
+      if (filePath.endsWith(".bruin.yml") || filePath.endsWith(".bruin.yaml")) {
         // Do not throw error, just send minimal message for the panel/UI to handle
         this.postMessageToPanels("success", JSON.stringify({ type: "bruinConfig", filePath }));
         return;

--- a/src/bruin/bruinInternalParse.ts
+++ b/src/bruin/bruinInternalParse.ts
@@ -38,8 +38,9 @@ export class BruinInternalParse extends BruinCommand {
         this.postMessageToPanels("success", JSON.stringify({ type: "pipelineConfig", ...pipelineMeta, filePath }));
         return;
       }
-      if (filePath.endsWith(".bruin.yml") || filePath.endsWith(".bruin.yaml")) {
+      if (filePath.endsWith("bruin.yml") || filePath.endsWith("bruin.yaml")) {
         // Do not throw error, just send minimal message for the panel/UI to handle
+        console.log("Bruin config parsed:", filePath);
         this.postMessageToPanels("success", JSON.stringify({ type: "bruinConfig", filePath }));
         return;
       }

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -62,7 +62,15 @@ export const isBruinPipeline = async (fileName: string): Promise<boolean> => {
   }
   return false;
 };
-
+export function isConfigFile(filePath: string): boolean {
+  const configSuffixes = [
+    "pipeline.yml",
+    "pipeline.yaml",
+    ".bruin.yml",
+    ".bruin.yaml"
+  ];
+  return configSuffixes.some(suffix => filePath.endsWith(suffix));
+}
 export const isYamlBruinAsset = async (fileName: string): Promise<boolean> =>
   isBruinAsset(fileName, [".asset.yml", ".asset.yaml"]);
 

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -171,12 +171,13 @@ window.addEventListener("message", (event) => {
         connectionsStore.setDefaultEnvironment(selectedEnvironment.value); // Set the default environment in the store
         break;
       case "parse-message": {
+        console.log("Webview received message:", message);
+
         parseError.value = updateValue(message, "error");
         const parsed = updateValue(message, "success");
         if (!parseError.value) {
           // Handle pipelineConfig (from pipeline.yml)
           if (parsed && parsed.type === "pipelineConfig") {
-            console.log("Pipeline config parsed:", parsed);
             data.value = parsed;
             lastRenderedDocument.value = parsed.filePath;
             break;
@@ -256,7 +257,8 @@ const parsedData = computed(() => {
 });
 
 const isPipelineConfig = computed(() => parsedData.value?.type === "pipelineConfig");
-const isBruinConfig = computed(() => parsedData.value?.type === "bruinConfig");
+const isBruinConfig = computed(() => parsedData.value?.type === "bruinConfig")
+const isConfigFile = computed(() => isBruinConfig.value || isPipelineConfig.value);
 const displayName = computed(() => {
   if (isPipelineConfig.value) return parsedData.value?.name || "";
   if (isBruinConfig.value) return "Bruin Config";
@@ -269,16 +271,15 @@ const displaySchedule = computed(() => {
 });
 
 const displayType = computed(() => {
-  if (isPipelineConfig.value) return parsedData.value?.type || "";
+  if (isPipelineConfig.value) return "pipeline";
   if (isBruinConfig.value) return "config";
   return assetDetailsProps.value?.type || "";
 });
 // Computed property for asset details
 const assetDetailsProps = computed({
   get: () => {
-    if (!data.value) return null;
+    if (!data.value ) return null;
     const parsedDetails = parseAssetDetails(data.value);
-    console.log("Parsed asset details:", parsedDetails);
     return parsedDetails;
   },
   set: (newValue) => {
@@ -378,6 +379,7 @@ const tabs = ref([
     component: AssetColumns,
     props: computed(() => ({
       columns: columns.value,
+      isConfigFile: isConfigFile.value,
     })),
   },
   {
@@ -385,6 +387,7 @@ const tabs = ref([
     component: CustomChecks,
     props: computed(() => ({
       customChecks: customChecksProps.value,
+      isConfigFile: isConfigFile.value,
     })),
   },
   {

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -51,10 +51,12 @@
             <!-- Tags div that will be hidden on small screens -->
             <div class="flex items-center tags">
               <DescriptionItem
-                :value="assetDetailsProps?.type ?? 'undefined'"
+                v-if="displayType"
+                :value="displayType"
                 :className="assetDetailsProps?.type ? badgeClass.badgeStyle : badgeClass.grayBadge"
               />
               <DescriptionItem
+                v-if="displaySchedule"
                 :value="displaySchedule"
                 :className="badgeClass.grayBadge"
                 class="xs:flex hidden overflow-hidden truncate"
@@ -182,6 +184,8 @@ window.addEventListener("message", (event) => {
           // Handle bruinConfig (from .bruin.yml)
           if (parsed && parsed.type === "bruinConfig") {
             // Only settings tab should be open
+            console.log("Bruin config parsed:", parsed);
+            isBruinYml.value = true;
             activeTab.value = 3; 
             break;
           }
@@ -214,17 +218,12 @@ window.addEventListener("message", (event) => {
   }
 });
 
+const isBruinYml = ref(false); 
 const activeTab = ref(0); // Tracks the currently active tab
 const navigateToGlossary = () => {
   console.log("Opening glossary.");
   vscode.postMessage({ command: "bruin.openGlossary" });
 };
-// Computed property to check if the last rendered document is a Bruin YAML file
-const isBruinYml = computed(() => {
-  const result = lastRenderedDocument.value && lastRenderedDocument.value.endsWith(".bruin.yml");
-  return result;
-});
-
 // Computed property to parse the list of environments
 const environmentsList = computed(() => {
   if (!environments.value) return [];
@@ -257,9 +256,10 @@ const parsedData = computed(() => {
 });
 
 const isPipelineConfig = computed(() => parsedData.value?.type === "pipelineConfig");
-
+const isBruinConfig = computed(() => parsedData.value?.type === "bruinConfig");
 const displayName = computed(() => {
   if (isPipelineConfig.value) return parsedData.value?.name || "";
+  if (isBruinConfig.value) return "Bruin Config";
   return assetDetailsProps.value?.name || "";
 });
 
@@ -270,6 +270,7 @@ const displaySchedule = computed(() => {
 
 const displayType = computed(() => {
   if (isPipelineConfig.value) return parsedData.value?.type || "";
+  if (isBruinConfig.value) return "config";
   return assetDetailsProps.value?.type || "";
 });
 // Computed property for asset details

--- a/webview-ui/src/components/asset/columns/AssetColumns.vue
+++ b/webview-ui/src/components/asset/columns/AssetColumns.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col py-4 sm:py-1 h-full w-full min-w-56 relative">
     <div class="flex justify-end mb-4 px-4">
-      <vscode-button @click="handleAddColumn" class="py-1 focus:outline-none"> Add column </vscode-button>
+      <vscode-button @click="handleAddColumn" class="py-1 focus:outline-none disabled:cursor-not-allowed" :disabled="isConfigFile"> Add column </vscode-button>
     </div>
 
     <!-- Header Row -->
@@ -274,6 +274,10 @@ const props = defineProps({
     type: Array,
     required: true,
   },
+  isConfigFile: {
+    type: Boolean,
+    required: true,
+  },
 });
 
 const emit = defineEmits(["update:columns", "open-glossary"]);
@@ -287,7 +291,7 @@ const showAcceptedValuesInput = ref(false);
 const newAcceptedValuesInput = ref("");
 const error = ref(null);
 const showAddCheckDropdown = ref(null);
-
+const isConfigFile = computed(() => props.isConfigFile);
 const updatePatternValue = () => {
   const patternCheck = editingColumn.value.checks.find((check) => check.name === "pattern");
   if (patternCheck) {

--- a/webview-ui/src/components/asset/columns/custom-checks/CustomChecks.vue
+++ b/webview-ui/src/components/asset/columns/custom-checks/CustomChecks.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col py-2 sm:py-1 h-full w-56 relative">
     <div class="flex justify-end mb-4">
-      <vscode-button @click="addCustomCheck" class="py-1 focus:outline-none">
+      <vscode-button :disabled="isConfigFile" @click="addCustomCheck" class="py-1 focus:outline-none disabled:cursor-not-allowed">
         Add Check
       </vscode-button>
     </div>
@@ -156,6 +156,7 @@ import DeleteAlert from "@/components/ui/alerts/AlertWithActions.vue";
 
 const props = defineProps<{
   customChecks: CustomChecks[];
+  isConfigFile: boolean;
 }>();
 
 const localCustomChecks = ref<CustomChecks[]>([]);


### PR DESCRIPTION
# PR Overview

This PR resolves issues when displaying configuration files (pipeline.yml and .bruin.yml) in the side panel and improves how they are parsed and rendered.

### Main changes
- Fix the parsing/rendering logic for pipeline.yml and .bruin.yml files to handle them without throwing errors.
- Display the pipeline name and schedule.
- Exclude the config files from lineage parsing.
- Disable `add column` and `add check` buttons when config files are rendered.

![display-config-files](https://github.com/user-attachments/assets/98fe8415-7bf5-43ab-a655-88c64ba9efd8)


