### PR TITLE
Improve Tab Rendering and Message Handling

### DIFF
--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -101,7 +101,7 @@
           :id="`view-${index}`"
           class="px-0"
         >
-          <template v-if="activeTab === index">
+          <keep-alive>
             <component
               v-if="tab.props"
               :is="tab.component"
@@ -110,7 +110,7 @@
               @open-glossary="navigateToGlossary"
               @update:description="updateDescription"
             />
-          </template>
+          </keep-alive>
         </vscode-panel-view>
       </vscode-panels>
     </div>

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -99,20 +99,21 @@
           v-for="(tab, index) in visibleTabs"
           :key="`view-${index}`"
           :id="`view-${index}`"
-          v-show="activeTab === index"
           class="px-0"
         >
-          <component
-            v-if="tab.props"
-            :is="tab.component"
-            v-bind="tab.props"
-            class="flex w-full h-full"
-            @update:assetName="updateAssetName"
-            @update:customChecks="updateCustomChecks"
-            @open-glossary="navigateToGlossary"
-            @update:description="updateDescription"
-            @update:materialization="updateMaterialization"
-          />
+          <template v-if="activeTab === index">
+            <component
+              v-if="tab.props"
+              :is="tab.component"
+              v-bind="tab.props"
+              class="flex w-full h-full"
+              @update:assetName="updateAssetName"
+              @update:customChecks="updateCustomChecks"
+              @open-glossary="navigateToGlossary"
+              @update:description="updateDescription"
+              @update:materialization="updateMaterialization"
+            />
+          </template>
         </vscode-panel-view>
       </vscode-panels>
     </div>

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -107,7 +107,6 @@
               :is="tab.component"
               v-bind="tab.props"
               class="flex w-full h-full"
-              @open-glossary="navigateToGlossary"
               @update:description="updateDescription"
             />
           </keep-alive>
@@ -266,10 +265,6 @@ const nonAssetFileType = ref("");
 const nonAssetFilePath = ref("");
 const activeTab = ref(0); // Tracks the currently active tab
 
