### PR TITLE
Simplify QueryPreview Structure and Scope Query Run to Individual Tabs 

### DIFF
--- a/src/bruin/queryOutput.ts
+++ b/src/bruin/queryOutput.ts
@@ -29,6 +29,7 @@ export class BruinQueryOutput extends BruinCommand {
     environment: string,
     asset: string,
     limit: string,
+    tabId?: string,
     { flags = [], ignoresErrors = false, query = "" }: BruinCommandOptions & { query?: string } = {}
   ): Promise<void> {
     // Construct base flags dynamically
@@ -62,15 +63,15 @@ export class BruinQueryOutput extends BruinCommand {
         return;
       }
       console.log("SQL query output:", result);
-      this.postMessageToPanels("success", result);
+      this.postMessageToPanels("success", result, tabId);
     } catch (error: any) {
       console.error("Error occurred while running query:", error);
       const errorMessage = error.message || error.toString();
-      this.postMessageToPanels("error", errorMessage);
+      this.postMessageToPanels("error", errorMessage, tabId);
     }
     finally {
       this.isLoading = false;
-      this.postMessageToPanels("loading", this.isLoading);
+      this.postMessageToPanels("loading", this.isLoading, tabId);
     }
   }
 
@@ -80,7 +81,7 @@ export class BruinQueryOutput extends BruinCommand {
    * @param {string} status - Status of the message ('success' or 'error').
    * @param {string | any} message - The message content to send to the panel.
    */
-  private postMessageToPanels(status: string, message: string | any) {
-    QueryPreviewPanel.postMessage("query-output-message", { status, message });
+  private postMessageToPanels(status: string, message: string | any, tabId?: string) {
+    QueryPreviewPanel.postMessage("query-output-message", { status, message, tabId });
   }
 }

--- a/src/extension/commands/queryCommands.ts
+++ b/src/extension/commands/queryCommands.ts
@@ -42,7 +42,7 @@ export const getQueryOutput = async (environment: string, limit: string, lastRen
   );
 
   // Pass the query only if there is a valid selection, otherwise leave it empty.
-  await output.getOutput(environment, lastRenderedDocumentUri.fsPath, limit, { query: selectedQuery });
+  await output.getOutput(environment, lastRenderedDocumentUri.fsPath, limit, tabId, { query: selectedQuery });
 };
 
 export const exportQueryResults = async (lastRenderedDocumentUri: Uri | undefined, tabId?: string, connectionName?: string) => {


### PR DESCRIPTION
# PR Overview
This PR ensures that the query loading state and response is isolated to the active tab where the query is being executed. Key improvements include:

- Only the specific QueryPreview tab initiating a query shows a loading state and the results.
- Other open tabs remain fully interactive and unaffected during execution.
- Introduced tabId handling in messaging and UI state logic to enable scoped updates.
