### PR TITLE
Update supported asset types list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## [0.50.8] - [2025-06-17]
+- Added support for additional seed asset types in snippets, schema and UI.
 ## [0.50.7] - [2025-06-17]
 - Added utility to format bruin run commands in a readable multi-line format.
 

--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -37,7 +37,15 @@
             "duckdb.seed",
             "emr_serverless.spark",
             "emr_serverless.pyspark",
-            "bq.seed"
+            "athena.seed",
+            "bq.seed",
+            "clickhouse.seed",
+            "databricks.seed",
+            "ms.seed",
+            "pg.seed",
+            "rs.seed",
+            "sf.seed",
+            "synapse.seed"
           ],
           "description": "The type of the asset"
         },

--- a/snippets/bruin-asset.code-snippets
+++ b/snippets/bruin-asset.code-snippets
@@ -9,7 +9,7 @@
   "Bruin Asset Type": {
     "prefix": "!type",
     "body": [
-      "type: ${1|python,sf.sql,sf.sensor.query,bq.sql,bq.sensor.table,bq.sensor.query,empty,pg.sql,rs.sql,ms.sql,synapse.sql,ingestr|}"
+      "type: ${1|python,sf.sql,sf.sensor.query,bq.sql,bq.sensor.table,bq.sensor.query,empty,pg.sql,rs.sql,ms.sql,synapse.sql,ingestr,athena.seed,bq.seed,clickhouse.seed,databricks.seed,duckdb.seed,ms.seed,pg.seed,rs.seed,sf.seed,synapse.seed,emr_serverless.spark,emr_serverless.pyspark|}"
     ],
     "description": "Insert the asset type"
   },
@@ -272,7 +272,7 @@
     "body": [
       "/* @bruin",
       "name: ${1:asset_name}",
-      "type: ${2|bq.sql,sf.sql,sf.sensor.query,bq.sensor.table,bq.sensor.query,empty,pg.sql,rs.sql,ms.sql,synapse.sql,ingestr|}",
+      "type: ${2|bq.sql,sf.sql,sf.sensor.query,bq.sensor.table,bq.sensor.query,empty,pg.sql,rs.sql,ms.sql,synapse.sql,ingestr,athena.seed,bq.seed,clickhouse.seed,databricks.seed,duckdb.seed,ms.seed,pg.seed,rs.seed,sf.seed,synapse.seed,emr_serverless.spark,emr_serverless.pyspark|}"
       "",
       "depends: ",
       "  - ${3:dependency1}",

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodeStyles.ts
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodeStyles.ts
@@ -37,6 +37,54 @@ export const styles = {
         main: 'bg-amber-300 text-amber-800',
         label: "bg-amber-500 text-amber-100",
     },
+    'duckdb.seed': {
+        main: 'bg-rose-300 text-rose-800',
+        label: "bg-rose-500 text-rose-100",
+    },
+    'emr_serverless.spark': {
+        main: 'bg-lime-300 text-lime-800',
+        label: "bg-lime-500 text-lime-100",
+    },
+    'emr_serverless.pyspark': {
+        main: 'bg-lime-300 text-lime-800',
+        label: "bg-lime-500 text-lime-100",
+    },
+    'bq.seed': {
+        main: 'bg-blue-300 text-blue-800',
+        label: "bg-blue-500 text-blue-100",
+    },
+    'athena.seed': {
+        main: 'bg-teal-300 text-teal-800',
+        label: "bg-teal-500 text-teal-100",
+    },
+    'clickhouse.seed': {
+        main: 'bg-pink-300 text-pink-800',
+        label: "bg-pink-500 text-pink-100",
+    },
+    'databricks.seed': {
+        main: 'bg-red-300 text-red-800',
+        label: "bg-red-500 text-red-100",
+    },
+    'ms.seed': {
+        main: 'bg-violet-300 text-violet-800',
+        label: "bg-violet-500 text-violet-100",
+    },
+    'pg.seed': {
+        main: 'bg-cyan-300 text-cyan-800',
+        label: "bg-cyan-500 text-cyan-100",
+    },
+    'rs.seed': {
+        main: 'bg-fuchsia-300 text-fuchsia-800',
+        label: "bg-fuchsia-500 text-fuchsia-100",
+    },
+    'sf.seed': {
+        main: 'bg-orange-300 text-orange-800',
+        label: "bg-orange-500 text-orange-100",
+    },
+    'synapse.seed': {
+        main: 'bg-purple-300 text-purple-800',
+        label: "bg-purple-500 text-purple-100",
+    },
     "python": {
         main: "bg-green-300 text-green-800",
         label: "bg-green-500 text-white",

--- a/webview-ui/src/components/ui/badges/CustomBadgesStyle.ts
+++ b/webview-ui/src/components/ui/badges/CustomBadgesStyle.ts
@@ -25,6 +25,42 @@ export const badgeStyles = {
     'ingestr': {
         main: 'bg-amber-400/10 text-amber-400 ring-amber-400/30',
     },
+    'duckdb.seed': {
+        main: 'bg-rose-400/10 text-rose-400 ring-rose-400/30',
+    },
+    'emr_serverless.spark': {
+        main: 'bg-lime-400/10 text-lime-400 ring-lime-400/30',
+    },
+    'emr_serverless.pyspark': {
+        main: 'bg-lime-400/10 text-lime-400 ring-lime-400/30',
+    },
+    'bq.seed': {
+        main: 'bg-blue-400/10 text-blue-400 ring-blue-400/30',
+    },
+    'athena.seed': {
+        main: 'bg-teal-400/10 text-teal-400 ring-teal-400/30',
+    },
+    'clickhouse.seed': {
+        main: 'bg-pink-400/10 text-pink-400 ring-pink-400/30',
+    },
+    'databricks.seed': {
+        main: 'bg-red-400/10 text-red-400 ring-red-400/30',
+    },
+    'ms.seed': {
+        main: 'bg-violet-400/10 text-violet-400 ring-violet-400/30',
+    },
+    'pg.seed': {
+        main: 'bg-cyan-400/10 text-cyan-400 ring-cyan-400/30',
+    },
+    'rs.seed': {
+        main: 'bg-fuchsia-400/10 text-fuchsia-400 ring-fuchsia-400/30',
+    },
+    'sf.seed': {
+        main: 'bg-orange-400/10 text-orange-400 ring-orange-400/30',
+    },
+    'synapse.seed': {
+        main: 'bg-purple-400/10 text-purple-400 ring-purple-400/30',
+    },
     "python": {
         main: "bg-green-400/10 text-green-400 ring-green-400/30",
     },


### PR DESCRIPTION
## Summary
- update snippet completion for asset types
- add missing asset badges for seed types
- style custom node types for the new seed assets
- expand yaml schema enum for additional seed types

## Testing
- `npm test` *(fails: Cannot find name 'it')*

------
https://chatgpt.com/codex/tasks/task_e_68518dbbd7848322b8ff136fc8879eb8