### PR TITLE
Add Column Selection for Partitioning and Clustering in Materialization

### DIFF
--- a/webview-ui/src/components/asset/materialization/Materialization.vue
+++ b/webview-ui/src/components/asset/materialization/Materialization.vue
@@ -89,11 +89,15 @@
       <div class="flex gap-x-4 gap-y-2 w-full justify-between ">
         <div class="flex-1">
           <label class="block text-sm font-medium text-editor-fg mb-2">Partitioning</label>
-          <input
+          <select
             v-model="localMaterialization.partition_by"
             class="w-full max-w-[300px] p-2 bg-input-background border border-commandCenter-border rounded text-sm focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
-            placeholder="column_name"
-          />
+          >
+            <option class="text-xs opacity-70" :value="''">Select a column</option>
+            <option v-for="column in columns" :key="column.name" :value="column.name">
+              {{ column.name }}
+            </option>
+          </select>
         </div>
 
         <div class="flex-1">
@@ -208,6 +212,10 @@ const props = defineProps({
   isConfigFile: {
     type: Boolean,
     default: false,
+  },
+  columns: {
+    type: Array,
+    default: () => [],
   },
   owner: {
     type: String,
@@ -404,7 +412,6 @@ const saveMaterialization = () => {
     };
   }
 
-  // Include owner and tags in the payload
   const payload = {
     materialization: cleanData,
   };

--- a/webview-ui/src/components/asset/materialization/Materialization.vue
+++ b/webview-ui/src/components/asset/materialization/Materialization.vue
@@ -106,6 +106,15 @@
               class="absolute z-10 w-full bg-dropdown-bg border border-commandCenter-border rounded shadow-lg mt-1 max-h-60 overflow-y-auto"
             >
               <div
+                class="px-3 py-2 hover:bg-list-hoverBackground hover:text-list-activeSelectionForeground cursor-pointer"
+                @click="
+                  localMaterialization.partition_by = '';
+                  isPartitionDropdownOpen = false;
+                "
+              >
+                <span class="text-xs opacity-70">Clear selection</span>
+              </div>
+              <div
                 v-for="column in columns"
                 :key="column.name"
                 class="px-3 py-2 hover:bg-list-hoverBackground hover:text-list-activeSelectionForeground cursor-pointer"


### PR DESCRIPTION
# PR Overview 
This PR enhances the Materialization UI as follows: 

* Updated **Partition By** to use a dropdown for selecting a single column.
* Added a **Clustering** dropdown with multi-select support for selecting multiple columns.
* Ensured both dropdowns are populated based on the current asset's available columns.

![partition-cluster-dropdown](https://github.com/user-attachments/assets/f6a1f657-9959-4a8e-88f9-0bf5db570578)
