### PR TITLE
Add Confirmation Prompt for Full Refresh Execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.51.5] - [2025-06-23]
+- Added confirmation prompt before running with `full-refresh`.
+
 ## [0.51.4] - [2025-06-23]
 - Fixed customCheck not showing on first render, added missing sensor types to the YAML schema, and expanded snippet completions.
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,12 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 **Note**: Ensure that you have the Bruin CLI installed on your system before using the new features. For guidance on installing the Bruin CLI, please refer to the [official documentation](https://github.com/bruin-data/bruin).
 
-
-
 ## Release Notes
-### Latest Release: 0.51.4
-- Fixed customCheck not showing on first render, added missing sensor types to the YAML schema, and expanded snippet completions.
+### Latest Release: 0.51.5
+- Added confirmation prompt before running with `full-refresh`.
 
 ### Recent Updates
+- **0.51.4**: Fixed customCheck not showing on first render, added missing sensor types to the YAML schema, and expanded snippet completions.
 - **0.51.3**: Enhanced Snowflake connection support with private key authentication, including validation and improved input handling.
 - **0.51.2**: Enabled auto-saving for materialization changes, removing the manual save button.
 - **0.51.1**: Fixed BQ connection updates and improved service account credential handling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.51.4",
+  "version": "0.51.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.51.4",
+      "version": "0.51.5",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.51.4",
+  "version": "0.51.5",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -557,6 +557,15 @@ function buildCommandPayload(
  * Functions to handle run and validate actions
  */
 function runAssetOnly() {
+  const fullRefreshChecked = checkboxItems.value.find(item => item.name === "Full-Refresh")?.checked;
+  
+  if (fullRefreshChecked) {
+    const confirmed = confirm("Do you want to run with full refresh? This will refresh all data.");
+    if (!confirmed) {
+      return;
+    }
+  }
+  
   const payload = buildCommandPayload(getCheckboxChangePayload());
 
   vscode.postMessage({
@@ -566,6 +575,15 @@ function runAssetOnly() {
 }
 
 function runAssetWithDownstream() {
+  const fullRefreshChecked = checkboxItems.value.find(item => item.name === "Full-Refresh")?.checked;
+  
+  if (fullRefreshChecked) {
+    const confirmed = confirm("Do you want to run with full refresh? This will refresh all data.");
+    if (!confirmed) {
+      return;
+    }
+  }
+  
   const payload = buildCommandPayload(getCheckboxChangePayload(), { downstream: true });
 
   vscode.postMessage({
@@ -575,6 +593,15 @@ function runAssetWithDownstream() {
 }
 
 function runPipelineWithContinue() {
+  const fullRefreshChecked = checkboxItems.value.find(item => item.name === "Full-Refresh")?.checked;
+  
+  if (fullRefreshChecked) {
+    const confirmed = confirm("Do you want to run with full refresh? This will refresh all data.");
+    if (!confirmed) {
+      return;
+    }
+  }
+  
   const payload = buildCommandPayload(getCheckboxChangePayload(), { continue: true });
 
   vscode.postMessage({
@@ -584,6 +611,15 @@ function runPipelineWithContinue() {
 }
 
 function runCurrentPipeline() {
+  const fullRefreshChecked = checkboxItems.value.find(item => item.name === "Full-Refresh")?.checked;
+  
+  if (fullRefreshChecked) {
+    const confirmed = confirm("Do you want to run with full refresh? This will refresh all data.");
+    if (!confirmed) {
+      return;
+    }
+  }
+  
   const payload = buildCommandPayload(getCheckboxChangePayload(), { downstream: false });
 
   vscode.postMessage({

--- a/webview-ui/src/components/asset/columns/AssetColumns.vue
+++ b/webview-ui/src/components/asset/columns/AssetColumns.vue
@@ -232,9 +232,10 @@
             </vscode-button>
             <DeleteAlert
               v-if="showDeleteAlert === index"
-              :elementName="column.name"
-              elementType="column"
+              title="Delete Column"
+              :message="`Are you sure you want to delete the column ${column.name}? This action cannot be undone.`"
               @confirm="deleteColumn(index)"
+              confirm-text="Delete"
               @cancel="showDeleteAlert = false"
               class="absolute z-50"
             />

--- a/webview-ui/src/components/asset/columns/custom-checks/CustomChecks.vue
+++ b/webview-ui/src/components/asset/columns/custom-checks/CustomChecks.vue
@@ -127,9 +127,10 @@
           <div>
             <DeleteAlert
               v-if="showDeleteAlert === index"
-              :elementName="check.name"
-              elementType="custom check"
+              title="Delete Custom Check"
+              :message="`Are you sure you want to delete the custom check ${check.name}? This action cannot be undone.`"
               @confirm="deleteCustomCheck(index)"
+              confirm-text="Delete"
               @cancel="showDeleteAlert = null"
               class="absolute z-50"
             />

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -30,8 +30,9 @@
 
     <DeleteAlert
       v-if="showDeleteAlert"
-      :elementName="connectionToDelete?.name"
-      elementType="connection"
+      title="Delete Connection"
+      :message="`Are you sure you want to delete the connection ${connectionToDelete?.name}? This action cannot be undone.`"
+      confirm-text="Delete"
       @confirm="deleteConnection"
       @cancel="cancelDeleteConnection"
     />
@@ -276,6 +277,7 @@ const deleteConnection = async () => {
         id: connectionToDelete.value.id,
       },
     });
+    showDeleteAlert.value = false;
   } catch (error) {
     console.error("Error deleting connection:", error);
   }

--- a/webview-ui/src/components/ui/alerts/AlertWithActions.vue
+++ b/webview-ui/src/components/ui/alerts/AlertWithActions.vue
@@ -1,10 +1,9 @@
 <template>
   <div class="fixed inset-0 flex items-center justify-center bg-editor-bg bg-opacity-75">
     <div class="bg-editorWidget-bg rounded-lg p-6">
-      <h3 class="text-lg font-medium text-editor-fg">Delete {{ elementType }}</h3>
+      <h3 v-if="title" class="text-lg font-medium text-editor-fg">{{ title }}</h3>
       <p class="mt-2 text-sm text-descriptionFg">
-        Are you sure you want to delete the {{ elementType }} "{{ elementName }}"? This action cannot be
-        undone.
+          {{ message }}
       </p>
       <div class="mt-4 flex justify-end">
         <button
@@ -18,7 +17,7 @@
           @click="$emit('confirm')"
           class="bg-errorForeground hover:bg-editorError-foreground hover:text-editor-fg px-4 py-1 rounded text-editor-fg"
         >
-          Delete
+          {{ confirmText }}
         </button>
       </div>
     </div>
@@ -26,7 +25,8 @@
 </template>
 <script setup>
 defineProps({
-  elementName: String,
-  elementType: String,
+  confirmText: String,
+  message: String,
+  title: String,  
 });
 </script>


### PR DESCRIPTION
# PR Overview 
This PR introduces a confirmation dialog before performing a full refresh. This helps prevent accidental `run`.

### Changes:
* Added a confirmation prompt when triggering a full refresh from the `General` tab.
* Updated `DeleteAlert` components to support custom titles and messages.
* Applied the updated `DeleteAlert` to `AssetColumns`, `CustomChecks`, and `BruinSettings`.

