### PR TITLE
Add Convert Files to Bruin Assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,16 @@
         {
           "command": "bruin.renderSQL",
           "group": "navigation"
+        },
+        {
+          "command": "bruin.convertFileToAsset",
+          "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "bruin.convertFileToAsset",
+          "group": "navigation"
         }
       ]
     },
@@ -199,6 +209,13 @@
         "title": "Toggle Folding",
         "category": "Bruin",
         "description": "Toggle the folding state of custom Bruin foldable regions in Python and SQL files."
+      },
+      {
+        "command": "bruin.convertFileToAsset",
+        "title": "Convert File to Asset",
+        "category": "Bruin",
+        "description": "Convert a file to a Bruin asset.",
+        "icon": "$(file-code)"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -176,10 +176,6 @@
         {
           "command": "bruin.renderSQL",
           "group": "navigation"
-        },
-        {
-          "command": "bruin.convertFileToAsset",
-          "group": "navigation"
         }
       ],
       "editor/context": [
@@ -214,8 +210,7 @@
         "command": "bruin.convertFileToAsset",
         "title": "Convert File to Asset",
         "category": "Bruin",
-        "description": "Convert a file to a Bruin asset.",
-        "icon": "$(file-code)"
+        "description": "Convert a file to a Bruin asset."      
       }
     ]
   },

--- a/src/bruin/bruinCommand.ts
+++ b/src/bruin/bruinCommand.ts
@@ -68,7 +68,7 @@ export abstract class BruinCommand {
           const endTime = Date.now();
           const duration = endTime - startTime;
           
-          console.log(`[${new Date().toISOString()}] Command completed in ${duration}ms`);
+          console.log(`[${new Date().toISOString()}] Command completed in ${duration}ms  ${commandString}`);
 
           if (error) {
             console.error(`[${new Date().toISOString()}] Command failed after ${duration}ms:`, error.message);

--- a/src/bruin/bruinInternalPatch.ts
+++ b/src/bruin/bruinInternalPatch.ts
@@ -38,6 +38,27 @@ export class BruinInternalPatch extends BruinCommand {
       });
   }
 
+  // internal patch with another flag --convert and only asset path 
+  public async convertFileToAsset(filePath: string) {
+    await this.run(["patch-asset", "--convert", filePath]).then(
+      (result) => {
+        // there is no result returned on success 
+        BruinPanel?.postMessage("convert-message", {
+          status: "success",
+          message: "File converted to asset successfully",
+        });
+      },
+      (err) => {
+        console.error("Error converting file to asset", err);
+        BruinPanel?.postMessage("convert-message", {
+          status: "error",
+          message: JSON.stringify({ error: err }),
+        });
+        console.error("Error converting file to asset", err);
+      }
+    );
+  }
+
   private postMessageToPanels(status: string, message: string | any) {
     BruinPanel.postMessage("patch-message", { status, message });
   }

--- a/src/extension/commands/parseAssetCommand.ts
+++ b/src/extension/commands/parseAssetCommand.ts
@@ -28,3 +28,14 @@ export const patchAssetCommand = async (body: object, lastRenderedDocumentUri: U
   );
   await patched.patchAsset(body, lastRenderedDocumentUri.fsPath);
 };
+
+export const convertFileToAssetCommand = async (lastRenderedDocumentUri: Uri | undefined) => {
+  if (!lastRenderedDocumentUri) {
+    return;
+  }
+  const patched = new BruinInternalPatch(
+    getBruinExecutablePath(),
+     ""
+  );
+  await patched.convertFileToAsset(lastRenderedDocumentUri.fsPath);
+};

