### PR TITLE
Add `interval_modifiers` to Assets Schema

### DIFF
--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -193,7 +193,7 @@
           "description": "The instance type for this asset"
         },
         "interval_modifiers": {
-          "type": "array",
+          "type": "object",
           "properties": {
             "start": {
               "type": "string",
@@ -240,9 +240,6 @@
           "description": "Snowflake configuration for this asset"
         }
       },
-      "required": [
-        "name"
-      ],
       "additionalProperties": false
     },
     "depends": {

--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -192,6 +192,20 @@
           "type": "string",
           "description": "The instance type for this asset"
         },
+        "interval_modifiers": {
+          "type": "array",
+          "properties": {
+            "start": {
+              "type": "string",
+              "description": "Shift start time"
+            },
+            "end": {
+              "type": "string",
+              "description": "Shift end time"
+            }
+          },
+          "description": "Interval modifiers for this asset"
+        },
         "materialization": {
           "$ref": "#/$defs/materialization",
           "description": "Materialization details for this asset"
@@ -341,9 +355,7 @@
         "create+replace",
         "delete+insert",
         "append",
-        "merge",
-        "interval_modifiers"
-      ],
+        "merge"      ],
       "description": "Materialization strategy"
     },
     "uri": {


### PR DESCRIPTION
# PR Overview 

This PR adds support for `interval_modifiers` in the asset schema and makes the asset name field optional.