### PR TITLE
Add Executed Query Preview with Copy and Formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.45.0] - [2025-05-02]
+- Added executed query preview with copy-to-clipboard support in the query results panel.
+
 ## [0.44.4] - [2025-05-02]
 - Scope query response to active tab only, allowing other tabs to remain responsive during execution.
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 **Note**: Ensure that you have the Bruin CLI installed on your system before using the new features. For guidance on installing the Bruin CLI, please refer to the [official documentation](https://github.com/bruin-data/bruin).
 
 ## Release Notes
-### Latest Release: 0.44.4
-- Scope query response to active tab only, allowing other tabs to remain responsive during execution.
+### Latest Release: 0.45.0
+- Added executed query preview with copy-to-clipboard support in the query results panel.
 
 ### Recent Updates
+- **0.44.4**: Scope query response to active tab only, allowing other tabs to remain responsive during execution.
 - **0.44.3**: Fixed SQL editor line display and improved layout styling for DateInput components.
 - **0.44.2**: Added support for `interval_modifiers` in asset schema and makes the name field optional.
 - **0.44.1**: Enhanced the date input component to support both manual text entry and calendar-based selection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.44.4",
+  "version": "0.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.44.4",
+      "version": "0.45.0",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.44.4",
+  "version": "0.45.0",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -192,6 +192,7 @@
           >
             <div class="flex items-center justify-end gap-1">
               <vscode-button
+                v-if="!copied"
                 appearance="icon"
                 title="Copy Query"
                 @click="copyQuery(currentTab.parsedOutput.query)"
@@ -199,6 +200,11 @@
               >
                 <span class="codicon codicon-copy text-xs"></span>
               </vscode-button>
+              <span
+                v-else
+                class="text-xs text-editor-fg opacity-70 hover:opacity-100 transition-opacity duration-200"
+                >Copied!</span
+              >
               <vscode-button
                 appearance="icon"
                 title="Close"
@@ -356,7 +362,7 @@ const currentConnectionName = ref("");
 const limit = ref(100);
 const showSearchInput = ref(false);
 const hoveredTab = ref("");
-
+const copied = ref(false);
 // State for expanded cells
 const expandedCells = ref(new Set<string>());
 const defaultTab = {
@@ -378,10 +384,10 @@ const defaultTab = {
 const tabs = shallowRef<TabData[]>([defaultTab]);
 const copyQuery = (query: string) => {
   navigator.clipboard.writeText(query);
-  vscode.postMessage({
-    command: "bruin.showInformationMessage",
-    payload: "Query copied to clipboard",
-  });
+  copied.value = true;
+  setTimeout(() => {
+    copied.value = false;
+  }, 2000);
 };
 
 const toggleQueryVisibility = () => {

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -190,34 +190,27 @@
             v-if="currentTab?.showQuery && currentTab?.parsedOutput?.query"
             class="query-panel bg-editorWidget-background border-b border-panel-border"
           >
-            <div class="flex items-center justify-between px-3 py-1">
-              <span class="text-3xs text-editor-foreground opacity-75 font-mono"
-                >Executed Query:</span
+            <div class="flex items-center justify-end gap-1">
+              <vscode-button
+                appearance="icon"
+                title="Copy Query"
+                @click="copyQuery(currentTab.parsedOutput.query)"
+                class="text-xs hover:bg-panel-border"
               >
-              <div class="flex items-center gap-1">
-                <vscode-button
-                  appearance="icon"
-                  title="Copy Query"
-                  @click="copyQuery(currentTab.parsedOutput.query)"
-                  class="text-xs hover:bg-panel-border"
-                >
-                  <span class="codicon codicon-copy text-xs"></span>
-                </vscode-button>
-                <vscode-button
-                  appearance="icon"
-                  title="Close"
-                  @click="toggleQueryVisibility"
-                  class="text-xs hover:bg-panel-border"
-                >
-                  <span class="codicon codicon-close text-xs"></span>
-                </vscode-button>
-              </div>
+                <span class="codicon codicon-copy text-xs"></span>
+              </vscode-button>
+              <vscode-button
+                appearance="icon"
+                title="Close"
+                @click="toggleQueryVisibility"
+                class="text-xs hover:bg-panel-border"
+              >
+                <span class="codicon codicon-close text-xs"></span>
+              </vscode-button>
             </div>
             <pre
               class="query-content px-3 pb-1 font-mono text-3xs leading-tight overflow-auto max-h-[150px]"
-            >
-    {{ formatQuery(currentTab.parsedOutput.query) }}
-  </pre
+              >{{ formatQuery(currentTab.parsedOutput.query) }}</pre
             >
           </div>
           <div
@@ -391,21 +384,6 @@ const copyQuery = (query: string) => {
   });
 };
 
-const formatQuery = (query: string) => {
-  return query
-    .replace(
-      /(WITH|SELECT|FROM|WHERE|GROUP BY|HAVING|ORDER BY|LIMIT|UNION ALL|JOIN|LEFT JOIN|INNER JOIN|OUTER JOIN|ON)\b/gi,
-      "\n$1"
-    )
-    .replace(/,(\s*)/g, ",\n  ")
-    .replace(/(\n)(\w+)(\s+AS\s+)/gi, "$1  $2$3")
-    .replace(/(\()\s*/g, "$1\n  ")
-    .replace(/(\))/g, "\n$1")
-    .replace(/\b(AND|OR)\b/gi, "\n  $1")
-    .replace(/\s+/, " ")
-    .trim();
-};
-
 const toggleQueryVisibility = () => {
   if (!currentTab.value) return;
 
@@ -428,7 +406,10 @@ const toggleQueryVisibility = () => {
 
 const activeTab = ref<string>("tab-1");
 const tabCounter = ref(2); // Start from 2 since we already have "Tab 1"
-
+const formatQuery = (query: string) => {
+  const lines = query.split("\n");
+  return lines.map((line, index) => (index === 0 ? line.trimStart() : line)).join("\n");
+};
 // Get current active tab
 const currentTab = computed(() => {
   return tabs.value.find((tab) => tab.id === activeTab.value);
@@ -516,7 +497,7 @@ const saveState = () => {
     totalRowCount: tab.totalRowCount,
     filteredRowCount: tab.filteredRowCount,
     environment: currentEnvironment.value,
-    isQueryExpanded: tab.showQuery,
+    showQuery: tab.showQuery,
     connectionName: tab.connectionName,
     tabCounter: tabCounter.value,
   }));
@@ -582,7 +563,7 @@ window.addEventListener("message", (event) => {
         ...t,
         parsedOutput: t.parsedOutput ? reviveParsedOutput(t.parsedOutput) : undefined,
         connectionName: reviveParsedOutput(t.parsedOutput)?.connectionName || t.connectionName,
-        isQueryExpanded: !!t.isQueryExpanded,
+        showQuery: !!t.showQuery,
         error: t.error ? new Error(t.error.message) : null,
         isLoading: false,
         isEditing: false,
@@ -1048,7 +1029,7 @@ watch(
 
 <style scoped>
 .query-panel {
-  background-color: var(--vscode-editorWidget-background);
+  background-color: var(--vscode-edito-background);
   border-color: var(--vscode-panel-border);
 }
 
@@ -1069,7 +1050,7 @@ watch(
   background-color: var(--vscode-button-hoverBackground);
 }
 .query-content:hover {
-  background-color: var(--vscode-editorWidget-border);
+  background-color: var(--vscode-editorWidget-background);
 }
 .text-editor-foreground {
   color: var(--vscode-editor-foreground);

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -157,7 +157,7 @@ export interface TabData extends Tab {
   limit: number;
   environment: string;
   connectionName: string;
-  isQueryExpanded: boolean;
+  showQuery: boolean;
 }
 
 export interface EditingState {

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -157,6 +157,7 @@ export interface TabData extends Tab {
   limit: number;
   environment: string;
   connectionName: string;
+  isQueryExpanded: boolean;
 }
 
 export interface EditingState {


### PR DESCRIPTION
# PR Overview 
This PR displays the executed query with formatting and a copy-to-clipboard button in the Query Preview:
- Added a toggle to display the executed query.
- Applied formatting to the query.
- Added a copy button with confirmation feedback.

![executed-query-3](https://github.com/user-attachments/assets/1c93e4b9-c220-4e54-87d9-51b04175539a)
