### PR TITLE
Add Materialization Component with Strategy Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## [0.47.0] - [2025-05-26]
+- Added materialization tab to the asset side panel.
 
 ## [0.46.1] - [2025-05-20]
 - Fix Bruin CLI installation on Windows.

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 **Note**: Ensure that you have the Bruin CLI installed on your system before using the new features. For guidance on installing the Bruin CLI, please refer to the [official documentation](https://github.com/bruin-data/bruin).
 
 ## Release Notes
-### Latest Release: 0.46.1
-- Fix Bruin CLI installation on Windows.
+### Latest Release: 0.47.0
+- Added materialization tab to the asset side panel.
 
 ### Recent Updates
+- **0.46.1**: Fix Bruin CLI installation on Windows.
 - **0.46.0**: Added convert feature to convert eligible files to Bruin assets.
 - **0.45.5**: Update SQL editor line height.
 - **0.45.4**: Improve long queries rendering in SQL editor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.46.1",
+      "version": "0.47.0",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -109,6 +109,7 @@
             @update:customChecks="updateCustomChecks"
             @open-glossary="navigateToGlossary"
             @update:description="updateDescription"
+            @update:materialization="updateMaterialization"
           />
         </vscode-panel-view>
       </vscode-panels>
@@ -137,6 +138,8 @@ import DescriptionItem from "./components/ui/description-item/DescriptionItem.vu
 import { badgeStyles, defaultBadgeStyle } from "./components/ui/badges/CustomBadgesStyle";
 import RudderStackService from "./services/RudderStackService";
 import NonAssetMessage from "./components/ui/alerts/NonAssetMessage.vue";
+import Materialization from "./components/asset/materialization/Materialization.vue";
+
 const rudderStack = RudderStackService.getInstance();
 const connectionsStore = useConnectionsStore();
 const parseError = ref(); // Holds any parsing errors
@@ -346,6 +349,11 @@ const focusName = () => {
     nameInput.value?.focus();
   });
 };