-const navigateToGlossary = () => {
-  console.log("Opening glossary.");
-  vscode.postMessage({ command: "bruin.openGlossary" });
-};
 // Computed property to parse the list of environments
 const environmentsList = computed(() => {
   if (!environments.value) return [];
@@ -558,10 +553,9 @@ const updateAssetName = (newName) => {
   }
   tabs.value.forEach((tab) => {
     if (tab && tab.props && "name" in tab.props) {
-      tab.props.name = newName; // Update the name in the tab props
+      tab.props.name = newName; 
     }
   });
-  vscode.postMessage({ command: "bruin.updateAssetName", name: newName });
 };
 const assetType = computed(() => {
   if (isPipelineConfig.value) return "pipeline";

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -107,11 +107,8 @@
               :is="tab.component"
               v-bind="tab.props"
               class="flex w-full h-full"
-              @update:assetName="updateAssetName"
-              @update:customChecks="updateCustomChecks"
               @open-glossary="navigateToGlossary"
               @update:description="updateDescription"
-              @update:materialization="updateMaterialization"
             />
           </template>
         </vscode-panel-view>
@@ -526,15 +523,6 @@ watch(activeTab, (newTab, oldTab) => {
     assetName: assetDetailsProps.value?.name,
   });
 });
-
-const updateMaterialization = (newMaterialization) => {
-  console.log("Updating materialization with new data:", newMaterialization);
-  materialization.value = newMaterialization;
-};
-const updateCustomChecks = (newCustomChecks) => {
-  console.log("Updating custom checks with new data:", newCustomChecks);
-  customChecks.value = newCustomChecks;
-};
 
 const updateDescription = (newDescription) => {
   console.log("Updating description with new data:", newDescription);

--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -142,7 +142,6 @@ onBeforeUnmount(() => {
 
 onMounted(async () => {
   window.addEventListener("message", handleMessage);
-  vscode.postMessage({ command: "bruin.getConnectionsList" });
   await updateContentHeight();
 
   if (descriptionRef.value) {

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -219,9 +219,6 @@
   </div>
 </template>
 <script setup lang="ts">
-/**
- * Import necessary dependencies
- */
 import { vscode } from "@/utilities/vscode";
 import { computed, onBeforeUnmount, onMounted, ref, defineProps, watch } from "vue";
 import ErrorAlert from "@/components/ui/alerts/ErrorAlert.vue";

--- a/webview-ui/src/components/asset/columns/custom-checks/CustomChecks.vue
+++ b/webview-ui/src/components/asset/columns/custom-checks/CustomChecks.vue
@@ -21,7 +21,6 @@
           :key="index"
           class="border-b border-commandCenter-border"
         >
-          <!-- Check Name with improved handling -->
           <td class="px-2 py-1 font-medium font-mono text-xs w-1/4">
             <div v-if="editingIndex === index" class="flex flex-col gap-1">
               <textarea
@@ -162,10 +161,9 @@ const props = defineProps<{
 const localCustomChecks = ref<CustomChecks[]>([]);
 const editingIndex = ref<number | null>(null);
 const editingCustomCheck = ref<CustomChecks | null>(null);
-const emit = defineEmits(["update:customChecks"]);
+
 const showDeleteAlert = ref<number | null>(null);
 const addCustomCheck = () => {
-  // Add custom check logic here
   try {
     const newCustomCheck = {
       id: uuidv4(),
@@ -175,7 +173,6 @@ const addCustomCheck = () => {
       query: "",
     };
 
-    // Add new custom check to local custom checks
     localCustomChecks.value.push(newCustomCheck);
     editingIndex.value = localCustomChecks.value.length - 1;
     editingCustomCheck.value = JSON.parse(JSON.stringify(newCustomCheck)) as CustomChecks;
@@ -198,7 +195,6 @@ const resetEditing = () => {
 
 const deleteCustomCheck = (index: number) => {
   try {
-    // Remove the custom check from local custom checks
     localCustomChecks.value.splice(index, 1);
     showDeleteAlert.value = null;
     saveCustomChecks();
@@ -220,14 +216,12 @@ const saveCustomChecks = () => {
       localCustomChecks.value[editingIndex.value] = updatedCheck;
     }
 
-    // Reset editing state
     editingIndex.value = null;
     editingCustomCheck.value = null;
 
-    // Post-process and emit checks
     const formattedCustomChecks = localCustomChecks.value.map((check) => ({
       ...check,
-      value: Number(check.value) || 0, // Ensure value is numeric
+      value: Number(check.value) || 0, 
     }));
 
     vscode.postMessage({
@@ -236,23 +230,20 @@ const saveCustomChecks = () => {
       source: "saveCustomChecks",
     });
 
-    emit("update:customChecks", formattedCustomChecks);
   } catch (error) {
     console.error("Error saving custom checks:", error);
   }
 };
 const highlightedLines = (query) => {
-  if (!query) return []; // Return an empty array if no query is provided
+  if (!query) return []; 
   const highlighted = hljs.highlight(query, { language: "sql" }).value;
 
-  // Split the highlighted output into lines
   let lines = highlighted.split("\n");
   if (lines[lines.length - 1] === "") {
-    lines.pop(); // Remove the last empty line if it exists
+    lines.pop();
   }
 
-  // Return each line wrapped in a <div> for proper formatting
-  return lines.map((line) => `<div>${line}</div>`).join(""); // Join lines with <div> for line breaks
+  return lines.map((line) => `<div>${line}</div>`).join(""); 
 };
 
 watch(
@@ -271,7 +262,7 @@ watch(
 
 <style scoped>
 table thead tr.border-opacity-test {
-  border: 0.7 !important; /* Adjust the opacity value as needed */
+  border: 0.7 !important; 
 }
 
 vscode-button::part(control) {

--- a/webview-ui/src/components/asset/materialization/Materialization.vue
+++ b/webview-ui/src/components/asset/materialization/Materialization.vue
@@ -735,8 +735,6 @@ const saveMaterialization = () => {
     payload: payload,
     source: "Materialization_saveMaterialization",
   });
-
-  emit("update:materialization", cleanData);
 };
 
 function getStrategyDescription(strategy) {

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -122,9 +122,6 @@ const handleConnectionDeleted = async (payload) => {
     connectionsStore.removeConnection(connectionToDelete.value.id);
     showDeleteAlert.value = false;
     connectionToDelete.value = null;
-
-    // Fetch updated connections list from the backend
-    await vscode.postMessage({ command: "bruin.getConnectionsList" });
   } else {
     console.error("Failed to delete connection:", payload.message);
   }


### PR DESCRIPTION
# PR Overview
This PR improves how tabs are rendered in the extension by replacing `v-show` with `v-if`, which prevents unnecessary rendering of inactive tabs. It also includes clean-up of unused emits and message calls, and adds `<keep-alive>` to maintain state.

### Changes
* Replaced `v-show` with `v-if` for tab rendering.
* Wrapped tabs in `<keep-alive>` for state retention.
* Removed unused event emits and message listeners.
* Refactored components to manage `postMessage` calls more efficiently.
