### PR TITLE
Prevent BruinPanel from auto-rendering on activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.54.1] - [2025-07-01]
+- Fixed the Bruin Panel rendering issue.
+
 ## [0.54.0] - [2025-07-01]
 - Added human-readable cron preview via CodeLens in pipeline YAML files.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 ### Recent Update
+- **0.54.1**: Fixed the Bruin Panel rendering issue.
 - **0.54.0**: Added human-readable cron preview via CodeLens in pipeline YAML files.
 - **0.53.2**: Relocated fill from DB buttons to the asset columns and materialization tabs and improved query output rendering.
 - **0.53.1**: Added default `Exclude Tag` input to the extension settings to exclude assets with specific tags from being validated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.54.0",
+      "version": "0.54.1",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -332,6 +332,5 @@ export async function activate(context: ExtensionContext) {
   console.debug(`Bruin activated successfully in ${activationTime}ms`);
   console.timeEnd("Bruin Activation Total");
 
-  BruinPanel.render(context.extensionUri);
   TableDetailsPanel.initialize(context.subscriptions);
 }


### PR DESCRIPTION
# PR Overview 

This PR fixes an issue where the BruinPanel (side panel) was being rendered automatically when the extension activates.