+const materializationProps = computed(() => {
+  if (!data.value) return;
+  const details = parseAssetDetails(data.value);
+  return details?.materialization || { type: 'table', strategy: 'create+replace' };
+});
 
 // Computed property for asset columns
 const columnsProps = computed(() => {
@@ -357,6 +365,7 @@ const columnsProps = computed(() => {
 });
 
 const columns = ref([...columnsProps.value]); // Reactive reference for columns
+const materialization = ref({...materializationProps.value});
 console.debug("Initial Columns:", columns.value);
 // Computed property for asset columns
 const customChecksProps = computed(() => {
@@ -389,6 +398,14 @@ const tabs = ref([
     props: computed(() => ({
       columns: columns.value,
       isConfigFile: isConfigFile.value,
+    })),
+  },
+  {
+    label: "Materialization",
+    component: Materialization,
+    props: computed(() => ({
+      materialization: materializationProps.value,
+      columns: columns.value,
     })),
   },
   {
@@ -483,7 +500,10 @@ const updateColumns = (newColumns) => {
   console.log("Updating columns with new data:", newColumns);
   columns.value = newColumns;
 };
-
+const updateMaterialization = (newMaterialization) => {
+  console.log("Updating materialization with new data:", newMaterialization);
+  materialization.value = newMaterialization;
+};
 const updateCustomChecks = (newCustomChecks) => {
   console.log("Updating custom checks with new data:", newCustomChecks);
   customChecks.value = newCustomChecks;

--- a/webview-ui/src/components/asset/materialization/Materialization.vue
+++ b/webview-ui/src/components/asset/materialization/Materialization.vue
@@ -1,0 +1,253 @@
+<template>
+    <div class="h-full w-full p-4 flex justify-center">
+      <div class="flex flex-col gap-4 h-full w-full max-w-4xl">
+        <div class="flex items-center gap-2">
+          <vscode-checkbox :checked="materializationEnabled" @change="toggleMaterialization" />
+          <label class="text-sm font-medium text-editor-fg"> Materialization </label>
+        </div>
+        <div
+          v-if="materializationEnabled"
+          class="flex flex-col sm:flex-row sm:items-start gap-8 border-t border-commandCenter-border pt-4"
+        >
+          <div class="flex-1 min-w-[260px]">
+            <div class="flex flex-col space-y-3">
+              <label class="block text-sm font-medium text-editor-fg mb-2">
+                Materialization Type
+              </label>
+              <div class="flex space-x-6">
+                <vscode-radio-group
+                  :value="localMaterialization.type"
+                  @change="(e) => setType(e.target.value)"
+                >
+                  <vscode-radio name="materialization-type" value="table">Table</vscode-radio>
+                  <vscode-radio name="materialization-type" value="view">View</vscode-radio>
+                </vscode-radio-group>
+              </div>
+            </div>
+          </div>
+  
+          <div v-if="localMaterialization.type === 'table'" class="flex flex-col gap-6 w-full">
+            <div class="flex gap-x-4 gap-y-2 w-full justify-between">
+              <div class="flex-1">
+                <label class="block text-sm font-medium text-editor-fg mb-2">Partitioning</label>
+                <input
+                  v-model="localMaterialization.partition_by"
+                  class="w-full max-w-[300px] p-2 bg-input-background border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
+                  placeholder="comma-separated columns"
+                />
+              </div>
+  
+              <div class="flex-1">
+                <label class="block text-sm font-medium text-editor-fg mb-2">Clustering</label>
+                <input
+                  v-model="localMaterialization.cluster_by"
+                  class="w-full max-w-[300px] p-2 bg-input-background border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
+                  placeholder="comma-separated columns"
+                />
+              </div>
+            </div>
+  
+            <div class="flex flex-col space-y-3">
+              <label class="block text-sm font-medium text-editor-fg mb-2"> Strategy </label>
+              <div class="relative">
+                <select
+                  v-model="localMaterialization.strategy"
+                  class="w-full max-w-[300px] p-2 bg-input-background text-input-foreground border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
+                >
+                  <option value="create+replace">Create + Replace</option>
+                  <option value="delete+insert">Delete + Insert</option>
+                  <option value="append">Append</option>
+                  <option value="merge">Merge</option>
+                  <option value="time_interval">Time Interval</option>
+                </select>
+              </div>
+              <p class="text-xs text-editor-fg opacity-70 mt-1 w-full">
+                {{ getStrategyDescription(localMaterialization.strategy) }}
+              </p>
+            </div>
+          </div>
+        </div>
+  
+        <div v-if="showStrategyOptions" class="flex-1">
+          <div class="p-4 bg-editorWidget-bg rounded border border-commandCenter-border h-full">
+            <div v-if="localMaterialization.strategy === 'merge'" class="space-y-4">
+              <label class="block text-sm font-medium text-editor-fg">Merge Configuration</label>
+              <div class="space-y-3">
+                <div>
+                  <label class="block text-xs text-editor-fg opacity-70 mb-2">
+                    Merge Key Columns (comma-separated)
+                  </label>
+                  <input
+                    v-model="localMaterialization.merge_keys"
+                    class="w-full max-w-[300px] p-2 bg-input-background text-input-foreground border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
+                    placeholder="id, user_id"
+                  />
+                </div>
+              </div>
+            </div>
+  
+            <div v-if="localMaterialization.strategy === 'time_interval'" class="space-y-4">
+              <label class="block text-sm font-medium text-editor-fg">
+                Time Interval Configuration
+              </label>
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label class="block text-xs text-editor-fg opacity-70 mb-2">Time Column</label>
+                  <input
+                    v-model="localMaterialization.time_column"
+                    class="w-full max-w-[300px] p-2 bg-input-background text-input-foreground border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
+                    placeholder="created_at"
+                  />
+                </div>
+                <div>
+                  <label class="block text-xs text-editor-fg opacity-70 mb-2">Interval</label>
+                  <select
+                    v-model="localMaterialization.interval"
+                    class="w-full max-w-[300px] p-2 bg-input-background text-input-foreground border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
+                  >
+                    <option value="hourly">Hourly</option>
+                    <option value="daily">Daily</option>
+                    <option value="weekly">Weekly</option>
+                    <option value="monthly">Monthly</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+  
+        <div v-if="materializationEnabled" class="border-t border-commandCenter-border pt-4 mt-auto">
+          <div class="flex justify-end">
+            <vscode-button
+              @click="saveMaterialization"
+              class="py-1 px-4 focus:outline-none save-button"
+            >
+              Save Changes
+            </vscode-button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+  
+  <script setup>
+  import { ref, computed, watch } from "vue";
+  
+  const props = defineProps({
+    materialization: {
+      type: Object,
+      default: () => ({
+        type: "table",
+        strategy: "create+replace",
+        partition_by: "",
+        cluster_by: "", 
+        merge_keys: "",
+        time_column: "",
+        interval: "daily",
+      }),
+    },
+    isConfigFile: {
+      type: Boolean,
+      default: false,
+    },
+  });
+  
+  const emit = defineEmits(["update:materialization"]);
+  const materializationEnabled = ref(!!props.materialization);
+  const toggleMaterialization = () => {
+    materializationEnabled.value = !materializationEnabled.value;
+  };
+  
+  const initializeMaterialization = () => {
+    const base = JSON.parse(JSON.stringify(props.materialization));
+    if (base.type === "table" && !base.strategy) {
+      base.strategy = "create+replace";
+    }
+    if (base.cluster_by === null) {
+      base.cluster_by = "";
+    }
+    return base;
+  };
+  
+  const localMaterialization = ref(initializeMaterialization());
+  
+  const showStrategyOptions = computed(() => {
+    return (
+      localMaterialization.value.type === "table" &&
+      (localMaterialization.value.strategy === "merge" ||
+        localMaterialization.value.strategy === "time_interval")
+    );
+  });
+  
+  // Consolidated function to handle setting type and updating strategy
+  const setType = (type) => {
+    localMaterialization.value.type = type;
+    if (type === "table") {
+      if (!localMaterialization.value.strategy) {
+        localMaterialization.value.strategy = "create+replace";
+      }
+    }
+  };
+  
+  const saveMaterialization = () => {
+    const cleanData = { ...localMaterialization.value };
+    emit("update:materialization", cleanData);
+    vscode.postMessage({
+      command: "bruin.setAssetDetails",
+      payload: { materialization: cleanData },
+    });
+  };
+  
+  const getStrategyDescription = (strategy) => {
+    const descriptions = {
+      "create+replace": "Drop and recreate the table completely",
+      "delete+insert": "Delete existing data and insert new data",
+      "append": "Add new rows to existing table",
+      "merge": "Update existing rows and insert new ones based on merge keys",
+      "time_interval": "Process data in time-based intervals",
+    };
+    return descriptions[strategy] || "";
+  };
+  
+  watch(
+    () => props.materialization,
+    (newVal) => {
+      if (newVal) {
+        const initialized = JSON.parse(JSON.stringify(newVal));
+        if (initialized.type === "table" && !initialized.strategy) {
+          initialized.strategy = "create+replace";
+        }
+        if (initialized.cluster_by === null) {
+          initialized.cluster_by = "";
+        }
+        localMaterialization.value = initialized;
+      }
+    },
+    { deep: true, immediate: true }
+  );
+  </script>
+  
+  <style scoped>
+  vscode-radio::part(control) {
+    @apply border-none outline-none w-4 h-4;
+  }
+  
+  vscode-radio::part(control):checked {
+    @apply bg-input-background;
+  }
+  
+  input,
+  select {
+    @apply text-sm bg-input-background text-input-foreground border border-commandCenter-border outline-none;
+  }
+  
+  input:focus,
+  select:focus {
+    @apply ring-1 ring-editorLink-activeFg border-editorLink-activeFg;
+  }
+  
+  input:disabled,
+  select:disabled {
+    @apply opacity-50 cursor-not-allowed;
+  }
+  </style>

--- a/webview-ui/src/components/asset/materialization/Materialization.vue
+++ b/webview-ui/src/components/asset/materialization/Materialization.vue
@@ -70,8 +70,8 @@
 
       <div v-if="showStrategyOptions" class="flex-1">
         <div class="p-4 bg-editorWidget-bg rounded border border-commandCenter-border h-full">
-          <div v-if="localMaterialization.strategy === 'delete+insert'" class="flex flex-col space-y-4">
-            <label class="block text-xs opacity-65 text-editor-fg">Incremental Key</label>
+          <div v-if="localMaterialization.strategy === 'delete+insert'" class="flex flex-col">
+            <label class="block text-sm opacity-65 text-editor-fg mb-2">Incremental Key</label>
             <input
               v-model="localMaterialization.incremental_key"
               placeholder="column_name"
@@ -89,11 +89,11 @@
           <div v-if="localMaterialization.strategy === 'time_interval'" class="flex flex-col space-y-4">
             <div class="grid grid-cols-2 gap-4">
               <div class="flex flex-col">
-                <label class="block text-sm font-medium text-editor-fg mb-2">Incremental Key</label>
+                <label class="block text-sm opacity-65 text-editor-fg mb-2">Incremental Key</label>
                 <input v-model="localMaterialization.incremental_key" placeholder="column_name" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-editor-fg mb-2">Time Granularity</label>
+                <label class="block text-sm opacity-65 text-editor-fg mb-2">Time Granularity</label>
                 <select v-model="localMaterialization.time_granularity">
                   <option value="date">Date</option>
                   <option value="timestamp">Timestamp</option>

--- a/webview-ui/src/components/asset/materialization/Materialization.vue
+++ b/webview-ui/src/components/asset/materialization/Materialization.vue
@@ -1,253 +1,235 @@
 <template>
-    <div class="h-full w-full p-4 flex justify-center">
-      <div class="flex flex-col gap-4 h-full w-full max-w-4xl">
-        <div class="flex items-center gap-2">
-          <vscode-checkbox :checked="materializationEnabled" @change="toggleMaterialization" />
-          <label class="text-sm font-medium text-editor-fg"> Materialization </label>
-        </div>
-        <div
-          v-if="materializationEnabled"
-          class="flex flex-col sm:flex-row sm:items-start gap-8 border-t border-commandCenter-border pt-4"
-        >
-          <div class="flex-1 min-w-[260px]">
-            <div class="flex flex-col space-y-3">
-              <label class="block text-sm font-medium text-editor-fg mb-2">
-                Materialization Type
-              </label>
-              <div class="flex space-x-6">
-                <vscode-radio-group
-                  :value="localMaterialization.type"
-                  @change="(e) => setType(e.target.value)"
-                >
-                  <vscode-radio name="materialization-type" value="table">Table</vscode-radio>
-                  <vscode-radio name="materialization-type" value="view">View</vscode-radio>
-                </vscode-radio-group>
-              </div>
-            </div>
-          </div>
-  
-          <div v-if="localMaterialization.type === 'table'" class="flex flex-col gap-6 w-full">
-            <div class="flex gap-x-4 gap-y-2 w-full justify-between">
-              <div class="flex-1">
-                <label class="block text-sm font-medium text-editor-fg mb-2">Partitioning</label>
-                <input
-                  v-model="localMaterialization.partition_by"
-                  class="w-full max-w-[300px] p-2 bg-input-background border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
-                  placeholder="comma-separated columns"
-                />
-              </div>
-  
-              <div class="flex-1">
-                <label class="block text-sm font-medium text-editor-fg mb-2">Clustering</label>
-                <input
-                  v-model="localMaterialization.cluster_by"
-                  class="w-full max-w-[300px] p-2 bg-input-background border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
-                  placeholder="comma-separated columns"
-                />
-              </div>
-            </div>
-  
-            <div class="flex flex-col space-y-3">
-              <label class="block text-sm font-medium text-editor-fg mb-2"> Strategy </label>
-              <div class="relative">
-                <select
-                  v-model="localMaterialization.strategy"
-                  class="w-full max-w-[300px] p-2 bg-input-background text-input-foreground border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
-                >
-                  <option value="create+replace">Create + Replace</option>
-                  <option value="delete+insert">Delete + Insert</option>
-                  <option value="append">Append</option>
-                  <option value="merge">Merge</option>
-                  <option value="time_interval">Time Interval</option>
-                </select>
-              </div>
-              <p class="text-xs text-editor-fg opacity-70 mt-1 w-full">
-                {{ getStrategyDescription(localMaterialization.strategy) }}
-              </p>
+  <div class="h-full w-full p-4 flex justify-center">
+    <div class="flex flex-col gap-4 h-full w-full max-w-4xl">
+      <div class="flex items-center gap-2">
+        <vscode-checkbox :checked="materializationEnabled" @change="toggleMaterialization" />
+        <label class="text-sm font-medium text-editor-fg"> Materialization </label>
+      </div>
+      <div
+        v-if="materializationEnabled"
+        class="flex flex-col sm:flex-row sm:items-start gap-8 border-t border-commandCenter-border pt-4"
+      >
+        <div class="flex-1 min-w-[260px]">
+          <div class="flex flex-col space-y-3">
+            <label class="block text-sm font-medium text-editor-fg mb-2">
+              Materialization Type
+            </label>
+            <div class="flex space-x-6">
+              <vscode-radio-group
+                :value="localMaterialization.type"
+                @change="(e) => setType(e.target.value)"
+              >
+                <vscode-radio name="materialization-type" value="table">Table</vscode-radio>
+                <vscode-radio name="materialization-type" value="view">View</vscode-radio>
+              </vscode-radio-group>
             </div>
           </div>
         </div>
-  
-        <div v-if="showStrategyOptions" class="flex-1">
-          <div class="p-4 bg-editorWidget-bg rounded border border-commandCenter-border h-full">
-            <div v-if="localMaterialization.strategy === 'merge'" class="space-y-4">
-              <label class="block text-sm font-medium text-editor-fg">Merge Configuration</label>
-              <div class="space-y-3">
-                <div>
-                  <label class="block text-xs text-editor-fg opacity-70 mb-2">
-                    Merge Key Columns (comma-separated)
-                  </label>
-                  <input
-                    v-model="localMaterialization.merge_keys"
-                    class="w-full max-w-[300px] p-2 bg-input-background text-input-foreground border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
-                    placeholder="id, user_id"
-                  />
-                </div>
-              </div>
+
+        <div v-if="localMaterialization.type === 'table'" class="flex flex-col gap-6 w-full">
+          <div class="flex gap-x-4 gap-y-2 w-full justify-between">
+            <div class="flex-1">
+              <label class="block text-sm font-medium text-editor-fg mb-2">Partitioning</label>
+              <input
+                v-model="localMaterialization.partition_by"
+                class="w-full max-w-[300px] p-2 bg-input-background border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
+                placeholder="comma-separated columns"
+              />
             </div>
-  
-            <div v-if="localMaterialization.strategy === 'time_interval'" class="space-y-4">
-              <label class="block text-sm font-medium text-editor-fg">
-                Time Interval Configuration
-              </label>
-              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label class="block text-xs text-editor-fg opacity-70 mb-2">Time Column</label>
-                  <input
-                    v-model="localMaterialization.time_column"
-                    class="w-full max-w-[300px] p-2 bg-input-background text-input-foreground border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
-                    placeholder="created_at"
-                  />
-                </div>
-                <div>
-                  <label class="block text-xs text-editor-fg opacity-70 mb-2">Interval</label>
-                  <select
-                    v-model="localMaterialization.interval"
-                    class="w-full max-w-[300px] p-2 bg-input-background text-input-foreground border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
-                  >
-                    <option value="hourly">Hourly</option>
-                    <option value="daily">Daily</option>
-                    <option value="weekly">Weekly</option>
-                    <option value="monthly">Monthly</option>
-                  </select>
-                </div>
-              </div>
+
+            <div class="flex-1">
+              <label class="block text-sm font-medium text-editor-fg mb-2">Clustering</label>
+              <input
+                v-model="localMaterialization.cluster_by"
+                class="w-full max-w-[300px] p-2 bg-input-background border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
+                placeholder="comma-separated columns"
+              />
             </div>
           </div>
-        </div>
-  
-        <div v-if="materializationEnabled" class="border-t border-commandCenter-border pt-4 mt-auto">
-          <div class="flex justify-end">
-            <vscode-button
-              @click="saveMaterialization"
-              class="py-1 px-4 focus:outline-none save-button"
-            >
-              Save Changes
-            </vscode-button>
+
+          <div class="flex flex-col space-y-3">
+            <label class="block text-sm font-medium text-editor-fg mb-2"> Strategy </label>
+            <div class="relative">
+              <select
+                v-model="localMaterialization.strategy"
+                class="w-full max-w-[300px] p-2 bg-input-background text-input-foreground border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
+              >
+                <option value="create+replace">Create + Replace</option>
+                <option value="delete+insert">Delete + Insert</option>
+                <option value="append">Append</option>
+                <option value="merge">Merge</option>
+                <option value="time_interval">Time Interval</option>
+              </select>
+            </div>
+            <p class="text-xs text-editor-fg opacity-70 mt-1 w-full">
+              {{ getStrategyDescription(localMaterialization.strategy) }}
+            </p>
           </div>
         </div>
       </div>
+
+      <div v-if="showStrategyOptions" class="flex-1">
+        <div class="p-4 bg-editorWidget-bg rounded border border-commandCenter-border h-full">
+          <div v-if="localMaterialization.strategy === 'delete+insert'" class="space-y-4">
+            <label>Delete+Insert Configuration</label>
+            <input
+              v-model="localMaterialization.incremental_key"
+              placeholder="incremental_key_column"
+            />
+          </div>
+
+          <!-- Merge -->
+          <div v-if="localMaterialization.strategy === 'merge'" class="space-y-4">
+            <label>Merge Configuration</label>
+            <p class="info-text">
+              Configure primary keys in column definitions using <code>primary_key: true</code>
+            </p>
+          </div>
+
+          <!-- Time Interval -->
+          <div v-if="localMaterialization.strategy === 'time_interval'" class="space-y-4">
+            <label>Time Interval Configuration</label>
+            <div class="grid grid-cols-2 gap-4">
+              <input v-model="localMaterialization.incremental_key" placeholder="dt" />
+              <select v-model="localMaterialization.time_granularity">
+                <option value="date">Date</option>
+                <option value="timestamp">Timestamp</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="materializationEnabled" class="border-t border-commandCenter-border pt-4 mt-auto">
+        <div class="flex justify-end">
+          <vscode-button
+            @click="saveMaterialization"
+            class="py-1 px-4 focus:outline-none save-button"
+          >
+            Save Changes
+          </vscode-button>
+        </div>
+      </div>
     </div>
-  </template>
-  
-  <script setup>
-  import { ref, computed, watch } from "vue";
-  
-  const props = defineProps({
-    materialization: {
-      type: Object,
-      default: () => ({
-        type: "table",
-        strategy: "create+replace",
-        partition_by: "",
-        cluster_by: "", 
-        merge_keys: "",
-        time_column: "",
-        interval: "daily",
-      }),
-    },
-    isConfigFile: {
-      type: Boolean,
-      default: false,
-    },
-  });
-  
-  const emit = defineEmits(["update:materialization"]);
-  const materializationEnabled = ref(!!props.materialization);
-  const toggleMaterialization = () => {
-    materializationEnabled.value = !materializationEnabled.value;
-  };
-  
-  const initializeMaterialization = () => {
-    const base = JSON.parse(JSON.stringify(props.materialization));
-    if (base.type === "table" && !base.strategy) {
-      base.strategy = "create+replace";
-    }
-    if (base.cluster_by === null) {
-      base.cluster_by = "";
-    }
-    return base;
-  };
-  
-  const localMaterialization = ref(initializeMaterialization());
-  
-  const showStrategyOptions = computed(() => {
-    return (
-      localMaterialization.value.type === "table" &&
-      (localMaterialization.value.strategy === "merge" ||
-        localMaterialization.value.strategy === "time_interval")
-    );
-  });
-  
-  // Consolidated function to handle setting type and updating strategy
-  const setType = (type) => {
-    localMaterialization.value.type = type;
-    if (type === "table") {
-      if (!localMaterialization.value.strategy) {
-        localMaterialization.value.strategy = "create+replace";
-      }
-    }
-  };
-  
-  const saveMaterialization = () => {
-    const cleanData = { ...localMaterialization.value };
-    emit("update:materialization", cleanData);
-    vscode.postMessage({
-      command: "bruin.setAssetDetails",
-      payload: { materialization: cleanData },
-    });
-  };
-  
-  const getStrategyDescription = (strategy) => {
-    const descriptions = {
-      "create+replace": "Drop and recreate the table completely",
-      "delete+insert": "Delete existing data and insert new data",
-      "append": "Add new rows to existing table",
-      "merge": "Update existing rows and insert new ones based on merge keys",
-      "time_interval": "Process data in time-based intervals",
-    };
-    return descriptions[strategy] || "";
-  };
-  
-  watch(
-    () => props.materialization,
-    (newVal) => {
-      if (newVal) {
-        const initialized = JSON.parse(JSON.stringify(newVal));
-        if (initialized.type === "table" && !initialized.strategy) {
-          initialized.strategy = "create+replace";
-        }
-        if (initialized.cluster_by === null) {
-          initialized.cluster_by = "";
-        }
-        localMaterialization.value = initialized;
-      }
-    },
-    { deep: true, immediate: true }
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from "vue";
+import { vscode } from "@/utilities/vscode";
+const props = defineProps({
+  materialization: {
+    type: Object,
+    default: () => ({
+      type: "table",
+      strategy: "create+replace",
+      partition_by: "",
+      cluster_by: [],
+      merge_keys: "",
+      time_column: "",
+      interval: "daily",
+    }),
+  },
+  isConfigFile: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(["update:materialization"]);
+const materializationEnabled = ref(!!props.materialization);
+const toggleMaterialization = () => {
+  materializationEnabled.value = !materializationEnabled.value;
+};
+
+const initializeMaterialization = () => {
+  const base = JSON.parse(JSON.stringify(props.materialization));
+  if (base.type === "table" && !base.strategy) {
+    base.strategy = "create+replace";
+  }
+  if (!Array.isArray(base.cluster_by)) {
+    base.cluster_by = [];
+  }
+  return base;
+};
+
+const localMaterialization = ref(initializeMaterialization());
+
+const showStrategyOptions = computed(() => {
+  return (
+    localMaterialization.value.type === "table" &&
+    ["delete+insert", "merge", "time_interval"].includes(localMaterialization.value.strategy)
   );
-  </script>
-  
-  <style scoped>
-  vscode-radio::part(control) {
-    @apply border-none outline-none w-4 h-4;
+});
+
+// Consolidated function to handle setting type and updating strategy
+const setType = (type) => {
+  localMaterialization.value.type = type;
+  if (type === "table") {
+    if (!localMaterialization.value.strategy) {
+      localMaterialization.value.strategy = "create+replace";
+    }
   }
-  
-  vscode-radio::part(control):checked {
-    @apply bg-input-background;
-  }
-  
-  input,
-  select {
-    @apply text-sm bg-input-background text-input-foreground border border-commandCenter-border outline-none;
-  }
-  
-  input:focus,
-  select:focus {
-    @apply ring-1 ring-editorLink-activeFg border-editorLink-activeFg;
-  }
-  
-  input:disabled,
-  select:disabled {
-    @apply opacity-50 cursor-not-allowed;
-  }
-  </style>
+};
+
+const saveMaterialization = () => {
+  const cleanData = { ...localMaterialization.value };
+  emit("update:materialization", cleanData);
+  vscode.postMessage({
+    command: "bruin.setAssetDetails",
+    payload: { materialization: cleanData },
+  });
+};
+
+function getStrategyDescription(strategy) {
+  return {
+    "create+replace": "Drop and recreate the table completely",
+    "delete+insert": "Delete existing data using incremental key and insert new records",
+    "append": "Add new rows without modifying existing data",
+    "merge": "Update existing rows and insert new ones using primary keys",
+    "time_interval": "Process time-based data using incremental key",
+  }[strategy];
+}
+
+watch(
+  () => props.materialization,
+  (newVal) => {
+    if (newVal) {
+      const initialized = JSON.parse(JSON.stringify(newVal));
+      if (initialized.type === "table" && !initialized.strategy) {
+        initialized.strategy = "create+replace";
+      }
+      if (initialized.cluster_by === null || initialized.cluster_by === undefined) {
+        initialized.cluster_by = null;
+      }
+      localMaterialization.value = initialized;
+    }
+  },
+  { deep: true, immediate: true }
+);
+</script>
+
+<style scoped>
+vscode-radio::part(control) {
+  @apply border-none outline-none w-4 h-4;
+}
+
+vscode-radio::part(control):checked {
+  @apply bg-input-background;
+}
+
+input,
+select {
+  @apply text-sm bg-input-background text-input-foreground border border-commandCenter-border outline-none;
+}
+
+input:focus,
+select:focus {
+  @apply ring-1 ring-editorLink-activeFg border-editorLink-activeFg;
+}
+
+input:disabled,
+select:disabled {
+  @apply opacity-50 cursor-not-allowed;
+}
+</style>

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -102,6 +102,7 @@ export const parseAssetDetails = (data: string) => {
     description: asset.description || undefined,
     owner: asset.owner || undefined,
     pipeline,
+    materialization: asset.materialization || undefined,
     columns: asset.columns ? transformColumnData(asset.columns) : [],
     custom_checks: asset.custom_checks || [],
   };


### PR DESCRIPTION
# PR Overview
This PR introduces a new `Materialization` tab to manage and display materialization settings for assets

### Changes:
* Parsed and rendered the `materialization` property from asset details.
* Added support for selecting materialization strategies via config options.

![materialization](https://github.com/user-attachments/assets/a05a7649-ff27-4367-aad4-7326d6e1ebd8)
