### PR TITLE
Fix Query Preview with Jinja Variables and Disable Convert Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [0.45.3] - [2025-05-14]
+- Added support for dates in the query preview panel.
+
 ## [0.45.2] - [2025-05-13]
 - Fix CLI version check to improve performance.
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 **Note**: Ensure that you have the Bruin CLI installed on your system before using the new features. For guidance on installing the Bruin CLI, please refer to the [official documentation](https://github.com/bruin-data/bruin).
 
 ## Release Notes
-### Latest Release: 0.45.2
-- Fix CLI version check to improve performance.
+### Latest Release: 0.45.3
+- Added support for dates in the query preview panel.
 
 ### Recent Updates
+- **0.45.2**: Fix CLI version check to improve performance.
 - **0.45.1**: Optimize the Bruin activation process.
 - **0.45.0**: Added executed query preview with copy-to-clipboard support in the query results panel.
 - **0.44.4**: Scope query response to active tab only, allowing other tabs to remain responsive during execution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.45.2",
+  "version": "0.45.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.45.2",
+      "version": "0.45.3",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -177,12 +177,6 @@
           "command": "bruin.renderSQL",
           "group": "navigation"
         }
-      ],
-      "editor/context": [
-        {
-          "command": "bruin.convertFileToAsset",
-          "group": "navigation"
-        }
       ]
     },
     "commands": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.45.2",
+  "version": "0.45.3",
   "engines": {
     "vscode": "^1.87.0"
   },
@@ -204,7 +204,7 @@
         "command": "bruin.convertFileToAsset",
         "title": "Convert File to Asset",
         "category": "Bruin",
-        "description": "Convert a file to a Bruin asset."      
+        "description": "Convert a file to a Bruin asset."
       }
     ]
   },

