### PR TITLE
Update the Line Height in SQL Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## [0.45.5] - [2025-05-16]
+- Updated SQL editor line height.
+
 ## [0.45.4] - [2025-05-15]
-- Improve long queries rendering in SQL editor.
+- Improved long queries rendering in SQL editor.
 
 ## [0.45.3] - [2025-05-14]
 - Added support for dates in the query preview panel.

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 **Note**: Ensure that you have the Bruin CLI installed on your system before using the new features. For guidance on installing the Bruin CLI, please refer to the [official documentation](https://github.com/bruin-data/bruin).
 
 ## Release Notes
-### Latest Release: 0.45.4
-- Improve long queries rendering in SQL editor.
+### Latest Release: 0.45.5
+- Update SQL editor line height.
 
 ### Recent Updates
+- **0.45.4**: Improve long queries rendering in SQL editor.
 - **0.45.3**: Added support for dates in the query preview panel.
 - **0.45.2**: Fix CLI version check to improve performance.
 - **0.45.1**: Optimize the Bruin activation process.
@@ -72,13 +73,6 @@ Bruin is a unified analytics platform that enables data professionals to work en
 - **0.43.2**: Added expandable labels for truncated asset names in lineage view.
 - **0.43.1**: Handle file renaming in BruinPanel to update last rendered document URI.
 - **0.43.0**: Automatically refresh the CLI status after update.
-- **0.42.3**: Added support for `bq.seed` type in asset yaml schema.
-- **0.42.2**: Support multiline input for column and custom check fields.
-- **0.42.1**: Improved `CLI install` and `update` UX in Settings Tab.
-- **0.42.0**: Added export functionality to export query output to a CSV file.
-- **0.41.2**: Fixed Editing Behavior When Adding or Deleting Columns.
-- **0.41.1**: Fixed payload sanitization for columns details.
-- **0.41.0**: Added auto CLI Version Check and Update Functionality to trigger a CLI update interactively.
 
 For a full changelog, see Bruin Extension [Changelog](https://marketplace.visualstudio.com/items/bruin.bruin/changelog).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.45.4",
+  "version": "0.45.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.45.4",
+      "version": "0.45.5",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.45.4",
+  "version": "0.45.5",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/asset/SqlEditor.vue
+++ b/webview-ui/src/components/asset/SqlEditor.vue
@@ -55,8 +55,8 @@ function copyToClipboard() {
     copied.value = false;
   }, 2000);
 }
-const lineHeight = 24; 
-const minEditorHeight = `${lineHeight * 5}px`;
+const lineHeight = 15; 
+const minEditorHeight = `${lineHeight * 8}px`;
 const maxEditorHeight = '500px';
 const highlightedLines = computed(() => {
   if (!props.code) return [];


### PR DESCRIPTION
# PR Overview 

This PR reduces the line height between the lines in the SQL Editor.

#### Before the fix:

<img width="846" alt="before-reduce-line-h" src="https://github.com/user-attachments/assets/e0e5367a-50bb-4094-a751-95f2d7bcebf2" />



#### After the fix:
<img width="885" alt="after-reduce-line-h" src="https://github.com/user-attachments/assets/0567be18-fb25-4398-b059-22f17ea784f7" />
