### PR TITLE
Add Ingestr Asset Snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,10 @@
       {
         "language": "yaml",
         "path": "./snippets/bruin-pipeline.code-snippets"
+      },
+      {
+        "language": "yaml",
+        "path": "./snippets/bruin-ingestr.code-snippets"
       }
     ],
     "grammars": [

--- a/snippets/bruin-ingestr.code-snippets
+++ b/snippets/bruin-ingestr.code-snippets
@@ -1,0 +1,17 @@
+{
+    "Bruin Ingestr Asset Block": {
+        "prefix": "!bruin-asset-ingestr",
+        "body": [
+            "name: ${1:bruin-ingestr}",
+            "type: ingestr",
+            "connection: ${2:google_cloud_platform}",
+            "parameters:",
+            "  source: ${3:source}",
+            "  source_connection: ${4:source_connection}",
+            "  source_table: ${5:source_table}",
+            "  destination: ${6:bigquery}",
+            "$0"
+        ],
+        "description": "Initialize a Bruin ingestr asset"
+    }
+}


### PR DESCRIPTION
# PR Overview

This PR introduces a new VS Code snippet for initializing Bruin ingestr assets `!bruin-asset-ingestr`.
![ingestr-snippet](https://github.com/user-attachments/assets/af11a6b5-19da-41c3-b560-2b2fc3b6be5e)