--- a/src/bruin/queryOutput.ts
+++ b/src/bruin/queryOutput.ts
@@ -30,6 +30,8 @@ export class BruinQueryOutput extends BruinCommand {
     asset: string,
     limit: string,
     tabId?: string,
+    startDate?: string,
+    endDate?: string,
     { flags = [], ignoresErrors = false, query = "" }: BruinCommandOptions & { query?: string } = {}
   ): Promise<void> {
     // Construct base flags dynamically
@@ -50,6 +52,12 @@ export class BruinQueryOutput extends BruinCommand {
     // we always need to push the other flags including the asset flag
     constructedFlags.push("-asset", asset);
 
+    if (startDate) {  
+      constructedFlags.push("--start-date", startDate);
+    }
+    if (endDate) {
+      constructedFlags.push("--end-date", endDate);
+    }
     // Use provided flags or fallback to constructed flags
     const finalFlags = flags.length > 0 ? flags : constructedFlags;
 

--- a/src/extension/commands/queryCommands.ts
+++ b/src/extension/commands/queryCommands.ts
@@ -5,7 +5,7 @@ import { BruinExportQueryOutput } from "../../bruin/exportQueryOutput";
 import { QueryPreviewPanel } from "../../panels/QueryPreviewPanel";
 import { getBruinExecutablePath } from "../../providers/BruinExecutableService";
 
-export const getQueryOutput = async (environment: string, limit: string, lastRenderedDocumentUri: Uri | undefined, tabId?: string) => {
+export const getQueryOutput = async (environment: string, limit: string, lastRenderedDocumentUri: Uri | undefined, tabId?: string, startDate?: string, endDate?: string) => {
   let editor = window.activeTextEditor;
   if (!editor) {
     editor = lastRenderedDocumentUri && await window.showTextDocument(lastRenderedDocumentUri);
@@ -39,9 +39,9 @@ export const getQueryOutput = async (environment: string, limit: string, lastRen
     getBruinExecutablePath(),
     ""
   );
-
+   console.log("Receiving dates", startDate, endDate);
   // Pass the query only if there is a valid selection, otherwise leave it empty.
-  await output.getOutput(environment, lastRenderedDocumentUri.fsPath, limit, tabId, { query: selectedQuery });
+  await output.getOutput(environment, lastRenderedDocumentUri.fsPath, limit, tabId, startDate, endDate, { query: selectedQuery });
 };
 
 export const exportQueryResults = async (lastRenderedDocumentUri: Uri | undefined, tabId?: string, connectionName?: string) => {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -220,7 +220,8 @@ export async function activate(context: ExtensionContext) {
       try {
         trackEvent("Command Executed", { command: "convertFileToAsset" });
         if (BruinPanel.currentPanel) {
-          await BruinPanel.currentPanel.convertCurrentDocument();
+          //await BruinPanel.currentPanel.convertCurrentDocument();
+          console.log("Bruin panel is active.");
         } else {
           console.error("Bruin panel is not active.");
         }

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -423,6 +423,17 @@ export class BruinPanel {
               message: envData,
             });
             break;
+          case "bruin.updateQueryDates":
+            const { startDate, endDate } = message.payload;
+            console.log(`BruinPanel: Sending dates to QueryPreviewPanel - start: ${startDate}, end: ${endDate}`);
+            QueryPreviewPanel.postMessage("update-query-dates", {
+              status: "success",
+              message: {
+                startDate,
+                endDate
+              }
+            });
+            break;
           case "checkBruinCliInstallation":
             this.checkAndUpdateBruinCliStatus();
             break;

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -2494,7 +2494,7 @@ suite("Query Output Tests", () => {
     sinon.stub(vscode.window, "activeTextEditor").value(fakeEditor);
     getWorkspaceFolderStub.returns(undefined);
 
-    await getQueryOutput("dev", "100", uri);
+    await getQueryOutput("dev", "100", uri, "tab-1", new Date().toISOString(), new Date().toISOString());
 
     assert.strictEqual(showErrorStub.calledWith("No workspace folder found"), true);
   });
@@ -2504,7 +2504,9 @@ suite("Query Output Tests", () => {
     const selectedQuery = "SELECT *"; 
     const fullQuery = "SELECT * FROM table";
     const tabId = "tab-1";
-  
+    const startDate = new Date();
+    const endDate = new Date();
+    endDate.setDate(startDate.getDate() + 1);
     const fakeDoc = {
       uri,
       getText: (range?: vscode.Range) => {
@@ -2526,11 +2528,11 @@ suite("Query Output Tests", () => {
     sinon.stub(vscode.window, "activeTextEditor").value(fakeEditor);
     getWorkspaceFolderStub.returns({ uri: { fsPath: "/mocked/workspace" } });
   
-    await getQueryOutput("dev", "10", uri, tabId);
+    await getQueryOutput("dev", "10", uri, tabId, startDate.toISOString(), endDate.toISOString());
   
-    assert.strictEqual(setTabQueryStub.calledWith("tab-1", selectedQuery), true);
+    assert.strictEqual(setTabQueryStub.calledWith(tabId, selectedQuery), true);
     assert.strictEqual(
-      getOutputStub.calledWithMatch("dev", uri.fsPath, "10", "tab-1", { query: selectedQuery }),
+      getOutputStub.calledWithMatch("dev", uri.fsPath, "10", tabId, startDate.toISOString(), endDate.toISOString(), { query: selectedQuery }),
       true
     );
   });
@@ -2557,11 +2559,11 @@ suite("Query Output Tests", () => {
     sinon.stub(vscode.window, "activeTextEditor").value(fakeEditor);
     getWorkspaceFolderStub.returns({ uri: { fsPath: "/mocked/workspace" } });
   
-    await getQueryOutput("dev", "50", uri, "tab-1");
+    await getQueryOutput("dev", "50", uri, "tab-1", new Date().toISOString(), new Date().toISOString());
   
     assert.strictEqual(setTabQueryStub.calledWith("tab-1", ""), true);
     assert.strictEqual(
-      getOutputStub.calledWithMatch("dev", uri.fsPath, "50", "tab-1", { query: "" }),
+      getOutputStub.calledWithMatch("dev", uri.fsPath, "50", "tab-1", sinon.match.string, sinon.match.string, { query: "" }),
       true
     );
   });

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -596,6 +596,16 @@ onBeforeUnmount(() => {
   window.removeEventListener("message", receiveMessage);
 });
 
+watch([startDate, endDate], ([newStart, newEnd]) => {
+  vscode.postMessage({
+    command: "bruin.updateQueryDates",
+    payload: {
+      startDate: newStart,
+      endDate: newEnd
+    }
+  });
+}, { immediate: true });
+
 function receiveMessage(event: { data: any }) {
   if (!event) return;
 


### PR DESCRIPTION
# PR Overview
This PR resolves an issue where queries containing Jinja variables would fail in the Query Preview panel. It also disables the "Convert to Bruin Asset" command, which needs improvement.

* Enables successful query previews by sending `start_date` and `end_date` values from the Bruin panel to the Query panel.
* Updates the query execution flow to use the provided dates for rendering Jinja-based queries.
* Cleans up UI and logic by removing the "Convert" command.

![quey-with-jinja](https://github.com/user-attachments/assets/ca906668-fb3d-4d3a-8660-988c4a31d0ce)



