### PR TITLE
Add validate exclude tag setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,11 @@
           "type": "boolean",
           "default": false,
           "description": "Sets whether the 'Push-Metadata' checkbox is checked by default."
+        },
+        "bruin.validate.excludeTag": {
+          "type": "string",
+          "default": "",
+          "description": "Default tag to exclude when validating assets."
         }
       }
     },

--- a/src/bruin/bruinValidate.ts
+++ b/src/bruin/bruinValidate.ts
@@ -2,6 +2,7 @@ import { BruinCommand } from "./bruinCommand";
 import { BruinPanel } from "../panels/BruinPanel";
 import { BruinCommandOptions } from "../types";
 import { platform } from "os";
+import { getValidateExcludeTag } from "../extension/configuration";
 /**
  * Extends the BruinCommand class to implement the bruin validate command on Bruin assets.
  */
@@ -29,6 +30,11 @@ export class BruinValidate extends BruinCommand {
     filePath: string,
     { flags = ["-o", "json"], ignoresErrors = false }: BruinCommandOptions = {}
   ): Promise<void> {
+    const excludeTag = getValidateExcludeTag();
+    let commandFlags = [...flags];
+    if (excludeTag && excludeTag.trim() !== "") {
+      commandFlags = commandFlags.concat(["--exclude-tag", excludeTag]);
+    }
     this.isLoading = true;
     BruinPanel.postMessage("validation-message", {
       status: "loading",
@@ -36,7 +42,7 @@ export class BruinValidate extends BruinCommand {
     });
 
     try {
-      const result = await this.run([...flags, filePath], { ignoresErrors });
+      const result = await this.run([...commandFlags, filePath], { ignoresErrors });
       let validationResults = JSON.parse(result);
 
       if (!Array.isArray(validationResults) && platform() === "win32") {

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -19,6 +19,11 @@ export function getPathSeparator(): string {
   return pathSeparator;
 }
 
+export function getValidateExcludeTag(): string {
+  const validateConfig = vscode.workspace.getConfiguration("bruin.validate");
+  return validateConfig.get<string>("excludeTag", "");
+}
+
 let documentInitState = new Map();
 
 export async function toggleFoldingsCommand(toggled: boolean): Promise<void> {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -789,6 +789,18 @@ suite("BruinValidate Tests", () => {
     sinon.assert.calledOnceWithExactly(runStub, [...flags, filePath], { ignoresErrors: false });
   });
 
+  test("validate should include exclude-tag flag from settings", async () => {
+    const filePath = "path/to/asset";
+    const flags = ["-o", "json"];
+    const tagStub = sinon.stub(configuration, "getValidateExcludeTag").returns("python");
+    runStub.resolves("{}");
+
+    await bruinValidate.validate(filePath, { flags });
+
+    sinon.assert.calledOnceWithExactly(runStub, [...flags, "--exclude-tag", "python", filePath], { ignoresErrors: false });
+    tagStub.restore();
+  });
+
   test("validate should handle error when running validation command on Mac and Linux", async () => {
     const filePath = "path/to/asset";
     const error = new Error("Validation command failed");
@@ -4979,6 +4991,45 @@ suite(" Query export Tests", () => {
         const result = getPathSeparator();
 
         assert.strictEqual(result, "/");
+      });
+    });
+
+    suite("getValidateExcludeTag", () => {
+      test("should return configured exclude tag", () => {
+        const mockConfig = {
+          get: sinon.stub().withArgs("excludeTag").returns("python")
+        };
+        workspaceGetConfigurationStub.withArgs("bruin.validate").returns(mockConfig);
+
+        const { getValidateExcludeTag } = require("../extension/configuration");
+        const result = getValidateExcludeTag();
+
+        assert.strictEqual(result, "python");
+        sinon.assert.calledWith(workspaceGetConfigurationStub, "bruin.validate");
+      });
+
+      test("should return empty string when not configured", () => {
+        const mockConfig = {
+          get: sinon.stub().withArgs("excludeTag").returns(undefined)
+        };
+        workspaceGetConfigurationStub.withArgs("bruin.validate").returns(mockConfig);
+
+        const { getValidateExcludeTag } = require("../extension/configuration");
+        const result = getValidateExcludeTag();
+
+        assert.strictEqual(result, "");
+      });
+
+      test("should return empty string when configuration returns null", () => {
+        const mockConfig = {
+          get: sinon.stub().withArgs("excludeTag").returns(null)
+        };
+        workspaceGetConfigurationStub.withArgs("bruin.validate").returns(mockConfig);
+
+        const { getValidateExcludeTag } = require("../extension/configuration");
+        const result = getValidateExcludeTag();
+
+        assert.strictEqual(result, "");
       });
     });
 


### PR DESCRIPTION
## Summary
- add `bruin.validate.excludeTag` setting
- implement getter for the new setting
- pass exclude tag to `bruin validate` command
- test default exclude tag functionality

## Testing
- `npm test` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6855692d7954832082729a1ee85de334