### PR TITLE
Fix Bruin CLI installation on Windows with Git Bash terminal profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.46.1] - [2025-05-20]
+- Fix Bruin CLI installation on Windows.
+
 ## [0.46.0] - [2025-05-19]
 - Added convert feature to convert eligible files to Bruin assets.
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 **Note**: Ensure that you have the Bruin CLI installed on your system before using the new features. For guidance on installing the Bruin CLI, please refer to the [official documentation](https://github.com/bruin-data/bruin).
 
 ## Release Notes
-### Latest Release: 0.46.0
-- Added convert feature to convert eligible files to Bruin assets.
+### Latest Release: 0.46.1
+- Fix Bruin CLI installation on Windows.
 
 ### Recent Updates
+- **0.46.0**: Added convert feature to convert eligible files to Bruin assets.
 - **0.45.5**: Update SQL editor line height.
 - **0.45.4**: Improve long queries rendering in SQL editor.
 - **0.45.3**: Added support for dates in the query preview panel.

--- a/src/bruin/bruinInstallCli.ts
+++ b/src/bruin/bruinInstallCli.ts
@@ -66,24 +66,30 @@ export class BruinInstallCLI {
         throw new Error("Git Bash not found. Please install Git or configure the Git Bash path in settings.");
       }
 
-      // Create a temporary batch file
-      const tempDir = os.tmpdir();
-      const batchFilePath = path.join(tempDir, 'bruin-install.bat');
+      const terminalProfile = this.getTerminalProfile();
+      if (terminalProfile && terminalProfile.toLowerCase().includes("bash")) {
+        return `curl -LsSL ${this.scriptPath} | sh -s --${specificVersion}`;
+      } else {
+        const tempDir = os.tmpdir();
+        const batchFilePath = path.join(tempDir, 'bruin-install.bat');
 
-      // Create batch file content that calls Git Bash
-      const batchContent =
-        '@echo off\r\n' +
-        `"${gitBashPath}" -c "curl -LsSL ${this.scriptPath} | sh -s --${specificVersion}"\r\n`;
+        const batchContent =
+          '@echo off\r\n' +
+          `"${gitBashPath}" -c "curl -LsSL ${this.scriptPath} | sh -s --${specificVersion}"\r\n`;
 
-      // Write the batch file
-      fs.writeFileSync(batchFilePath, batchContent);
-
-      // Return the command to execute the batch file
-      return batchFilePath;
+        fs.writeFileSync(batchFilePath, batchContent);
+        return batchFilePath;
+      }
     } else {
       return `curl -LsSL ${this.scriptPath} | sh -s --${specificVersion}`;
     }
   }
+
+  private getTerminalProfile(): string | undefined {
+    const config = vscode.workspace.getConfiguration('terminal.integrated.defaultProfile');
+    return config.get<string>('windows');
+  }
+  
   public async getBruinCliVersion(): Promise<string> {
     const versionInfo = await getBruinVersion();
     if (!versionInfo) {


### PR DESCRIPTION
# PR Overview 

This PR addresses an issue where the Bruin CLI installation would fail when running in VS Code with Git Bash set as the default terminal profile in Windows.

- Added terminal profile detection to determine if we're running in Git Bash or PowerShell.
- For Git Bash terminals: Directly run the curl command without the intermediate batch file
- For PowerShell terminals: Keep the old implementation 