### PR TITLE
Release/v0.50.3 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [0.50.3] - [2025-06-12]
+- Fix vscode publishing issue.
+
 ## [0.50.2] - [2025-06-12]
 - Fix DateInput component to handle focus correctly and adjust SQL editor height.
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Bruin is a unified analytics platform that enables data professionals to work en
 **Note**: Ensure that you have the Bruin CLI installed on your system before using the new features. For guidance on installing the Bruin CLI, please refer to the [official documentation](https://github.com/bruin-data/bruin).
 
 ## Release Notes
-### Latest Release: 0.50.2
-- Fix DateInput component to handle focus correctly and adjust SQL editor height.
+### Latest Release: 0.50.3
+- Fix vscode publishing issue.
 
 ### Recent Updates
+- **0.50.2**: Fix DateInput component to handle focus correctly and adjust SQL editor height.
 - **0.50.1**: Fix auto format on initial interval modifiers rendering.
 - **0.50.0**: Implement UI for adding and editing interval modifiers directly from the panel.
 - **0.49.3**: Remove redundant update columns to fix toggle primary key issue.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.50.2",
+      "version": "0.50.3",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "engines": {
     "vscode": "^1.87.0"
   },


### PR DESCRIPTION
# PR Overview

Bump the version and republish due to a failed attempt to publish `v0.50.2` to the VS Code Marketplace.