--- a/src/extension/commands/parseAssetCommand.ts
+++ b/src/extension/commands/parseAssetCommand.ts
@@ -7,15 +7,11 @@ export const parseAssetCommand = async (lastRenderedDocumentUri: Uri | undefined
   if (!lastRenderedDocumentUri) {
     return;
   }
-  console.warn("get Default bruin exec", (new Date()).toISOString());
   const bruinExec = getBruinExecutablePath();
-  console.warn("get Default bruin exec after", (new Date()).toISOString());
-  console.warn("BruinInternalParse before", (new Date()).toISOString());
   const parsed = new BruinInternalParse(
     bruinExec, ""
   );
   await parsed.parseAsset(lastRenderedDocumentUri.fsPath);
-  console.warn("BruinInternalParse after", (new Date()).toISOString());
 };
 
 export const patchAssetCommand = async (body: object, lastRenderedDocumentUri: Uri | undefined) => {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -22,6 +22,7 @@ import { installOrUpdateCli } from "./commands/updateBruinCLI";
 import { QueryPreviewPanel } from "../panels/QueryPreviewPanel";
 import { BruinPanel } from "../panels/BruinPanel";
 import { BruinEnvList } from "../bruin/bruinSelectEnv";
+import { convertFileToAssetCommand } from "./commands/parseAssetCommand";
 
 let analyticsClient: any = null;
 
@@ -212,6 +213,20 @@ export async function activate(context: ExtensionContext) {
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`Error toggling foldings: ${errorMessage}`); 
+      }
+    }),
+
+    commands.registerCommand("bruin.convertFileToAsset", async () => {
+      try {
+        trackEvent("Command Executed", { command: "convertFileToAsset" });
+        if (BruinPanel.currentPanel) {
+          await BruinPanel.currentPanel.convertCurrentDocument();
+        } else {
+          console.error("Bruin panel is not active.");
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error converting file to asset: ${errorMessage}`);
       }
     })
   ];

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -69,7 +69,6 @@ export class BruinPanel {
           if (editor.document.uri.fsPath === "tasks") {
             return;
           }
-          window.showInformationMessage("Document in change event", this._lastRenderedDocumentUri?.fsPath);
           parseAssetCommand(this._lastRenderedDocumentUri);
           renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
         }
@@ -88,20 +87,16 @@ export class BruinPanel {
               command: "clear-asset-details",
               isAsset: false
             });
-            window.showInformationMessage("Document is not a bruin asset.", this._lastRenderedDocumentUri.fsPath);
           } else {
-            window.showInformationMessage("Document is a bruin asset.", this._lastRenderedDocumentUri.fsPath);
             parseAssetCommand(docUri);
           }
           renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
-          window.showInformationMessage("Document is a rendered as.", this._lastRenderedDocumentUri.fsPath);
         }
       }),
       vscode.workspace.onDidRenameFiles((e) => {
         e.files.forEach((file) => {
           if (this._lastRenderedDocumentUri?.fsPath === file.oldUri.fsPath) {
             this._lastRenderedDocumentUri = file.newUri;
-            console.log(`File renamed from ${file.oldUri.fsPath} to ${file.newUri.fsPath}`);
           }
         });
       })
@@ -110,7 +105,6 @@ export class BruinPanel {
     // Ensure initial state is set based on the currently active editor
     if (window.activeTextEditor) {
       this._lastRenderedDocumentUri = window.activeTextEditor.document.uri;
-      window.showInformationMessage("Document in constructor.", this._lastRenderedDocumentUri.fsPath);
     }
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -64,15 +64,12 @@ export class BruinPanel {
           getEnvListCommand(this._lastRenderedDocumentUri);
           getConnections(this._lastRenderedDocumentUri);
         }
+        this._lastRenderedDocumentUri = editor.document.uri;
         if (editor && editor.document.uri) {
           if (editor.document.uri.fsPath === "tasks") {
             return;
           }
-          this._lastRenderedDocumentUri = !this.relevantFileExtensions.some((ext) =>
-            editor.document.uri.fsPath.endsWith(ext)
-          )
-            ? this._lastRenderedDocumentUri
-            : editor.document.uri;
+          window.showInformationMessage("Document in change event", this._lastRenderedDocumentUri?.fsPath);
           parseAssetCommand(this._lastRenderedDocumentUri);
           renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
         }
@@ -83,7 +80,7 @@ export class BruinPanel {
           const isAsset = await isBruinAsset(docUri.fsPath, [".sql", ".py"]);
           const isConfig = isConfigFile(docUri.fsPath);
     
-          this._lastRenderedDocumentUri = isAsset || isConfig ? docUri : undefined;
+          this._lastRenderedDocumentUri = docUri;
     
           if (!isAsset && !isConfig) {
             // Clear asset details from UI
@@ -91,10 +88,13 @@ export class BruinPanel {
               command: "clear-asset-details",
               isAsset: false
             });
+            window.showInformationMessage("Document is not a bruin asset.", this._lastRenderedDocumentUri.fsPath);
           } else {
-            parseAssetCommand(this._lastRenderedDocumentUri);
+            window.showInformationMessage("Document is a bruin asset.", this._lastRenderedDocumentUri.fsPath);
+            parseAssetCommand(docUri);
           }
           renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri?.fsPath);
+          window.showInformationMessage("Document is a rendered as.", this._lastRenderedDocumentUri.fsPath);
         }
       }),
       vscode.workspace.onDidRenameFiles((e) => {
@@ -110,12 +110,10 @@ export class BruinPanel {
     // Ensure initial state is set based on the currently active editor
     if (window.activeTextEditor) {
       this._lastRenderedDocumentUri = window.activeTextEditor.document.uri;
+      window.showInformationMessage("Document in constructor.", this._lastRenderedDocumentUri.fsPath);
     }
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri);
-
-    // Set the last rendered document URI to the current active editor document URI
-    this._lastRenderedDocumentUri = window.activeTextEditor?.document.uri;
 
     // Set an event listener to listen for messages passed from the webview context
     this._setWebviewMessageListener(this._panel.webview);

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -10,7 +10,7 @@ import {
 } from "../bruin";
 import * as vscode from "vscode";
 import { renderCommandWithFlags } from "../extension/commands/renderCommand";
-import { parseAssetCommand, patchAssetCommand } from "../extension/commands/parseAssetCommand";
+import { convertFileToAssetCommand, parseAssetCommand, patchAssetCommand } from "../extension/commands/parseAssetCommand";
 import { getEnvListCommand } from "../extension/commands/getEnvListCommand";
 import { BruinInstallCLI } from "../bruin/bruinInstallCli";
 import {
@@ -140,6 +140,21 @@ export class BruinPanel {
    *
    * @param extensionUri The URI of the directory containing the extension.
    */
+  public async convertCurrentDocument() {
+    if (!this._lastRenderedDocumentUri) {
+      console.error("No active document to convert.");
+      return;
+    }
+
+    try {
+      // Call the function to convert the file to an asset
+      await convertFileToAssetCommand(this._lastRenderedDocumentUri);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Error converting file to asset: ${errorMessage}`);
+    }
+  }
+
   public static render(extensionUri: Uri) {
     const column = window.activeTextEditor ? ViewColumn.Beside : undefined;
 

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -23,6 +23,7 @@ import {
 import { openGlossary } from "../bruin/bruinGlossaryUtility";
 import { QueryPreviewPanel } from "./QueryPreviewPanel";
 import { getBruinExecutablePath } from "../providers/BruinExecutableService";
+import { isBruinAsset } from "../utilities/helperUtils";
 
 /**
  * This class manages the state and behavior of Bruin webview panels.
@@ -145,7 +146,11 @@ export class BruinPanel {
       console.error("No active document to convert.");
       return;
     }
-
+    // chack if this is a bruin asset
+    if (await isBruinAsset(this._lastRenderedDocumentUri.fsPath, [".sql", ".py"])) {
+      vscode.window.showErrorMessage("Document is already a bruin asset.");
+      return;
+    }
     try {
       // Call the function to convert the file to an asset
       await convertFileToAssetCommand(this._lastRenderedDocumentUri);

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="isBruinInstalled">
     <div class="flex flex-col pt-1">
-      <div class="">
-        <div class="flex items-center space-x-2 w-full justify-between">
+      <div v-if="!isNotAsset" class="">
+        <div class="flex items-center space-x-2 w-full justify-between min-h-6">
           <div class="flex items-baseline w-3/4 min-w-0 font-md text-editor-fg text-lg font-mono">
             <!-- Asset name -->
             <div class="flex-grow min-w-0 overflow-hidden">
@@ -26,7 +26,7 @@
                     />
                   </template>
                   <template v-else>
-                    <span id="input-name" class="block truncate">
+                    <span v-if="assetDetailsProps?.name && assetDetailsProps?.name !== 'undefined'" id="input-name" class="block truncate">
                       {{ displayName }}
                     </span>
                   </template>
@@ -145,7 +145,7 @@ const versionStatus = ref({
 const data = ref(
   JSON.stringify({
     asset: {
-      name: "Asset Name",
+      name: "",
       description: "Asset Description",
       type: "undefined",
       schedule: "daily",
@@ -169,6 +169,10 @@ const  handleMessage = ((event: MessageEvent) => {
       case "environments-list-message":
         environments.value = updateValue(message, "success");
         connectionsStore.setDefaultEnvironment(selectedEnvironment.value); // Set the default environment in the store
+        break;
+      case "non-asset-file":
+        console.warn("Non-asset file received:", (new Date).toISOString());
+        isNotAsset.value = true;
         break;
       case "parse-message": {
         console.warn("Parsing message received:", (new Date).toISOString());
@@ -220,6 +224,7 @@ const  handleMessage = ((event: MessageEvent) => {
 });
 
 const isBruinYml = ref(false); 
+const isNotAsset = ref(false);
 const activeTab = ref(0); // Tracks the currently active tab
 const navigateToGlossary = () => {
   console.log("Opening glossary.");

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -46,13 +46,21 @@ export const handleError = (validationError: any | null, renderSQLAssetError: an
         // If parsing fails, use the original error message
       }
     }
-
+    if(typeof errorMessage === 'string' && errorMessage.startsWith('no asset found')) {
+       return {
+        errorCaptured: true,
+        errorMessage: null,
+        isValidationError: false,
+       };
+    }
     return {
       errorCaptured: true,
       errorMessage,
       isValidationError,
     };
+    
   }
+
   return null;
 };
 


### PR DESCRIPTION
# PR Overview 
This PR introduces a new command that enables users to convert standard files into Bruin assets.

- Added convertToBruinAsset command and registered it with the VS Code extension.
- Ensured the command checks if a file is already a Bruin asset before proceeding.
- Improved error handling for unsupported or non-asset files.

![convert-error](https://github.com/user-attachments/assets/a2cc8408-4ead-4bb8-8cb2-d8af1002b989)
![convert-file](https://github.com/user-attachments/assets/8ef4d66a-bbc3-415c-a521-5eca6938e0d7)

