### PR TITLE
Add default flag setting to extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
         "bruin.validate.defaultExcludeTag": {
           "type": "string",
           "default": "",
-          "description": "Sets the default exclude tag to be used with validation commands."
+          "description": "Sets the validate exclude tag to be used with validation commands."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -158,6 +158,11 @@
           "type": "boolean",
           "default": false,
           "description": "Sets whether the 'Push-Metadata' checkbox is checked by default."
+        },
+        "bruin.defaultExcludeTag": {
+          "type": "string",
+          "default": "",
+          "description": "Sets the default exclude tag value."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -159,10 +159,10 @@
           "default": false,
           "description": "Sets whether the 'Push-Metadata' checkbox is checked by default."
         },
-        "bruin.defaultExcludeTag": {
+        "bruin.validate.defaultExcludeTag": {
           "type": "string",
           "default": "",
-          "description": "Sets the default exclude tag value."
+          "description": "Sets the default exclude tag to be used with validation commands."
         }
       }
     },

--- a/src/bruin/bruinValidate.ts
+++ b/src/bruin/bruinValidate.ts
@@ -23,11 +23,13 @@ export class BruinValidate extends BruinCommand {
    *
    * @param {string} filePath - The path of the asset to be validated.
    * @param {BruinCommandOptions} [options={}] - Optional parameters for validation, including flags and errors.
+   * @param {string} [excludeTag=""] - Optional exclude tag to use in validation.
    * @returns {Promise<void>} A promise that resolves when the validation is complete or an error is caught.
    */
   public async validate(
     filePath: string,
-    { flags = ["-o", "json"], ignoresErrors = false }: BruinCommandOptions = {}
+    { flags = ["-o", "json"], ignoresErrors = false }: BruinCommandOptions = {},
+    excludeTag: string = ""
   ): Promise<void> {
     this.isLoading = true;
     BruinPanel.postMessage("validation-message", {
@@ -36,7 +38,14 @@ export class BruinValidate extends BruinCommand {
     });
 
     try {
-      const result = await this.run([...flags, filePath], { ignoresErrors });
+      const commandFlags = [...flags];
+      
+      // Add exclude-tag if provided
+      if (excludeTag) {
+        commandFlags.push("--exclude-tag", excludeTag);
+      }
+      
+      const result = await this.run([...commandFlags, filePath], { ignoresErrors });
       let validationResults = JSON.parse(result);
 
       if (!Array.isArray(validationResults) && platform() === "win32") {

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -13,6 +13,11 @@ export function getDefaultCheckboxSettings() {
   };
 }
 
+export function getDefaultExcludeTag(): string {
+  const config = vscode.workspace.getConfiguration("bruin");
+  return config.get<string>("validate.defaultExcludeTag", "");
+}
+
 export function getPathSeparator(): string {
   const bruinConfig = vscode.workspace.getConfiguration("bruin");
   const pathSeparator = bruinConfig.get<string>("pathSeparator") || "/";

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -368,11 +368,8 @@ export class BruinPanel {
             );
             const validator = new BruinValidate(getBruinExecutablePath(), "");
             
-            // Get default exclude tag
-            const excludeTag = getDefaultExcludeTag();
-            // Pass the exclude tag to validate method
-            console.log("Using default exclude tag for validate:", excludeTag);
-            await validator.validate(filePath, {}, excludeTag);
+            
+            await validator.validate(filePath);
             break;
           case "bruin.runSql":
             if (!this._lastRenderedDocumentUri) {

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -35,8 +35,10 @@ import { QueryPreviewPanel } from "./QueryPreviewPanel";
 import { getBruinExecutablePath } from "../providers/BruinExecutableService";
 import path = require("path");
 import { isBruinAsset } from "../utilities/helperUtils";
-import { getDefaultCheckboxSettings } from "../extension/configuration";
-import { exec } from "child_process";import { flowLineageCommand } from "../extension/commands/FlowLineageCommand";
+
+import { getDefaultCheckboxSettings, getDefaultExcludeTag } from "../extension/configuration";
+import { exec } from "child_process";
+import { flowLineageCommand } from "../extension/commands/FlowLineageCommand";
 
 /**
  * This class manages the state and behavior of Bruin webview panels.
@@ -304,7 +306,10 @@ export class BruinPanel {
               workspaceFolder.uri.fsPath
             );
 
-            await validatorAll.validate(workspaceFolder.uri.fsPath);
+            // Get default exclude tag
+            const defaultExcludeTag = getDefaultExcludeTag();
+            console.log("Using default exclude tag for validateAll:", defaultExcludeTag);
+            await validatorAll.validate(workspaceFolder.uri.fsPath, {}, defaultExcludeTag);
             break;
           case "bruin.checkTelemtryPreference":
             const config = workspace.getConfiguration("bruin");
@@ -330,8 +335,11 @@ export class BruinPanel {
             const pipelineValidator = new BruinValidate(getBruinExecutablePath(), "");
 
             try {
-              // if the promess is rejected, the error will be catched and logged
-              await pipelineValidator.validate(currentPipelinePath);
+              // Get default exclude tag
+              const excludeTag = getDefaultExcludeTag();
+              // Pass the exclude tag to validate method
+              console.log("Using default exclude tag for validateCurrentPipeline:", excludeTag);
+              await pipelineValidator.validate(currentPipelinePath, {}, excludeTag);
             } catch (error) {
               console.error("Error validating pipeline:", currentPipelinePath, error);
             }
@@ -359,7 +367,12 @@ export class BruinPanel {
               getBruinExecutablePath()
             );
             const validator = new BruinValidate(getBruinExecutablePath(), "");
-            await validator.validate(filePath);
+            
+            // Get default exclude tag
+            const excludeTag = getDefaultExcludeTag();
+            // Pass the exclude tag to validate method
+            console.log("Using default exclude tag for validate:", excludeTag);
+            await validator.validate(filePath, {}, excludeTag);
             break;
           case "bruin.runSql":
             if (!this._lastRenderedDocumentUri) {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -863,6 +863,38 @@ suite("BruinValidate Tests", () => {
       "Loading state should be false after validation"
     );
   });
+
+  test("validate should call run with exclude-tag flag when excludeTag parameter is provided", async () => {
+    const filePath = "path/to/asset";
+    const excludeTag = "test-tag";
+    const flags = ["-o", "json"];
+    runStub.resolves("{}");
+
+    await bruinValidate.validate(filePath, { flags }, excludeTag);
+
+    // Verify that run is called with the correct arguments including --exclude-tag
+    sinon.assert.calledOnceWithExactly(
+      runStub, 
+      ["-o", "json", "--exclude-tag", excludeTag, filePath], 
+      { ignoresErrors: false }
+    );
+  });
+
+  test("validate should not include exclude-tag flag when excludeTag parameter is empty", async () => {
+    const filePath = "path/to/asset";
+    const excludeTag = "";
+    const flags = ["-o", "json"];
+    runStub.resolves("{}");
+
+    await bruinValidate.validate(filePath, { flags }, excludeTag);
+
+    // Verify that run is called without --exclude-tag when excludeTag is empty
+    sinon.assert.calledOnceWithExactly(
+      runStub, 
+      ["-o", "json", filePath], 
+      { ignoresErrors: false }
+    );
+  });
 });
 suite("patch asset testing", () => {
   let bruinInternalPatch: BruinInternalPatch;


### PR DESCRIPTION
- A default **Exclude Tag** text input was added to the extension settings section.
- The `validate` function was updated to support the **exclude tag** parameter.
- A test was implemented for the `validate` function with the **exclude tag** support.
![image](https://github.com/user-attachments/assets/52b58bd5-5b97-4068-a48b-229b5d89546c)
