### PR TITLE
Update S3 connection fields

### DIFF
--- a/webview-ui/src/components/connections/connectionUtility.ts
+++ b/webview-ui/src/components/connections/connectionUtility.ts
@@ -17,13 +17,24 @@ export const generateConnectionConfig = (schema: any) => {
     const connectionDef = schema.$defs[connectionDefKey];
     if (connectionDef) {
       connectionConfig[type] = Object.keys(connectionDef.properties)
-        .filter((prop) => prop !== "name" && prop !== "service_account_file") // Exclude the 'name' field
+        .filter((prop) =>
+          prop !== "name" &&
+          prop !== "service_account_file" &&
+          // Remove deprecated S3 fields
+          prop !== "bucket_name" &&
+          prop !== "path_to_file"
+        )
         .map((prop) => {
           const propDef = connectionDef.properties[prop];
           let inputType = "text";
           let rows: number | undefined = undefined;
           let cols: number | undefined = undefined;
           let required = connectionDef.required.includes(prop);
+
+          // Endpoint URL and Layout are optional for S3 connections
+          if (prop === "endpoint_url" || prop === "layout") {
+            required = false;
+          }
           
           if (prop === "players" && type === "chess") {
             inputType = "csv";


### PR DESCRIPTION
## Summary
- update connection config generator to make `endpoint_url` and `layout` optional for S3
- drop deprecated fields `bucket_name` and `path_to_file`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run compile` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6853f3641f088322932defe828f50dbe