### PR TITLE
Add Interval Modifiers Checkbox and Disclaimer 

### DIFF
--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -416,7 +416,7 @@ const customChecks = ref([...customChecksProps.value]); // Reactive reference fo
 // Define tabs for the application
 const tabs = ref([
   {
-    label: "Asset Details",
+    label: "General",
     component: AssetDetails,
     props: computed(() => ({
       ...assetDetailsProps.value,
@@ -435,7 +435,7 @@ const tabs = ref([
     })),
   },
   {
-    label: "Materialization",
+    label: "Details",
     component: Materialization,
     props: computed(() => ({
       materialization: materializationProps.value,

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -268,6 +268,7 @@ const showConvertMessage = ref(false);
 const nonAssetFileType = ref("");
 const nonAssetFilePath = ref("");
 const activeTab = ref(0); // Tracks the currently active tab
+
 const navigateToGlossary = () => {
   console.log("Opening glossary.");
   vscode.postMessage({ command: "bruin.openGlossary" });
@@ -326,6 +327,16 @@ const assetDetailsProps = computed({
       // console.log("Updated asset data after setting:", data.value);
     }
   },
+});
+
+const intervalModifiers = computed(() => {
+  return assetDetailsProps.value?.interval_modifiers || false;
+});
+
+const hasIntervalModifiers = computed(() => {
+  const intervalModifiersValue = assetDetailsProps.value?.interval_modifiers ? true : false;
+  console.warn("Has interval modifiers computed:", intervalModifiersValue);
+  return intervalModifiersValue;
 });
 
 const isEditingName = ref(false);
@@ -411,6 +422,7 @@ const tabs = ref([
       ...assetDetailsProps.value,
       environments: environmentsList.value,
       selectedEnvironment: selectedEnvironment.value,
+      hasIntervalModifiers: hasIntervalModifiers.value,
     })),
     emits: ["update:name", "update:description"],
   },

--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -81,6 +81,7 @@
         :schedule="scheduleExists ? props.pipeline.schedule : ''"
         :environments="environments"
         :selectedEnvironment="selectedEnvironment"
+        :hasIntervalModifiers="hasIntervalModifiers"
       />
     </div>
   </div>
@@ -104,6 +105,7 @@ const props = defineProps<{
   pipeline: any;
   environments: string[];
   selectedEnvironment: string;
+  hasIntervalModifiers: boolean;
 }>();
 
 const descriptionRef = ref<HTMLElement | null>(null);

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -195,24 +195,6 @@
       </div>
 
       <!-- Alerts and Code Display Section -->
-      <div
-        v-if="showIntervalAlert"
-        class="mb-2 transition-all duration-300 ease-in-out overflow-hidden"
-      >
-        <div
-          class="flex items-center border border-commandCenter-border bg-notification-bg p-2 rounded-md text-notification-fg"
-        >
-          <span class="mr-2 text-notificationsInfoIcon-fg codicon codicon-info text-xs"></span>
-          <span class="flex-1 text-sm">Interval modifiers are present. Check "Interval-modifiers" to apply them.</span>
-          <button
-            @click="dismissIntervalAlert"
-            class="text-current hover:bg-notification-bg hover:text-notification-fg rounded-full w-5 h-5 flex items-center justify-center"
-            title="Dismiss"
-          >
-            <span class="codicon codicon-close text-xs"></span>
-          </button>
-        </div>
-      </div>
       <ErrorAlert
         v-if="hasCriticalErrors"
         :errorMessage="errorMessage!"
@@ -227,7 +209,7 @@
       />
       <div class="">
         <div v-if="language === 'sql'" class="mt-1">
-          <SqlEditor :code="code" :copied="false" :language="language" />
+          <SqlEditor :code="code" :copied="false" :language="language" :showIntervalAlert="showIntervalAlert"/>
         </div>
         <div v-else class="overflow-hidden w-full h-20">
           <pre class="white-space"></pre>

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -353,6 +353,7 @@ const warningMessages = computed(() =>
  */
 const checkboxItems = ref([
   { name: "Full-Refresh", checked: false },
+  { name: "Interval-modifiers", checked: false },
   { name: "Exclusive-End-Date", checked: true },
   { name: "Push-Metadata", checked: false },
 ]);

--- a/webview-ui/src/components/asset/SqlEditor.vue
+++ b/webview-ui/src/components/asset/SqlEditor.vue
@@ -1,52 +1,105 @@
 <template>
-  <div class="highlight-container rounded-md overflow-hidden">
-    <div
-      class="header flex items-center justify-between p-2 border-gray-300 shadow-sm"
-    >
-      <label class="text-sm font-medium">SQL Preview</label>
-      <button
-        @click="copyToClipboard"
-        :disabled="!code"
-        class="copy-button flex items-center bg-none border-none cursor-pointer"
-      >
-        <IConButton v-show="!copied" aria-hidden="true" />
-        <span v-if="copied" class="text-sm">Copied!</span>
-      </button>
+  <div class="highlight-container rounded overflow-hidden">
+    <div class="header flex items-center justify-between px-1.5 py-0.5 border-commandCenter-border shadow-sm">
+      <label class="text-xs font-sans">Preview</label>
+      <div class="flex items-center">
+        <div class="relative" v-if="showIntervalAlert">
+          <vscode-button
+            appearance="icon"
+            class="ml-1"
+            @click="toggleWarningMessage"
+            @mouseenter="onWarningMouseEnter"
+            @mouseleave="onWarningMouseLeave"
+            v-click-outside="onClickOutsideWarning"
+          >
+            <span
+              class="codicon codicon-warning text-xs text-notificationsWarningIcon-fg"
+              aria-hidden="true"
+            ></span>
+          </vscode-button>
+          <div
+            v-if="showAlertMassage"
+            class="absolute top-full right-0 mt-1 z-50 transition-all duration-300 ease-in-out"
+            style="min-width: 250px; white-space: nowrap"
+          >
+            <div
+              class="flex items-center border border-commandCenter-border bg-vscode-input-background px-2 py-1 rounded-md text-notification-fg shadow-lg warning-message-box"
+            >
+              <span class="text-xs">Check "Interval-modifiers" to apply them.</span>
+            </div>
+          </div>
+        </div>
+        <vscode-button
+          @click="copyToClipboard"
+          appearance="icon"
+          :disabled="!code"
+          class="copy-button flex items-center bg-none border-none cursor-pointer"
+        >
+          <span class="codicon codicon-copy text-xs" v-show="!copied" aria-hidden="true" />
+          <span v-if="copied" class="text-sm">Copied!</span>
+        </vscode-button>
+      </div>
     </div>
     <div id="sql-editor" class="code-container pb-0" :style="{ height: editorHeight }">
-      <DynamicScroller
-        class="scroller"
-        :items="visibleHighlightedLines"
-        :min-item-size="lineHeight"       
-        key-field="lineNumber"
-        v-slot="{ item }"
-      >
-        <DynamicScrollerItem :item="item">
-          <div class="line">
-            <span class="line-number">{{ item.lineNumber }}</span>
-            <span class="line-content" v-html="item.content"></span>
-          </div>
-        </DynamicScrollerItem>
-      </DynamicScroller>
+      <!-- Use regular rendering for small content, virtual scroller for large content -->
+      <div v-if="shouldUseVirtualScroller" class="scroller">
+        <DynamicScroller
+          :items="visibleHighlightedLines"
+          :min-item-size="lineHeight"
+          key-field="lineNumber"
+          v-slot="{ item }"
+        >
+          <DynamicScrollerItem :item="item">
+            <div class="line">
+              <span class="line-number">{{ item.lineNumber }}</span>
+              <span class="line-content" v-html="item.content"></span>
+            </div>
+          </DynamicScrollerItem>
+        </DynamicScroller>
+      </div>
+      <div v-else class="regular-content">
+        <div v-for="item in visibleHighlightedLines" :key="item.lineNumber" class="line">
+          <span class="line-number">{{ item.lineNumber }}</span>
+          <span class="line-content" v-html="item.content"></span>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, defineProps, computed } from "vue";
-import 'highlight.js/styles/default.css'; 
-import IConButton from "@/components/ui/buttons/IconButton.vue";
-import hljs from 'highlight.js/lib/core';
-import { DynamicScroller, DynamicScrollerItem } from 'vue3-virtual-scroller';
-import 'vue3-virtual-scroller/dist/vue3-virtual-scroller.css';
+import { ref, defineProps, computed, watch } from "vue";
+import "highlight.js/styles/default.css";
+import hljs from "highlight.js/lib/core";
+import { DynamicScroller, DynamicScrollerItem } from "vue3-virtual-scroller";
+import "vue3-virtual-scroller/dist/vue3-virtual-scroller.css";
 
 const props = defineProps({
   code: String | undefined,
   language: "sql" | "python",
   copied: Boolean,
+  showIntervalAlert: Boolean,
 });
 
+const showIntervalAlert = ref(props.showIntervalAlert);
+const showAlertMassage = ref(false);
 const copied = ref(false);
+const clickOpened = ref(false);
+
+// Directive to detect clicks outside an element
+const vClickOutside = {
+  mounted(el, binding) {
+    el.__ClickOutsideHandler__ = (event) => {
+      if (!(el === event.target || el.contains(event.target))) {
+        binding.value(event);
+      }
+    };
+    document.body.addEventListener("click", el.__ClickOutsideHandler__);
+  },
+  unmounted(el) {
+    document.body.removeEventListener("click", el.__ClickOutsideHandler__);
+  },
+};
 
 function copyToClipboard() {
   navigator.clipboard.writeText(props.code);
@@ -55,19 +108,36 @@ function copyToClipboard() {
     copied.value = false;
   }, 2000);
 }
-const lineHeight = 15; 
-const minEditorHeight = `${lineHeight * 8}px`;
-const maxEditorHeight = '500px';
-const highlightedLines = computed(() => {
-  if (!props.code) return [];
-  const highlighted = hljs.highlight(props.code, { language: props.language }).value;
 
-  const lines = highlighted.split('\n').filter(line => line !== ''); // Filter out empty strings
-  return lines.map(line => `<span>${line}</span>`);
+const lineHeight = 18;
+const editorPadding = 12; 
+const minEditorHeight = `${lineHeight * 2}px`;
+const maxEditorHeight = "500px";
+
+// Calculate line number width based on total lines
+const lineNumberWidth = computed(() => {
+  const totalLines = visibleHighlightedLines.value.length;
+  const digits = totalLines.toString().length;
+  return 20 + (digits * 8);
 });
+
+// Only use virtual scroller for large content to avoid unnecessary scrolling
+const shouldUseVirtualScroller = computed(() => {
+  return visibleHighlightedLines.value.length > 50; // Use virtual scroller only for 50+ lines
+});
+
+const highlightedLines = computed(() => {
+  if (!props.code) return [""];
+  const highlighted = hljs.highlight(props.code, { language: props.language }).value;
+  return highlighted.split("\n").map((line) => `<span>${line}</span>`);
+});
+
 const visibleHighlightedLines = computed(() => {
-  if (!props.code) return [];
   const lines = highlightedLines.value;
+  // If no lines, provide one empty line for consistent height
+  if (lines.length === 0) {
+    return [{ lineNumber: 1, content: "<span></span>" }];
+  }
   return lines.map((line, index) => ({
     lineNumber: index + 1,
     content: line,
@@ -75,21 +145,64 @@ const visibleHighlightedLines = computed(() => {
 });
 
 const editorHeight = computed(() => {
-  if (!props.code) return minEditorHeight;
   const lineCount = visibleHighlightedLines.value.length;
-  const calculatedHeight = lineCount * lineHeight;
-  return `${Math.min(Math.max(calculatedHeight, lineHeight * 5), 500)}px`;
+  const calculatedHeight = lineCount * lineHeight + editorPadding;
+
+  // If there's no code or only empty lines, use minEditorHeight
+  if (!props.code || lineCount === 0) {
+    return minEditorHeight;
+  }
+
+  // For any number of lines, ensure proper height calculation including padding
+  // Use minEditorHeight as minimum, maxEditorHeight as maximum
+  return `${Math.min(Math.max(calculatedHeight, parseInt(minEditorHeight)), parseInt(maxEditorHeight))}px`;
 });
 
+const toggleWarningMessage = () => {
+  if (clickOpened.value) {
+    // If already opened by click, close it
+    showAlertMassage.value = false;
+    clickOpened.value = false;
+  } else {
+    // Open it and mark as click-opened
+    showAlertMassage.value = true;
+    clickOpened.value = true;
+  }
+};
+
+const onWarningMouseEnter = () => {
+  if (!clickOpened.value) {
+    showAlertMassage.value = true;
+  }
+};
+
+const onWarningMouseLeave = () => {
+  if (!clickOpened.value) {
+    showAlertMassage.value = false;
+  }
+};
+
+const onClickOutsideWarning = () => {
+  if (clickOpened.value) {
+    showAlertMassage.value = false;
+    clickOpened.value = false;
+  }
+};
+
+watch(
+  () => props.showIntervalAlert,
+  (newVal) => {
+    showIntervalAlert.value = newVal;
+  }
+);
 </script>
 
 <style scoped>
 .highlight-container {
   background-color: var(--vscode-sideBar-background);
-  border: 1px solid var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border);
   display: flex;
   flex-direction: column;
-  min-height: v-bind(minEditorHeight);
   max-height: v-bind(maxEditorHeight);
 }
 
@@ -101,13 +214,14 @@ const editorHeight = computed(() => {
 .copy-button {
   color: var(--vscode-icon-foreground);
 }
+
 #sql-editor,
 .python-content {
   background-color: var(--vscode-sideBar-background);
 }
 
 .python-content {
-  white-space: pre-wrap; 
+  white-space: pre-wrap;
   color: var(--vscode-foreground);
 }
 
@@ -117,8 +231,8 @@ const editorHeight = computed(() => {
 }
 
 .line {
-  display: grid;
-  grid-template-columns: 60px 1fr;
+  display: flex;
+  align-items: flex-start;
 }
 #sql-editor {
   position: relative;
@@ -129,22 +243,25 @@ const editorHeight = computed(() => {
 }
 
 .line-number {
-  height: v-bind(lineHeight + 'px');
-  line-height: v-bind(lineHeight + 'px');
-  padding: 0 1rem;
+  height: v-bind(lineHeight + "px");
+  line-height: v-bind(lineHeight + "px");
+  padding: 0 10px;
   color: var(--vscode-disabledForeground);
   user-select: none;
   position: sticky;
   left: 0;
   text-align: right;
   white-space: nowrap;
+  width: v-bind(lineNumberWidth + "px");
+  flex-shrink: 0;
 }
 .line-content {
-  line-height: v-bind(lineHeight + 'px');
+  line-height: v-bind(lineHeight + "px");
   white-space: pre-wrap;
   word-break: break-word;
   overflow-wrap: anywhere;
   overflow-x: visible;
+  padding-right: 10px;
 }
 .header {
   color: var(--vscode-disabledForeground);
@@ -154,7 +271,7 @@ const editorHeight = computed(() => {
   color: var(--vscode-icon-foreground);
 }
 .python-content {
-  white-space: pre-wrap; 
+  white-space: pre-wrap;
   color: var(--vscode-foreground);
 }
 
@@ -182,8 +299,18 @@ const editorHeight = computed(() => {
 .scroller {
   height: 100%;
   width: 100%;
-  min-height: v-bind(minEditorHeight);
   white-space: pre-wrap;
 }
-</style>
 
+.regular-content {
+  height: 100%;
+  width: 100%;
+  overflow: visible;
+}
+
+.warning-message-box {
+  background-color: var(--vscode-input-background);
+  backdrop-filter: blur(8px);
+  font-family: var(--vscode-font-family);
+}
+</style>

--- a/webview-ui/src/components/asset/SqlEditor.vue
+++ b/webview-ui/src/components/asset/SqlEditor.vue
@@ -86,7 +86,6 @@ const showAlertMassage = ref(false);
 const copied = ref(false);
 const clickOpened = ref(false);
 
-// Directive to detect clicks outside an element
 const vClickOutside = {
   mounted(el, binding) {
     el.__ClickOutsideHandler__ = (event) => {
@@ -114,16 +113,14 @@ const editorPadding = 12;
 const minEditorHeight = `${lineHeight * 2}px`;
 const maxEditorHeight = "500px";
 
-// Calculate line number width based on total lines
 const lineNumberWidth = computed(() => {
   const totalLines = visibleHighlightedLines.value.length;
   const digits = totalLines.toString().length;
   return 20 + (digits * 8);
 });
 
-// Only use virtual scroller for large content to avoid unnecessary scrolling
 const shouldUseVirtualScroller = computed(() => {
-  return visibleHighlightedLines.value.length > 50; // Use virtual scroller only for 50+ lines
+  return visibleHighlightedLines.value.length > 50;
 });
 
 const highlightedLines = computed(() => {
@@ -134,7 +131,6 @@ const highlightedLines = computed(() => {
 
 const visibleHighlightedLines = computed(() => {
   const lines = highlightedLines.value;
-  // If no lines, provide one empty line for consistent height
   if (lines.length === 0) {
     return [{ lineNumber: 1, content: "<span></span>" }];
   }
@@ -148,23 +144,17 @@ const editorHeight = computed(() => {
   const lineCount = visibleHighlightedLines.value.length;
   const calculatedHeight = lineCount * lineHeight + editorPadding;
 
-  // If there's no code or only empty lines, use minEditorHeight
   if (!props.code || lineCount === 0) {
     return minEditorHeight;
   }
-
-  // For any number of lines, ensure proper height calculation including padding
-  // Use minEditorHeight as minimum, maxEditorHeight as maximum
   return `${Math.min(Math.max(calculatedHeight, parseInt(minEditorHeight)), parseInt(maxEditorHeight))}px`;
 });
 
 const toggleWarningMessage = () => {
   if (clickOpened.value) {
-    // If already opened by click, close it
     showAlertMassage.value = false;
     clickOpened.value = false;
   } else {
-    // Open it and mark as click-opened
     showAlertMassage.value = true;
     clickOpened.value = true;
   }
@@ -250,7 +240,6 @@ watch(
   user-select: none;
   position: sticky;
   left: 0;
-  text-align: right;
   white-space: nowrap;
   width: v-bind(lineNumberWidth + "px");
   flex-shrink: 0;
@@ -262,6 +251,7 @@ watch(
   overflow-wrap: anywhere;
   overflow-x: visible;
   padding-right: 10px;
+  flex-grow: 1;
 }
 .header {
   color: var(--vscode-disabledForeground);

--- a/webview-ui/src/components/ui/date-inputs/DateInput.vue
+++ b/webview-ui/src/components/ui/date-inputs/DateInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col w-full xs:min-w-32">
-    <label class="text-xs mb-1 font-medium whitespace-nowrap">
+    <label class="text-xs text-editor-fg mb-1 font-medium whitespace-nowrap">
       {{ label }}
       <span class="text-3xs italic font-mono opacity-65 text-editor-fg">(UTC)</span>
     </label>

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -26,10 +26,12 @@ export const concatCommandFlags = (
   const endDateFlag = isExclusiveChecked(checkboxItems) ? ` --end-date ${endDateExclusive}` : ` --end-date ${endDate}`;
 
   const checkboxesFlags = checkboxItems
-    .filter((item) => item.checked && item.name !== "Exclusive-End-Date")
+    .filter((item) => item.checked && item.name !== "Exclusive-End-Date" && item.name !== "Interval-modifiers")
     .map((item) => ` --${item.name.toLowerCase()}`);
-
-  return [startDateFlag, endDateFlag, ...checkboxesFlags].join("");
+  const intervalModifiersFlags = checkboxItems
+    .filter((item) => item.checked && item.name === "Interval-modifiers")
+    .map((item) => ` --apply-${item.name.toLowerCase()}`);
+  return [startDateFlag, endDateFlag, ...checkboxesFlags, ...intervalModifiersFlags].join("");
 };
 
 export const handleError = (validationError: any | null, renderSQLAssetError: any | null) => {

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -105,6 +105,7 @@ export const parseAssetDetails = (data: string) => {
     owner: asset.owner || undefined,
     pipeline,
     materialization: asset.materialization || undefined,
+    interval_modifiers: asset.interval_modifiers || undefined,
     tags: asset.tags || undefined,
     columns: asset.columns ? transformColumnData(asset.columns) : [],
     custom_checks: asset.custom_checks || [],

--- a/webview-ui/tailwind.config.js
+++ b/webview-ui/tailwind.config.js
@@ -90,6 +90,7 @@ module.exports = {
         "editorError-foreground": "var(--vscode-editorError-foreground)",
         "input-background": "var(--vscode-input-background)",
         "input-foreground": "var(--vscode-input-foreground)",
+        "input-border": "var(--vscode-input-border)",
         "inputOption-activeBorder": "var(--vscode-inputOption-activeBorder)",
         "inputOption-hoverBackground": "var(--vscode-inputOption-hoverBackground)",
         "inputOption-activeBackground": "var(--vscode-inputOption-activeBackground)",
@@ -118,6 +119,7 @@ module.exports = {
         "notification-bg": "var(--vscode-notification-background)",
         "notification-fg": "var(--vscode-notification-foreground)",
         "notificationsInfoIcon-fg": "var(--vscode-notificationsInfoIcon-foreground)",
+        "notificationsWarningIcon-fg": "var(--vscode-notificationsWarningIcon-foreground)",
 
         "primary": {
           DEFAULT: "hsl(var(--primary))",

--- a/webview-ui/tailwind.config.js
+++ b/webview-ui/tailwind.config.js
@@ -117,6 +117,7 @@ module.exports = {
         "keybindingLabel-bottom-border": "var(--vscode-keybindingLabel-bottomBorder)",
         "notification-bg": "var(--vscode-notification-background)",
         "notification-fg": "var(--vscode-notification-foreground)",
+        "notificationsInfoIcon-fg": "var(--vscode-notificationsInfoIcon-foreground)",
 
         "primary": {
           DEFAULT: "hsl(var(--primary))",


### PR DESCRIPTION
# PR Overview 
This PR introduces support for applying the `--apply-interval-modifiers` flag when running a Bruin asset via the run-cmd.

### Changes:

* Introduced a checkbox to toggle the `--apply-interval-modifiers` flag.
* Display a warning icon in the preview header if the asset includes interval modifiers but the checkbox is not selected. Hovering or clicking the icon shows a message explaining that the modifiers won’t be applied unless explicitly enabled.
* Cleaned up preview UI: removed extra padding, adjusted fonts, fixed container height, and resolved layout shifts caused by line numbers.
* Renamed tabs in the side panel for improved clarity.

![interval-modifiers-flag-and-disclaimer](https://github.com/user-attachments/assets/bbd94da4-ad74-4643-af2d-c0b728a086fb)
