### PR TITLE
Add favorites webview and changed methods in activitybar

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,12 +95,14 @@
     "views": {
       "bruin": [
         {
-          "id": "bruinConnections",
-          "name": "Databases"
+          "id": "bruinFavorites",
+          "name": "Favorites",
+          "collapsed": true
         },
         {
-          "id": "bruinFavorites",
-          "name": "Favorites"
+          "id": "bruinConnections",
+          "name": "Connections"
+          
         }
       ],
       "bruin-assetLineageView": [
@@ -283,8 +285,14 @@
         },
         {
           "command": "bruin.refreshSchema",
-          "when": "view == bruinConnections && (viewItem == 'schema_favorite' || viewItem == 'schema_unfavorite')",
-          "group": "inline"
+          "when": "view == bruinConnections && (viewItem == 'schema_favorite' || viewItem == 'schema_unfavorite') ",
+          "group": "inline@2"
+        },
+
+        {
+          "command": "bruin.refreshSchema",
+          "when": "view == bruinFavorites && (viewItem == 'favorite_schema' || viewItem == 'playground')",
+          "group": "inline@2"
         },
         {
           "command": "bruin.refreshFavorites",
@@ -294,32 +302,32 @@
         {
           "command": "bruin.removeFavorite",
           "when": "view == bruinFavorites && viewItem == 'favorite_schema'",
-          "group": "inline"
+          "group": "inline@1"
         },
         {
           "command": "bruin.removeTableFavorite",
           "when": "view == bruinFavorites && (viewItem == 'favorite_table' || viewItem == 'favorite_table_starred')",
-          "group": "inline"
+          "group": "inline@1"
         },
         {
           "command": "bruin.addSchemaToFavorites",
           "when": "view == bruinConnections && viewItem == 'schema_unfavorite'",
-          "group": "inline"
+          "group": "inline@1"
         },
         {
           "command": "bruin.removeSchemaFromFavorites",
           "when": "view == bruinConnections && viewItem == 'schema_favorite'",
-          "group": "inline"
+          "group": "inline@1"
         },
         {
           "command": "bruin.addTableToFavorites",
           "when": "view == bruinConnections && viewItem == 'table_unfavorite'",
-          "group": "inline"
+          "group": "inline@1"
         },
         {
           "command": "bruin.removeTableFromFavorites",
           "when": "view == bruinConnections && viewItem == 'table_favorite'",
-          "group": "inline"
+          "group": "inline@1"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -96,8 +96,7 @@
       "bruin": [
         {
           "id": "bruinFavorites",
-          "name": "Favorites",
-          "collapsed": true
+          "name": "Favorites"
         },
         {
           "id": "bruinConnections",

--- a/package.json
+++ b/package.json
@@ -282,6 +282,11 @@
           "group": "inline"
         },
         {
+          "command": "bruin.refreshSchema",
+          "when": "view == bruinConnections && (viewItem == 'schema_favorite' || viewItem == 'schema_unfavorite')",
+          "group": "inline"
+        },
+        {
           "command": "bruin.refreshFavorites",
           "when": "view == bruinFavorites",
           "group": "navigation"
@@ -340,6 +345,13 @@
         "category": "Bruin",
         "icon": "$(refresh)",
         "description": "Refresh a single connection."
+      },
+      {
+        "command": "bruin.refreshSchema",
+        "title": "Refresh Schema",
+        "category": "Bruin",
+        "icon": "$(refresh)",
+        "description": "Refresh a single schema."
       },
       {
         "command": "bruin.showConnectionDetails",

--- a/package.json
+++ b/package.json
@@ -285,6 +285,11 @@
           "group": "inline" 
         },
         {
+          "command": "bruin.removeTableFavorite",
+          "when": "view == bruinFavorites && viewItem == 'favorite_table'",
+          "group": "inline" 
+        },
+        {
           "command": "bruin.addSchemaToFavorites",
           "when": "view == bruinConnections && viewItem == 'schema_unfavorite'",
           "group": "inline"
@@ -395,6 +400,13 @@
         "category": "Bruin",
         "icon": "$(star-full)",
         "description": "Remove table from favorites."
+      },
+      {
+        "command": "bruin.removeTableFavorite",
+        "title": "Remove Table Favorite",
+        "category": "Bruin",
+        "icon": "$(trash)",
+        "description": "Remove table from favorites list."
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -180,7 +180,10 @@
                 "type": "string"
               }
             },
-            "required": ["schemaName", "connectionName"]
+            "required": [
+              "schemaName",
+              "connectionName"
+            ]
           },
           "default": [],
           "description": "List of favorite schemas with their connection names."
@@ -200,7 +203,11 @@
                 "type": "string"
               }
             },
-            "required": ["tableName", "schemaName", "connectionName"]
+            "required": [
+              "tableName",
+              "schemaName",
+              "connectionName"
+            ]
           },
           "default": [],
           "description": "List of favorite tables with their schema and connection names."
@@ -276,18 +283,18 @@
         },
         {
           "command": "bruin.refreshFavorites",
-          "when": "view == bruinFavorites",  
+          "when": "view == bruinFavorites",
           "group": "navigation"
         },
         {
           "command": "bruin.removeFavorite",
           "when": "view == bruinFavorites && viewItem == 'favorite_schema'",
-          "group": "inline" 
+          "group": "inline"
         },
         {
           "command": "bruin.removeTableFavorite",
-          "when": "view == bruinFavorites && viewItem == 'favorite_table'",
-          "group": "inline" 
+          "when": "view == bruinFavorites && (viewItem == 'favorite_table' || viewItem == 'favorite_table_starred')",
+          "group": "inline"
         },
         {
           "command": "bruin.addSchemaToFavorites",
@@ -384,7 +391,7 @@
         "command": "bruin.removeFavorite",
         "title": "Remove Favorite",
         "category": "Bruin",
-        "icon": "$(trash)",
+        "icon": "$(star-full)",
         "description": "Remove favorite from list."
       },
       {
@@ -405,7 +412,7 @@
         "command": "bruin.removeTableFavorite",
         "title": "Remove Table Favorite",
         "category": "Bruin",
-        "icon": "$(trash)",
+        "icon": "$(star-full)",
         "description": "Remove table from favorites list."
       }
     ]

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
         },
         {
           "command": "bruin.removeFavorite",
-          "when": "view == bruinFavorites && viewItem == 'favorite'",
+          "when": "view == bruinFavorites && viewItem == 'favorite_schema'",
           "group": "inline" 
         },
         {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         },
         {
           "id": "bruinConnections",
-          "name": "Connections"
+          "name": "Databases"
           
         }
       ],

--- a/package.json
+++ b/package.json
@@ -184,6 +184,26 @@
           },
           "default": [],
           "description": "List of favorite schemas with their connection names."
+        },
+        "bruin.tables.favorites": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tableName": {
+                "type": "string"
+              },
+              "schemaName": {
+                "type": "string"
+              },
+              "connectionName": {
+                "type": "string"
+              }
+            },
+            "required": ["tableName", "schemaName", "connectionName"]
+          },
+          "default": [],
+          "description": "List of favorite tables with their schema and connection names."
         }
       }
     },
@@ -273,6 +293,16 @@
           "command": "bruin.removeSchemaFromFavorites",
           "when": "view == bruinConnections && viewItem == 'schema_favorite'",
           "group": "inline"
+        },
+        {
+          "command": "bruin.addTableToFavorites",
+          "when": "view == bruinConnections && viewItem == 'table_unfavorite'",
+          "group": "inline"
+        },
+        {
+          "command": "bruin.removeTableFromFavorites",
+          "when": "view == bruinConnections && viewItem == 'table_favorite'",
+          "group": "inline"
         }
       ]
     },
@@ -351,6 +381,20 @@
         "category": "Bruin",
         "icon": "$(trash)",
         "description": "Remove favorite from list."
+      },
+      {
+        "command": "bruin.addTableToFavorites",
+        "title": "Add Table to Favorites",
+        "category": "Bruin",
+        "icon": "$(star-empty)",
+        "description": "Add table to favorites."
+      },
+      {
+        "command": "bruin.removeTableFromFavorites",
+        "title": "Remove Table from Favorites",
+        "category": "Bruin",
+        "icon": "$(star-full)",
+        "description": "Remove table from favorites."
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -227,6 +227,16 @@
           "command": "bruin.refreshConnection",
           "when": "view == bruinConnections && viewItem == 'bruin_connection'",
           "group": "inline"
+        },
+        {
+          "command": "bruin.addSchemaToFavorites",
+          "when": "view == bruinConnections && viewItem == 'schema_unfavorite'",
+          "group": "inline"
+        },
+        {
+          "command": "bruin.removeSchemaFromFavorites",
+          "when": "view == bruinConnections && viewItem == 'schema_favorite'",
+          "group": "inline"
         }
       ]
     },
@@ -277,6 +287,20 @@
         "title": "Convert File to Asset",
         "category": "Bruin",
         "description": "Convert a file to a Bruin asset."
+      },
+      {
+        "command": "bruin.addSchemaToFavorites",
+        "title": "Add to Favorites",
+        "category": "Bruin",
+        "icon": "$(star-empty)",
+        "description": "Add schema to favorites."
+      },
+      {
+        "command": "bruin.removeSchemaFromFavorites",
+        "title": "Remove from Favorites",
+        "category": "Bruin",
+        "icon": "$(star-full)",
+        "description": "Remove schema from favorites."
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -97,6 +97,10 @@
         {
           "id": "bruinConnections",
           "name": "Databases"
+        },
+        {
+          "id": "bruinFavorites",
+          "name": "Favorites"
         }
       ],
       "bruin-assetLineageView": [
@@ -237,6 +241,11 @@
           "command": "bruin.refreshConnections",
           "when": "view == bruinConnections",
           "group": "navigation"
+        },
+        {
+          "command": "bruin.refreshFavorites",
+          "when": "view == bruinFavorites",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
@@ -244,6 +253,16 @@
           "command": "bruin.refreshConnection",
           "when": "view == bruinConnections && viewItem == 'bruin_connection'",
           "group": "inline"
+        },
+        {
+          "command": "bruin.refreshFavorites",
+          "when": "view == bruinFavorites",  
+          "group": "navigation"
+        },
+        {
+          "command": "bruin.removeFavorite",
+          "when": "view == bruinFavorites && viewItem == 'favorite'",
+          "group": "inline" 
         },
         {
           "command": "bruin.addSchemaToFavorites",
@@ -318,6 +337,20 @@
         "category": "Bruin",
         "icon": "$(star-full)",
         "description": "Remove schema from favorites."
+      },
+      {
+        "command": "bruin.refreshFavorites",
+        "title": "Refresh Favorites",
+        "category": "Bruin",
+        "icon": "$(refresh)",
+        "description": "Refresh favorites list."
+      },
+      {
+        "command": "bruin.removeFavorite",
+        "title": "Remove Favorite",
+        "category": "Bruin",
+        "icon": "$(trash)",
+        "description": "Remove favorite from list."
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -163,6 +163,23 @@
           "type": "string",
           "default": "",
           "description": "Sets the validate exclude tag to be used with validation commands."
+        },
+        "bruin.schemas.favorites": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "schemaName": {
+                "type": "string"
+              },
+              "connectionName": {
+                "type": "string"
+              }
+            },
+            "required": ["schemaName", "connectionName"]
+          },
+          "default": [],
+          "description": "List of favorite schemas with their connection names."
         }
       }
     },

--- a/src/bruin/bruinConnections.ts
+++ b/src/bruin/bruinConnections.ts
@@ -26,9 +26,14 @@ export class BruinConnections extends BruinCommand {
   public async getConnections({
     flags = ["list", "-o", "json"],
     ignoresErrors = false,
-  }: BruinCommandOptions = {}): Promise<void> {
+    environment,
+  }: BruinCommandOptions & { environment?: string } = {}): Promise<void> {
+    // Add environment flag if provided
+    const commandFlags = environment 
+      ? ["list", "-env", environment, "-o", "json"]
+      : flags;
 
-    await this.run([...flags], { ignoresErrors })
+    await this.run([...commandFlags], { ignoresErrors })
       .then(
         (result) => {
           const connections = extractNonNullConnections(JSON.parse(result));
@@ -73,9 +78,15 @@ export class BruinConnections extends BruinCommand {
   public async getConnectionsForActivityBar({
     flags = ["list", "-o", "json"],
     ignoresErrors = false,
-  }: BruinCommandOptions = {}): Promise<any[]> {
+    environment,
+  }: BruinCommandOptions & { environment?: string } = {}): Promise<any[]> {
     try {
-      const result = await this.run([...flags], { ignoresErrors });
+      // Add environment flag if provided
+      const commandFlags = environment 
+        ? ["list", "-env", environment, "-o", "json"]
+        : flags;
+        
+      const result = await this.run([...commandFlags], { ignoresErrors });
       const connections = extractNonNullConnections(JSON.parse(result));
       return connections;
     } catch (error) {

--- a/src/bruin/bruinDBTCommand.ts
+++ b/src/bruin/bruinDBTCommand.ts
@@ -16,4 +16,15 @@ export class BruinDBTCommand extends BruinCommand {
     }
   }
 
+  public async getFetchTables(connectionName: string, database: string): Promise<any> {
+    const flags = ["fetch-tables", "-c", connectionName, "-d", database, "-o", "json"];
+    try {
+      const result = await this.run(flags, { ignoresErrors: false });
+      return JSON.parse(result);
+    } catch (error) {
+      console.error(`Error fetching tables for ${connectionName} in database ${database}:`, error);
+      throw error;
+    }
+  }
+
 } 

--- a/src/bruin/bruinDBTCommand.ts
+++ b/src/bruin/bruinDBTCommand.ts
@@ -27,4 +27,15 @@ export class BruinDBTCommand extends BruinCommand {
     }
   }
 
+  public async getFetchColumns(connectionName: string, database: string, table: string): Promise<any> {
+    const flags = ["fetch-columns", "-c", connectionName, "-d", database, "-table", table, "-o", "json"];
+    try {
+      const result = await this.run(flags, { ignoresErrors: false });
+      return JSON.parse(result);
+    } catch (error) {
+      console.error(`Error fetching columns for table ${table} in ${connectionName}.${database}:`, error);
+      throw error;
+    }
+  }
+
 } 

--- a/src/bruin/bruinDBTCommand.ts
+++ b/src/bruin/bruinDBTCommand.ts
@@ -5,14 +5,15 @@ export class BruinDBTCommand extends BruinCommand {
     return "internal";
   }
 
-  public async getDbSummary(connectionName: string): Promise<any> {
-    const flags = ["db-summary", "--connection", connectionName, "-o", "json"];
+  public async getFetchDatabases(connectionName: string): Promise<any> {
+    const flags = ["fetch-databases", "-c", connectionName, "-o", "json"];
     try {
       const result = await this.run(flags, { ignoresErrors: false });
       return JSON.parse(result);
     } catch (error) {
-      console.error(`Error getting db summary for ${connectionName}:`, error);
+      console.error(`Error fetching databases for ${connectionName}:`, error);
       throw error;
     }
   }
+
 } 

--- a/src/bruin/bruinDBTCommand.ts
+++ b/src/bruin/bruinDBTCommand.ts
@@ -5,8 +5,10 @@ export class BruinDBTCommand extends BruinCommand {
     return "internal";
   }
 
-  public async getFetchDatabases(connectionName: string): Promise<any> {
-    const flags = ["fetch-databases", "-c", connectionName, "-o", "json"];
+  public async getFetchDatabases(connectionName: string, environment?: string): Promise<any> {
+    const flags = environment 
+      ? ["fetch-databases", "-c", connectionName, "-env", environment, "-o", "json"]
+      : ["fetch-databases", "-c", connectionName, "-o", "json"];
     try {
       const result = await this.run(flags, { ignoresErrors: false });
       return JSON.parse(result);
@@ -16,8 +18,10 @@ export class BruinDBTCommand extends BruinCommand {
     }
   }
 
-  public async getFetchTables(connectionName: string, database: string): Promise<any> {
-    const flags = ["fetch-tables", "-c", connectionName, "-d", database, "-o", "json"];
+  public async getFetchTables(connectionName: string, database: string, environment?: string): Promise<any> {
+    const flags = environment 
+      ? ["fetch-tables", "-c", connectionName, "-d", database, "-env", environment, "-o", "json"]
+      : ["fetch-tables", "-c", connectionName, "-d", database, "-o", "json"];
     try {
       const result = await this.run(flags, { ignoresErrors: false });
       return JSON.parse(result);
@@ -27,8 +31,10 @@ export class BruinDBTCommand extends BruinCommand {
     }
   }
 
-  public async getFetchColumns(connectionName: string, database: string, table: string): Promise<any> {
-    const flags = ["fetch-columns", "-c", connectionName, "-d", database, "-table", table, "-o", "json"];
+  public async getFetchColumns(connectionName: string, database: string, table: string, environment?: string): Promise<any> {
+    const flags = environment 
+      ? ["fetch-columns", "-c", connectionName, "-d", database, "-table", table, "-env", environment, "-o", "json"]
+      : ["fetch-columns", "-c", connectionName, "-d", database, "-table", table, "-o", "json"];
     try {
       const result = await this.run(flags, { ignoresErrors: false });
       return JSON.parse(result);

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -135,12 +135,14 @@ export function subscribeToConfigurationChanges() {
 export interface SchemaFavorite {
   schemaName: string;
   connectionName: string;
+  environment?: string;
 }
 
 export interface TableFavorite {
   tableName: string;
   schemaName: string;
   connectionName: string;
+  environment?: string;
 }
 
 export function getSchemaFavorites(): SchemaFavorite[] {
@@ -163,10 +165,10 @@ export async function saveTableFavorites(favorites: TableFavorite[]): Promise<vo
   await config.update("favorites", favorites, vscode.ConfigurationTarget.Global);
 }
 
-export function createFavoriteKey(schemaName: string, connectionName: string): string {
-  return `${connectionName}.${schemaName}`;
+export function createFavoriteKey(schemaName: string, connectionName: string, environment?: string): string {
+  return environment ? `${connectionName}.${environment}.${schemaName}` : `${connectionName}.${schemaName}`;
 }
 
-export function createTableFavoriteKey(tableName: string, schemaName: string, connectionName: string): string {
-  return `${connectionName}.${schemaName}.${tableName}`;
+export function createTableFavoriteKey(tableName: string, schemaName: string, connectionName: string, environment?: string): string {
+  return environment ? `${connectionName}.${environment}.${schemaName}.${tableName}` : `${connectionName}.${schemaName}.${tableName}`;
 }

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -137,6 +137,12 @@ export interface SchemaFavorite {
   connectionName: string;
 }
 
+export interface TableFavorite {
+  tableName: string;
+  schemaName: string;
+  connectionName: string;
+}
+
 export function getSchemaFavorites(): SchemaFavorite[] {
   const config = vscode.workspace.getConfiguration("bruin.schemas");
   return config.get<SchemaFavorite[]>("favorites", []);
@@ -147,6 +153,20 @@ export async function saveSchemaFavorites(favorites: SchemaFavorite[]): Promise<
   await config.update("favorites", favorites, vscode.ConfigurationTarget.Global);
 }
 
+export function getTableFavorites(): TableFavorite[] {
+  const config = vscode.workspace.getConfiguration("bruin.tables");
+  return config.get<TableFavorite[]>("favorites", []);
+}
+
+export async function saveTableFavorites(favorites: TableFavorite[]): Promise<void> {
+  const config = vscode.workspace.getConfiguration("bruin.tables");
+  await config.update("favorites", favorites, vscode.ConfigurationTarget.Global);
+}
+
 export function createFavoriteKey(schemaName: string, connectionName: string): string {
   return `${connectionName}.${schemaName}`;
+}
+
+export function createTableFavoriteKey(tableName: string, schemaName: string, connectionName: string): string {
+  return `${connectionName}.${schemaName}.${tableName}`;
 }

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -131,3 +131,22 @@ export function subscribeToConfigurationChanges() {
     }
   });
 }
+
+export interface SchemaFavorite {
+  schemaName: string;
+  connectionName: string;
+}
+
+export function getSchemaFavorites(): SchemaFavorite[] {
+  const config = vscode.workspace.getConfiguration("bruin.schemas");
+  return config.get<SchemaFavorite[]>("favorites", []);
+}
+
+export async function saveSchemaFavorites(favorites: SchemaFavorite[]): Promise<void> {
+  const config = vscode.workspace.getConfiguration("bruin.schemas");
+  await config.update("favorites", favorites, vscode.ConfigurationTarget.Global);
+}
+
+export function createFavoriteKey(schemaName: string, connectionName: string): string {
+  return `${connectionName}.${schemaName}`;
+}

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -298,6 +298,25 @@ export async function activate(context: ExtensionContext) {
         vscode.window.showErrorMessage(`Error removing favorite: ${errorMessage}`);
       }
     }),
+    commands.registerCommand("bruin.removeTableFavorite", async (item: any) => {
+      try {
+        trackEvent("Command Executed", { command: "removeTableFavorite" });
+        if (item && item.itemData && item.contextValue === 'favorite_table') {
+          const tableData = item.itemData as any;
+          const tableFavorite = {
+            tableName: tableData.name,
+            schemaName: tableData.schema,
+            connectionName: tableData.connectionName
+          };
+          await favoritesProvider.removeTableFavorite(tableFavorite);
+          activityBarConnectionsProvider.refresh();
+          vscode.window.showInformationMessage("Table favorite removed successfully!");
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error removing table favorite: ${errorMessage}`);
+      }
+    }),
     commands.registerCommand("bruin.addTableToFavorites", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "addTableToFavorites" });

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -259,10 +259,10 @@ export async function activate(context: ExtensionContext) {
     }),
     commands.registerCommand(
       "bruin.showTableDetails",
-      (tableName: string, schemaName?: string, connectionName?: string) => {
+      (tableName: string, schemaName?: string, connectionName?: string, environmentName?: string) => {
         try {
           trackEvent("Command Executed", { command: "showTableDetails" });
-          TableDetailsPanel.render(context.extensionUri, tableName, schemaName, connectionName);
+          TableDetailsPanel.render(context.extensionUri, tableName, schemaName, connectionName, environmentName);
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           vscode.window.showErrorMessage(`Error showing table details: ${errorMessage}`);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -227,6 +227,18 @@ export async function activate(context: ExtensionContext) {
         vscode.window.showErrorMessage(`Error refreshing connection: ${errorMessage}`);
       }
     }),
+    commands.registerCommand("bruin.refreshSchema", (item: any) => {
+      try {
+        trackEvent("Command Executed", { command: "refreshSchema" });
+        if (item && item.itemData) {
+          activityBarConnectionsProvider.refreshSchema(item.itemData);
+          vscode.window.showInformationMessage(`Schema ${item.itemData.name} refreshed.`);
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error refreshing schema: ${errorMessage}`);
+      }
+    }),
     commands.registerCommand("bruin.showConnectionDetails", (connection: any) => {
       try {
         trackEvent("Command Executed", { command: "showConnectionDetails" });

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -288,8 +288,8 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("bruin.removeFavorite", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "removeFavorite" });
-        if (item && item.favorite) {
-          await favoritesProvider.removeFavorite(item.favorite);
+        if (item && item.itemData && item.contextValue === 'favorite_schema') {
+          await favoritesProvider.removeFavorite(item.itemData);
           activityBarConnectionsProvider.refresh();
           vscode.window.showInformationMessage("Favorite removed successfully!");
         }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -247,6 +247,29 @@ export async function activate(context: ExtensionContext) {
         vscode.window.showErrorMessage(`Error showing table details: ${errorMessage}`);
       }
     }),
+    commands.registerCommand("bruin.addSchemaToFavorites", (item: any) => {
+      try {
+        trackEvent("Command Executed", { command: "addSchemaToFavorites" });
+        if (item && item.itemData && 'tables' in item.itemData) {
+          activityBarConnectionsProvider.toggleSchemaFavorite(item.itemData);
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error adding schema to favorites: ${errorMessage}`);
+      }
+    }),
+    commands.registerCommand("bruin.removeSchemaFromFavorites", (item: any) => {
+      try {
+        trackEvent("Command Executed", { command: "removeSchemaFromFavorites" });
+        if (item && item.itemData && 'tables' in item.itemData) {
+          activityBarConnectionsProvider.toggleSchemaFavorite(item.itemData);
+          vscode.window.showInformationMessage(`Schema ${item.itemData.name} removed from favorites.`);
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error removing schema from favorites: ${errorMessage}`);
+      }
+    }),
     commands.registerCommand("bruin.runQuery", async (uri: vscode.Uri, range: vscode.Range) => {
       try {
         trackEvent("Command Executed", { command: "runQuery" });

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -28,7 +28,7 @@ import { ActivityBarConnectionsProvider } from "../providers/ActivityBarConnecti
 import { FavoritesProvider } from "../providers/FavoritesProvider";
 import { isBruinAsset, isBruinPipeline } from "../utilities/helperUtils";
 import { getBruinExecutablePath } from "../providers/BruinExecutableService";
-import { TableDetailsPanel } from '../panels/TableDetailsPanel';
+import { TableDetailsPanel } from "../panels/TableDetailsPanel";
 
 let analyticsClient: any = null;
 
@@ -159,7 +159,7 @@ export async function activate(context: ExtensionContext) {
             console.debug("Bruin panel restored from state:", state);
           } catch (error) {
             console.error("Failed to restore Bruin panel:", error);
-          } 
+          }
         },
       })
     );
@@ -195,10 +195,10 @@ export async function activate(context: ExtensionContext) {
   subscribeToConfigurationChanges();
 
   const activityBarConnectionsProvider = new ActivityBarConnectionsProvider(context.extensionPath);
-  vscode.window.registerTreeDataProvider('bruinConnections', activityBarConnectionsProvider);
+  vscode.window.registerTreeDataProvider("bruinConnections", activityBarConnectionsProvider);
 
   const favoritesProvider = new FavoritesProvider();
-  vscode.window.registerTreeDataProvider('bruinFavorites', favoritesProvider);
+  vscode.window.registerTreeDataProvider("bruinFavorites", favoritesProvider);
 
   const defaultFoldingState = bruinConfig.get("bruin.FoldingState", "folded");
   let toggled = defaultFoldingState === "folded";
@@ -232,7 +232,7 @@ export async function activate(context: ExtensionContext) {
         trackEvent("Command Executed", { command: "showConnectionDetails" });
         const details = `Connection: ${connection.name}\nType: ${connection.type}\nStatus: ${connection.status}`;
         if (connection.host) {
-          const hostDetails = `\nHost: ${connection.host}:${connection.port || 'default'}`;
+          const hostDetails = `\nHost: ${connection.host}:${connection.port || "default"}`;
           vscode.window.showInformationMessage(details + hostDetails);
         } else {
           vscode.window.showInformationMessage(details);
@@ -242,19 +242,22 @@ export async function activate(context: ExtensionContext) {
         vscode.window.showErrorMessage(`Error showing connection details: ${errorMessage}`);
       }
     }),
-    commands.registerCommand("bruin.showTableDetails", (tableName: string, schemaName?: string, connectionName?: string) => {
-      try {
-        trackEvent("Command Executed", { command: "showTableDetails" });
-        TableDetailsPanel.render(context.extensionUri, tableName, schemaName, connectionName);
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        vscode.window.showErrorMessage(`Error showing table details: ${errorMessage}`);
+    commands.registerCommand(
+      "bruin.showTableDetails",
+      (tableName: string, schemaName?: string, connectionName?: string) => {
+        try {
+          trackEvent("Command Executed", { command: "showTableDetails" });
+          TableDetailsPanel.render(context.extensionUri, tableName, schemaName, connectionName);
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          vscode.window.showErrorMessage(`Error showing table details: ${errorMessage}`);
+        }
       }
-    }),
+    ),
     commands.registerCommand("bruin.addSchemaToFavorites", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "addSchemaToFavorites" });
-        if (item && item.itemData && 'tables' in item.itemData) {
+        if (item && item.itemData && "tables" in item.itemData) {
           await activityBarConnectionsProvider.toggleSchemaFavorite(item.itemData);
           favoritesProvider.refresh();
         }
@@ -266,7 +269,7 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("bruin.removeSchemaFromFavorites", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "removeSchemaFromFavorites" });
-        if (item && item.itemData && 'tables' in item.itemData) {
+        if (item && item.itemData && "tables" in item.itemData) {
           await activityBarConnectionsProvider.toggleSchemaFavorite(item.itemData);
           favoritesProvider.refresh();
         }
@@ -288,7 +291,7 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("bruin.removeFavorite", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "removeFavorite" });
-        if (item && item.itemData && item.contextValue === 'favorite_schema') {
+        if (item && item.itemData && item.contextValue === "favorite_schema") {
           await favoritesProvider.removeFavorite(item.itemData);
           activityBarConnectionsProvider.refresh();
           vscode.window.showInformationMessage("Favorite removed successfully!");
@@ -301,12 +304,12 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("bruin.removeTableFavorite", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "removeTableFavorite" });
-        if (item && item.itemData && item.contextValue === 'favorite_table') {
+        if (item && item.itemData && item.contextValue === "favorite_table") {
           const tableData = item.itemData as any;
           const tableFavorite = {
             tableName: tableData.name,
             schemaName: tableData.schema,
-            connectionName: tableData.connectionName
+            connectionName: tableData.connectionName,
           };
           await favoritesProvider.removeTableFavorite(tableFavorite);
           activityBarConnectionsProvider.refresh();
@@ -320,8 +323,8 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("bruin.addTableToFavorites", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "addTableToFavorites" });
-        if (item && item.itemData && 'name' in item.itemData && 'schema' in item.itemData) {
-          await activityBarConnectionsProvider.toggleTableFavorite(item.itemData);
+        if (item && item.itemData && "name" in item.itemData && "schema" in item.itemData) {
+          await activityBarConnectionsProvider.toggleTableFavorite(item.itemData, item);
           favoritesProvider.refresh();
         }
       } catch (error) {
@@ -332,8 +335,8 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("bruin.removeTableFromFavorites", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "removeTableFromFavorites" });
-        if (item && item.itemData && 'name' in item.itemData && 'schema' in item.itemData) {
-          await activityBarConnectionsProvider.toggleTableFavorite(item.itemData);
+        if (item && item.itemData && "name" in item.itemData && "schema" in item.itemData) {
+          await activityBarConnectionsProvider.toggleTableFavorite(item.itemData, item);
           favoritesProvider.refresh();
         }
       } catch (error) {
@@ -347,7 +350,7 @@ export async function activate(context: ExtensionContext) {
         const document = await workspace.openTextDocument(uri);
         const query = document.getText(range);
         QueryPreviewPanel.setLastExecutedQuery(query);
-        const activeTabId = QueryPreviewPanel.getActiveTabId(); 
+        const activeTabId = QueryPreviewPanel.getActiveTabId();
 
         QueryPreviewPanel.postMessage("query-output-message", {
           status: "loading",
@@ -413,6 +416,16 @@ export async function activate(context: ExtensionContext) {
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`Error converting file to asset: ${errorMessage}`);
+      }
+    }),
+    commands.registerCommand("bruin.toggleTableFavorite", async (item: any) => {
+      if (item && item.itemData) {
+        await activityBarConnectionsProvider.toggleTableFavorite(item.itemData, item);
+      }
+    }),
+    commands.registerCommand("bruin.toggleTableUnfavorite", async (item: any) => {
+      if (item && item.itemData) {
+        await activityBarConnectionsProvider.toggleTableFavorite(item.itemData, item);
       }
     }),
   ];

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -219,8 +219,11 @@ export async function activate(context: ExtensionContext) {
       try {
         trackEvent("Command Executed", { command: "refreshConnection" });
         if (item && item.itemData && item.itemData.name) {
-          activityBarConnectionsProvider.refreshConnection(item.itemData.name);
-          vscode.window.showInformationMessage(`Connection ${item.itemData.name} refreshed.`);
+          // Pass environment information if available
+          const environment = item.itemData.environment;
+          activityBarConnectionsProvider.refreshConnection(item.itemData.name, environment);
+          const envText = environment ? ` (${environment})` : '';
+          vscode.window.showInformationMessage(`Connection ${item.itemData.name}${envText} refreshed.`);
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -326,6 +329,7 @@ export async function activate(context: ExtensionContext) {
             tableName: tableData.name,
             schemaName: tableData.schema,
             connectionName: tableData.connectionName,
+            environment: tableData.environment,
           };
           await favoritesProvider.removeTableFavorite(tableFavorite);
           activityBarConnectionsProvider.refresh();

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -304,7 +304,11 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("bruin.removeTableFavorite", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "removeTableFavorite" });
-        if (item && item.itemData && item.contextValue === "favorite_table") {
+        if (
+          item &&
+          item.itemData &&
+          (item.contextValue === "favorite_table" || item.contextValue === "favorite_table_starred")
+        ) {
           const tableData = item.itemData as any;
           const tableFavorite = {
             tableName: tableData.name,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -298,6 +298,30 @@ export async function activate(context: ExtensionContext) {
         vscode.window.showErrorMessage(`Error removing favorite: ${errorMessage}`);
       }
     }),
+    commands.registerCommand("bruin.addTableToFavorites", async (item: any) => {
+      try {
+        trackEvent("Command Executed", { command: "addTableToFavorites" });
+        if (item && item.itemData && 'name' in item.itemData && 'schema' in item.itemData) {
+          await activityBarConnectionsProvider.toggleTableFavorite(item.itemData);
+          favoritesProvider.refresh();
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error adding table to favorites: ${errorMessage}`);
+      }
+    }),
+    commands.registerCommand("bruin.removeTableFromFavorites", async (item: any) => {
+      try {
+        trackEvent("Command Executed", { command: "removeTableFromFavorites" });
+        if (item && item.itemData && 'name' in item.itemData && 'schema' in item.itemData) {
+          await activityBarConnectionsProvider.toggleTableFavorite(item.itemData);
+          favoritesProvider.refresh();
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error removing table from favorites: ${errorMessage}`);
+      }
+    }),
     commands.registerCommand("bruin.runQuery", async (uri: vscode.Uri, range: vscode.Range) => {
       try {
         trackEvent("Command Executed", { command: "runQuery" });

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -247,23 +247,22 @@ export async function activate(context: ExtensionContext) {
         vscode.window.showErrorMessage(`Error showing table details: ${errorMessage}`);
       }
     }),
-    commands.registerCommand("bruin.addSchemaToFavorites", (item: any) => {
+    commands.registerCommand("bruin.addSchemaToFavorites", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "addSchemaToFavorites" });
         if (item && item.itemData && 'tables' in item.itemData) {
-          activityBarConnectionsProvider.toggleSchemaFavorite(item.itemData);
+          await activityBarConnectionsProvider.toggleSchemaFavorite(item.itemData);
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`Error adding schema to favorites: ${errorMessage}`);
       }
     }),
-    commands.registerCommand("bruin.removeSchemaFromFavorites", (item: any) => {
+    commands.registerCommand("bruin.removeSchemaFromFavorites", async (item: any) => {
       try {
         trackEvent("Command Executed", { command: "removeSchemaFromFavorites" });
         if (item && item.itemData && 'tables' in item.itemData) {
-          activityBarConnectionsProvider.toggleSchemaFavorite(item.itemData);
-          vscode.window.showInformationMessage(`Schema ${item.itemData.name} removed from favorites.`);
+          await activityBarConnectionsProvider.toggleSchemaFavorite(item.itemData);
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/panels/TableDetailsPanel.ts
+++ b/src/panels/TableDetailsPanel.ts
@@ -25,16 +25,17 @@ export class TableDetailsPanel {
     });
   }
 
-  public static async render(extensionUri: Uri, tableName: string, schemaName?: string, connectionName?: string) {
+  public static async render(extensionUri: Uri, tableName: string, schemaName?: string, connectionName?: string, environmentName?: string) {
     try {
       const cleanTableName = tableName.replace(/\.sql$/, "");
       const connectionIdentifier = connectionName || 'default';
+      const environmentIdentifier = environmentName || 'default';
       
       // Check if there's already an open document for this table
       const openDocuments = workspace.textDocuments;
       const existingDoc = openDocuments.find(doc => {
         const fileName = path.basename(doc.fileName);
-        return fileName.startsWith(`bruin-${cleanTableName}-${connectionIdentifier}-`) && fileName.endsWith('.sql');
+        return fileName.startsWith(`bruin-${cleanTableName}-${connectionIdentifier}-${environmentIdentifier}-`) && fileName.endsWith('.sql');
       });
       
       if (existingDoc) {
@@ -62,13 +63,14 @@ export class TableDetailsPanel {
         fs.mkdirSync(tempDir, { recursive: true });
       }
       
-      const tempFileName = `bruin-${cleanTableName}-${connectionIdentifier}-${Date.now()}.sql`;
+      const tempFileName = `bruin-${cleanTableName}-${connectionIdentifier}-${environmentIdentifier}-${Date.now()}.sql`;
       const tempFilePath = path.join(tempDir, tempFileName);
       
       // Track temp file for cleanup
       this.tempFiles.add(tempFilePath);
       
-      let initialContent = `-- connection: ${connectionName || 'default'}\n`;
+      let initialContent = `-- environment: ${environmentName || 'default'}\n`;
+      initialContent += `-- connection: ${connectionName || 'default'}\n`;
       if (schemaName) {
         initialContent += `SELECT * FROM ${this._sanitizeTableName(schemaName)}.${this._sanitizeTableName(cleanTableName)};\n\n`;
       } else {
@@ -83,7 +85,7 @@ export class TableDetailsPanel {
       await window.showTextDocument(doc, {
         viewColumn: ViewColumn.One,
         preview: false,
-        selection: new Range(new Position(2, 0), new Position(2, 0))
+        selection: new Range(new Position(3, 0), new Position(3, 0))
       });
 
       // Safely focus QueryPreview panel without recreating it

--- a/src/panels/TableDetailsPanel.ts
+++ b/src/panels/TableDetailsPanel.ts
@@ -6,6 +6,8 @@ import {
   workspace,
   WorkspaceEdit,
   commands,
+  Range,
+  Position,
 } from "vscode";
 import { QueryPreviewPanel } from "./QueryPreviewPanel";
 import * as fs from "fs";
@@ -66,12 +68,11 @@ export class TableDetailsPanel {
       // Track temp file for cleanup
       this.tempFiles.add(tempFilePath);
       
-      // Create SQL query with schema if provided
       let initialContent = `-- connection: ${connectionName || 'default'}\n`;
       if (schemaName) {
-        initialContent += `SELECT * FROM ${this._sanitizeTableName(schemaName)}.${this._sanitizeTableName(cleanTableName)};`;
+        initialContent += `SELECT * FROM ${this._sanitizeTableName(schemaName)}.${this._sanitizeTableName(cleanTableName)};\n\n`;
       } else {
-        initialContent += `SELECT * FROM ${this._sanitizeTableName(cleanTableName)};`;
+        initialContent += `SELECT * FROM ${this._sanitizeTableName(cleanTableName)};\n\n`;
       }
 
       fs.writeFileSync(tempFilePath, initialContent);
@@ -82,6 +83,7 @@ export class TableDetailsPanel {
       await window.showTextDocument(doc, {
         viewColumn: ViewColumn.One,
         preview: false,
+        selection: new Range(new Position(2, 0), new Position(2, 0))
       });
 
       // Safely focus QueryPreview panel without recreating it

--- a/src/providers/ActivityBarConnectionsProvider.ts
+++ b/src/providers/ActivityBarConnectionsProvider.ts
@@ -569,7 +569,7 @@ export class ActivityBarConnectionsProvider implements vscode.TreeDataProvider<C
     }
   }
 
-  private async getChildrenForTable(table: Table): Promise<Column[]> {
+  private async getChildrenForTable(table: Table): Promise<ConnectionItem[]> {
     const cacheKey = `${table.connectionName}.${table.schema}.${table.name}`;
 
     if (this.columnsCache.has(cacheKey)) {
@@ -609,5 +609,26 @@ export class ActivityBarConnectionsProvider implements vscode.TreeDataProvider<C
       vscode.window.showErrorMessage(`Failed to get columns for ${table.name}: ${error}`);
       return [];
     }
+  }
+
+  private parseTableSummary(summary: any, schema: Schema): Table[] {
+    const tablesArray = Array.isArray(summary) ? summary : summary?.tables;
+    if (!Array.isArray(tablesArray)) {
+      throw new Error("Invalid tables summary format: not an array or object with a 'tables' property.");
+    }
+    return tablesArray.map((item) => {
+      if (typeof item === "string") {
+        return {
+          name: item,
+          schema: schema.name,
+          connectionName: schema.connectionName,
+        };
+      }
+      return {
+        name: item.name || "Unknown Table",
+        schema: schema.name,
+        connectionName: schema.connectionName,
+      };
+    });
   }
 }

--- a/src/providers/ActivityBarConnectionsProvider.ts
+++ b/src/providers/ActivityBarConnectionsProvider.ts
@@ -308,11 +308,12 @@ export class ActivityBarConnectionsProvider implements vscode.TreeDataProvider<C
       if (this.columnsCache.has(cacheKey)) {
         return this.columnsCache.get(cacheKey)!.map(column => {
           const columnItem = new ConnectionItem(
-            `${column.name} (${column.type})`,
+            column.name,
             vscode.TreeItemCollapsibleState.None,
             column,
             'column'
           );
+          columnItem.description = column.type;
           columnItem.tooltip = `Column: ${column.name}, Type: ${column.type}`;
           return columnItem;
         });
@@ -324,11 +325,12 @@ export class ActivityBarConnectionsProvider implements vscode.TreeDataProvider<C
         this.columnsCache.set(cacheKey, columns);
         return columns.map(column => {
           const columnItem = new ConnectionItem(
-            `${column.name} (${column.type})`,
+            column.name,
             vscode.TreeItemCollapsibleState.None,
             column,
             'column'
           );
+          columnItem.description = column.type;
           columnItem.tooltip = `Column: ${column.name}, Type: ${column.type}`;
           return columnItem;
         });

--- a/src/providers/ActivityBarConnectionsProvider.ts
+++ b/src/providers/ActivityBarConnectionsProvider.ts
@@ -353,7 +353,7 @@ export class ActivityBarConnectionsProvider implements vscode.TreeDataProvider<C
       element.command = {
         command: "bruin.showTableDetails",
         title: "Show Table Details",
-        arguments: [table.name, table.schema, table.connectionName],
+        arguments: [table.name, table.schema, table.connectionName, table.environment],
       };
     }
     return element;
@@ -466,7 +466,7 @@ export class ActivityBarConnectionsProvider implements vscode.TreeDataProvider<C
           tableTreeItem.command = {
             command: "bruin.showTableDetails",
             title: "Show Table Details",
-            arguments: [table, schema.name, schema.connectionName],
+            arguments: [table, schema.name, schema.connectionName, environment],
           };
           return tableTreeItem;
         });

--- a/src/providers/FavoritesProvider.ts
+++ b/src/providers/FavoritesProvider.ts
@@ -57,6 +57,7 @@ class FavoriteItem extends vscode.TreeItem {
       this.iconPath = new vscode.ThemeIcon('symbol-field');
       const column = itemData as FavoriteColumn;
       this.tooltip = `Column: ${column.name}, Type: ${column.type}`;
+      this.description = column.type;
     }
   }
 }
@@ -158,32 +159,44 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
     }
 
     if (element.contextValue === 'favorite_connection') {
-      // Show schemas and tables under connection
+      // Show schemas and tables under connection, grouped by schema
       const connection = element.itemData as FavoriteConnection;
       const items: FavoriteItem[] = [];
       
-      // Add schema items
+      // Create a map to group items by schema
+      const schemaMap = new Map<string, { 
+        schema?: SchemaFavorite, 
+        tables: TableFavorite[] 
+      }>();
+      
+      // Add schema favorites to the map
       connection.schemas.forEach(schema => {
-        items.push(new FavoriteItem(
-          `[Schema] ${schema.schemaName}`,
-          vscode.TreeItemCollapsibleState.Collapsed,
-          schema,
-          'favorite_schema'
-        ));
+        if (!schemaMap.has(schema.schemaName)) {
+          schemaMap.set(schema.schemaName, { tables: [] });
+        }
+        schemaMap.get(schema.schemaName)!.schema = schema;
       });
       
-      // Add table items
+      // Add table favorites to the map, grouped by schema
       connection.tables.forEach(table => {
-        const tableItem: FavoriteTable = {
-          name: table.tableName,
-          schema: table.schemaName,
-          connectionName: table.connectionName
+        if (!schemaMap.has(table.schemaName)) {
+          schemaMap.set(table.schemaName, { tables: [] });
+        }
+        schemaMap.get(table.schemaName)!.tables.push(table);
+      });
+      
+      // Create items for each schema
+      Array.from(schemaMap.entries()).forEach(([schemaName, schemaData]) => {
+        const schemaItem: SchemaFavorite = schemaData.schema || {
+          schemaName: schemaName,
+          connectionName: connection.name
         };
+        
         items.push(new FavoriteItem(
-          `[Table] ${table.schemaName}.${table.tableName}`,
+          `${schemaName}`,
           vscode.TreeItemCollapsibleState.Collapsed,
-          tableItem,
-          'favorite_table'
+          schemaItem,
+          'favorite_schema'
         ));
       });
       
@@ -191,53 +204,32 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
     }
 
     if (element.contextValue === 'favorite_schema') {
-      // Show tables under schema
       const schema = element.itemData as SchemaFavorite;
       const cacheKey = `${schema.connectionName}.${schema.schemaName}`;
       
-      // Check cache first
-      if (this.tableCache.has(cacheKey)) {
-        const tables = this.tableCache.get(cacheKey)!;
-        return tables.map(tableName => {
-          const table: FavoriteTable = {
-            name: tableName,
-            schema: schema.schemaName,
-            connectionName: schema.connectionName
-          };
-          return new FavoriteItem(
-            tableName,
-            vscode.TreeItemCollapsibleState.Collapsed,
-            table,
-            'favorite_table'
-          );
-        });
+      // Get favorite tables for this schema
+      const favoriteTablesInSchema = this.tableFavorites.filter(table => 
+        table.connectionName === schema.connectionName && 
+        table.schemaName === schema.schemaName
+      );
+      
+      // Check if this schema is actually favorited
+      const isSchemaFavorited = this.favorites.some(fav => 
+        fav.connectionName === schema.connectionName && 
+        fav.schemaName === schema.schemaName
+      );
+      
+      // Scenario 1: Only table favorites (no schema favorite)
+      if (!isSchemaFavorited && favoriteTablesInSchema.length > 0) {
+        return this.createTableItems(favoriteTablesInSchema.map(ft => ft.tableName), schema, favoriteTablesInSchema.map(ft => ft.tableName));
       }
-
-      try {
-        // Fetch tables using the same method as ActivityBarConnectionsProvider
-        const tablesResponse = await this.getTablesSummary(schema.connectionName, schema.schemaName);
-        const tables = tablesResponse.tables || [];
-        
-        // Cache the results
-        this.tableCache.set(cacheKey, tables);
-        
-        return tables.map((tableName: string) => {
-          const table: FavoriteTable = {
-            name: tableName,
-            schema: schema.schemaName,
-            connectionName: schema.connectionName
-          };
-          return new FavoriteItem(
-            tableName,
-            vscode.TreeItemCollapsibleState.Collapsed,
-            table,
-            'favorite_table'
-          );
-        });
-      } catch (error) {
-        vscode.window.showErrorMessage(`Failed to get tables for ${schema.schemaName}: ${error}`);
-        return [];
+      
+      // Scenario 2 & 3: Schema is favorited (with or without table favorites)
+      if (isSchemaFavorited) {
+        return await this.getSchemaTablesWithFavorites(schema, favoriteTablesInSchema, cacheKey);
       }
+      
+      return [];
     }
 
     if (element.contextValue === 'favorite_table') {
@@ -250,7 +242,7 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
         const columns = this.columnsCache.get(cacheKey)!;
         return columns.map(column => {
           return new FavoriteItem(
-            `${column.name} (${column.type})`,
+            column.name,
             vscode.TreeItemCollapsibleState.None,
             column,
             'favorite_column'
@@ -268,7 +260,7 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
         
         return columns.map(column => {
           return new FavoriteItem(
-            `${column.name} (${column.type})`,
+            column.name,
             vscode.TreeItemCollapsibleState.None,
             column,
             'favorite_column'
@@ -281,6 +273,130 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
     }
 
     return [];
+  }
+
+  // Helper method to get schema tables with favorites prioritized
+  private async getSchemaTablesWithFavorites(schema: SchemaFavorite, favoriteTablesInSchema: TableFavorite[], cacheKey: string): Promise<FavoriteItem[]> {
+    // Check cache first
+    if (this.tableCache.has(cacheKey)) {
+      const allTables = this.tableCache.get(cacheKey)!;
+      const favoriteTableNames = favoriteTablesInSchema.map(ft => ft.tableName);
+      return this.createTableItems(allTables, schema, favoriteTableNames);
+    }
+
+    try {
+      // Fetch all tables from the database with retry logic
+      const tablesResponse = await this.getTablesWithRetry(schema.connectionName, schema.schemaName);
+      const allTables = tablesResponse.tables || [];
+      
+      // Cache the results
+      this.tableCache.set(cacheKey, allTables);
+      
+      const favoriteTableNames = favoriteTablesInSchema.map(ft => ft.tableName);
+      return this.createTableItems(allTables, schema, favoriteTableNames);
+    } catch (error) {
+      console.error(`Failed to get tables for ${schema.schemaName}:`, error);
+      
+      // If we have favorite tables, show them even if we can't get all tables
+      if (favoriteTablesInSchema.length > 0) {
+        const favoriteTableNames = favoriteTablesInSchema.map(ft => ft.tableName);
+        return this.createTableItems(favoriteTableNames, schema, favoriteTableNames);
+      }
+      
+      // Show error message but don't block the UI
+      vscode.window.showWarningMessage(`Database connection issue for ${schema.schemaName}. Showing cached data if available.`);
+      return [];
+    }
+  }
+
+  // Helper method with retry logic for database operations
+  private async getTablesWithRetry(connectionName: string, schemaName: string, maxRetries: number = 2): Promise<any> {
+    let lastError: any;
+    
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        if (attempt > 0) {
+          // Wait before retry (exponential backoff)
+          await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+        }
+        
+        return await this.getTablesSummary(connectionName, schemaName);
+      } catch (error) {
+        lastError = error;
+        console.warn(`Attempt ${attempt + 1} failed for ${connectionName}.${schemaName}:`, error);
+        
+        // If it's a connection issue, try again
+        if (this.isConnectionError(error)) {
+          continue;
+        }
+        
+        // If it's not a connection issue, don't retry
+        throw error;
+      }
+    }
+    
+    throw lastError;
+  }
+
+  // Helper method to check if error is connection-related
+  private isConnectionError(error: any): boolean {
+    const errorMessage = error?.message || error?.toString() || '';
+    const connectionErrorPatterns = [
+      'could not open database',
+      'connection refused',
+      'timeout',
+      'network error',
+      'connection lost',
+      'database/sql/driver'
+    ];
+    
+    return connectionErrorPatterns.some(pattern => 
+      errorMessage.toLowerCase().includes(pattern.toLowerCase())
+    );
+  }
+
+  // Helper method to create table items with favorites at top
+  private createTableItems(allTables: string[], schema: SchemaFavorite, favoriteTableNames: string[]): FavoriteItem[] {
+    const items: FavoriteItem[] = [];
+    const favoriteSet = new Set(favoriteTableNames);
+    
+    // Add favorite tables first with star icon
+    favoriteTableNames.forEach(tableName => {
+      if (allTables.includes(tableName)) {
+        const table: FavoriteTable = {
+          name: tableName,
+          schema: schema.schemaName,
+          connectionName: schema.connectionName
+        };
+        const favoriteTableItem = new FavoriteItem(
+          tableName,
+          vscode.TreeItemCollapsibleState.Collapsed,
+          table,
+          'favorite_table'
+        );
+        favoriteTableItem.iconPath = new vscode.ThemeIcon('star-full');
+        items.push(favoriteTableItem);
+      }
+    });
+    
+    // Add other tables (non-favorites)
+    allTables.forEach(tableName => {
+      if (!favoriteSet.has(tableName)) {
+        const table: FavoriteTable = {
+          name: tableName,
+          schema: schema.schemaName,
+          connectionName: schema.connectionName
+        };
+        items.push(new FavoriteItem(
+          tableName,
+          vscode.TreeItemCollapsibleState.Collapsed,
+          table,
+          'favorite_table'
+        ));
+      }
+    });
+    
+    return items;
   }
 
   private async getTablesSummary(connectionName: string, database: string): Promise<any> {

--- a/src/providers/FavoritesProvider.ts
+++ b/src/providers/FavoritesProvider.ts
@@ -1,6 +1,15 @@
-import * as vscode from 'vscode';
-import { getSchemaFavorites, saveSchemaFavorites, SchemaFavorite, createFavoriteKey, getTableFavorites, saveTableFavorites, TableFavorite, createTableFavoriteKey } from "../extension/configuration";
-import { BruinDBTCommand } from '../bruin/bruinDBTCommand';
+import * as vscode from "vscode";
+import {
+  getSchemaFavorites,
+  saveSchemaFavorites,
+  SchemaFavorite,
+  createFavoriteKey,
+  getTableFavorites,
+  saveTableFavorites,
+  TableFavorite,
+  createTableFavoriteKey,
+} from "../extension/configuration";
+import { BruinDBTCommand } from "../bruin/bruinDBTCommand";
 
 // Define interfaces for the hierarchical structure
 interface FavoriteConnection {
@@ -30,31 +39,45 @@ class FavoriteItem extends vscode.TreeItem {
     public readonly label: string,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
     public readonly itemData: FavoriteItemData,
-    public readonly contextValue: 'favorite_connection' | 'favorite_schema' | 'favorite_table' | 'favorite_column'
+    public readonly contextValue:
+      | "favorite_connection"
+      | "favorite_schema"
+      | "schema_with_table_favorites"
+      | "favorite_table"
+      | "favorite_table_starred"
+      | "favorite_column"
+      | "table"
   ) {
     super(label, collapsibleState);
     this.contextValue = contextValue;
-    
+
     // Set appropriate icons
-    if (this.contextValue === 'favorite_connection') {
-      this.iconPath = new vscode.ThemeIcon('plug');
+    if (this.contextValue === "favorite_connection") {
+      this.iconPath = new vscode.ThemeIcon("plug");
       this.tooltip = `Connection: ${label}`;
-    } else if (this.contextValue === 'favorite_schema') {
-      this.iconPath = new vscode.ThemeIcon('database');
+    } else if (
+      this.contextValue === "favorite_schema" ||
+      this.contextValue === "schema_with_table_favorites"
+    ) {
+      this.iconPath = new vscode.ThemeIcon("database");
       const schema = itemData as SchemaFavorite;
       this.tooltip = `${schema.connectionName}.${schema.schemaName}`;
-    } else if (this.contextValue === 'favorite_table') {
-      this.iconPath = new vscode.ThemeIcon('table');
+    } else if (
+      this.contextValue === "favorite_table" ||
+      this.contextValue === "favorite_table_starred" ||
+      this.contextValue === "table"
+    ) {
+      this.iconPath = new vscode.ThemeIcon("table");
       const table = itemData as FavoriteTable;
       this.tooltip = `${table.connectionName}.${table.schema}.${table.name}`;
       // Add command for table details
       this.command = {
-        command: 'bruin.showTableDetails',
-        title: 'Show Table Details',
-        arguments: [table.name, table.schema, table.connectionName]
+        command: "bruin.showTableDetails",
+        title: "Show Table Details",
+        arguments: [table.name, table.schema, table.connectionName],
       };
-    } else if (this.contextValue === 'favorite_column') {
-      this.iconPath = new vscode.ThemeIcon('symbol-field');
+    } else if (this.contextValue === "favorite_column") {
+      this.iconPath = new vscode.ThemeIcon("symbol-field");
       const column = itemData as FavoriteColumn;
       this.tooltip = `Column: ${column.name}, Type: ${column.type}`;
       this.description = column.type;
@@ -63,8 +86,10 @@ class FavoriteItem extends vscode.TreeItem {
 }
 
 export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> {
-  private _onDidChangeTreeData: vscode.EventEmitter<FavoriteItem | undefined | null | void> = new vscode.EventEmitter<FavoriteItem | undefined | null | void>();
-  readonly onDidChangeTreeData: vscode.Event<FavoriteItem | undefined | null | void> = this._onDidChangeTreeData.event;
+  private _onDidChangeTreeData: vscode.EventEmitter<FavoriteItem | undefined | null | void> =
+    new vscode.EventEmitter<FavoriteItem | undefined | null | void>();
+  readonly onDidChangeTreeData: vscode.Event<FavoriteItem | undefined | null | void> =
+    this._onDidChangeTreeData.event;
 
   private favorites: SchemaFavorite[] = [];
   private tableFavorites: TableFavorite[] = [];
@@ -73,7 +98,7 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
   private columnsCache = new Map<string, FavoriteColumn[]>(); // Cache for columns per table
 
   constructor() {
-    this.extensionPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
+    this.extensionPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || "";
     this.loadFavorites();
   }
 
@@ -91,20 +116,24 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
 
   public async removeFavorite(favorite: SchemaFavorite): Promise<void> {
     const favoriteKey = createFavoriteKey(favorite.schemaName, favorite.connectionName);
-    this.favorites = this.favorites.filter(f => 
-      createFavoriteKey(f.schemaName, f.connectionName) !== favoriteKey
+    this.favorites = this.favorites.filter(
+      (f) => createFavoriteKey(f.schemaName, f.connectionName) !== favoriteKey
     );
-    
+
     await saveSchemaFavorites(this.favorites);
     this._onDidChangeTreeData.fire();
   }
 
   public async removeTableFavorite(favorite: TableFavorite): Promise<void> {
-    const favoriteKey = createTableFavoriteKey(favorite.tableName, favorite.schemaName, favorite.connectionName);
-    this.tableFavorites = this.tableFavorites.filter(f => 
-      createTableFavoriteKey(f.tableName, f.schemaName, f.connectionName) !== favoriteKey
+    const favoriteKey = createTableFavoriteKey(
+      favorite.tableName,
+      favorite.schemaName,
+      favorite.connectionName
     );
-    
+    this.tableFavorites = this.tableFavorites.filter(
+      (f) => createTableFavoriteKey(f.tableName, f.schemaName, f.connectionName) !== favoriteKey
+    );
+
     await saveTableFavorites(this.tableFavorites);
     this._onDidChangeTreeData.fire();
   }
@@ -112,26 +141,26 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
   // Group favorites by connection name
   private groupFavoritesByConnection(): FavoriteConnection[] {
     const connectionMap = new Map<string, FavoriteConnection>();
-    
+
     // Add schema favorites
-    this.favorites.forEach(favorite => {
+    this.favorites.forEach((favorite) => {
       if (!connectionMap.has(favorite.connectionName)) {
         connectionMap.set(favorite.connectionName, {
           name: favorite.connectionName,
           schemas: [],
-          tables: []
+          tables: [],
         });
       }
       connectionMap.get(favorite.connectionName)!.schemas.push(favorite);
     });
 
     // Add table favorites
-    this.tableFavorites.forEach(favorite => {
+    this.tableFavorites.forEach((favorite) => {
       if (!connectionMap.has(favorite.connectionName)) {
         connectionMap.set(favorite.connectionName, {
           name: favorite.connectionName,
           schemas: [],
-          tables: []
+          tables: [],
         });
       }
       connectionMap.get(favorite.connectionName)!.tables.push(favorite);
@@ -148,122 +177,147 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
     if (!element) {
       // Root level - return connections grouped by connection name
       const groupedConnections = this.groupFavoritesByConnection();
-      return groupedConnections.map(connection => {
+      return groupedConnections.map((connection) => {
         return new FavoriteItem(
           connection.name,
           vscode.TreeItemCollapsibleState.Collapsed,
           connection,
-          'favorite_connection'
+          "favorite_connection"
         );
       });
     }
 
-    if (element.contextValue === 'favorite_connection') {
+    if (element.contextValue === "favorite_connection") {
       // Show schemas and tables under connection, grouped by schema
       const connection = element.itemData as FavoriteConnection;
       const items: FavoriteItem[] = [];
-      
+
       // Create a map to group items by schema
-      const schemaMap = new Map<string, { 
-        schema?: SchemaFavorite, 
-        tables: TableFavorite[] 
-      }>();
-      
+      const schemaMap = new Map<
+        string,
+        {
+          schema?: SchemaFavorite;
+          tables: TableFavorite[];
+        }
+      >();
+
       // Add schema favorites to the map
-      connection.schemas.forEach(schema => {
+      connection.schemas.forEach((schema) => {
         if (!schemaMap.has(schema.schemaName)) {
           schemaMap.set(schema.schemaName, { tables: [] });
         }
         schemaMap.get(schema.schemaName)!.schema = schema;
       });
-      
+
       // Add table favorites to the map, grouped by schema
-      connection.tables.forEach(table => {
+      connection.tables.forEach((table) => {
         if (!schemaMap.has(table.schemaName)) {
           schemaMap.set(table.schemaName, { tables: [] });
         }
         schemaMap.get(table.schemaName)!.tables.push(table);
       });
-      
+
       // Create items for each schema
       Array.from(schemaMap.entries()).forEach(([schemaName, schemaData]) => {
         const schemaItem: SchemaFavorite = schemaData.schema || {
           schemaName: schemaName,
-          connectionName: connection.name
+          connectionName: connection.name,
         };
-        
-        items.push(new FavoriteItem(
-          `${schemaName}`,
-          vscode.TreeItemCollapsibleState.Collapsed,
-          schemaItem,
-          'favorite_schema'
-        ));
+
+        // Determine context value based on whether schema is actually favorited
+        const isSchemaFavorited = schemaData.schema !== undefined;
+        const contextValue = isSchemaFavorited ? "favorite_schema" : "schema_with_table_favorites";
+
+        items.push(
+          new FavoriteItem(
+            `${schemaName}`,
+            vscode.TreeItemCollapsibleState.Collapsed,
+            schemaItem,
+            contextValue
+          )
+        );
       });
-      
+
       return items;
     }
 
-    if (element.contextValue === 'favorite_schema') {
+    if (
+      element.contextValue === "favorite_schema" ||
+      element.contextValue === "schema_with_table_favorites"
+    ) {
       const schema = element.itemData as SchemaFavorite;
       const cacheKey = `${schema.connectionName}.${schema.schemaName}`;
-      
+
       // Get favorite tables for this schema
-      const favoriteTablesInSchema = this.tableFavorites.filter(table => 
-        table.connectionName === schema.connectionName && 
-        table.schemaName === schema.schemaName
+      const favoriteTablesInSchema = this.tableFavorites.filter(
+        (table) =>
+          table.connectionName === schema.connectionName && table.schemaName === schema.schemaName
       );
-      
+
       // Check if this schema is actually favorited
-      const isSchemaFavorited = this.favorites.some(fav => 
-        fav.connectionName === schema.connectionName && 
-        fav.schemaName === schema.schemaName
+      const isSchemaFavorited = this.favorites.some(
+        (fav) =>
+          fav.connectionName === schema.connectionName && fav.schemaName === schema.schemaName
       );
-      
+
       // Scenario 1: Only table favorites (no schema favorite)
       if (!isSchemaFavorited && favoriteTablesInSchema.length > 0) {
-        return this.createTableItems(favoriteTablesInSchema.map(ft => ft.tableName), schema, favoriteTablesInSchema.map(ft => ft.tableName));
+        return this.createTableItems(
+          favoriteTablesInSchema.map((ft) => ft.tableName),
+          schema,
+          favoriteTablesInSchema.map((ft) => ft.tableName),
+          false // Schema is not favorited
+        );
       }
-      
+
       // Scenario 2 & 3: Schema is favorited (with or without table favorites)
       if (isSchemaFavorited) {
         return await this.getSchemaTablesWithFavorites(schema, favoriteTablesInSchema, cacheKey);
       }
-      
+
       return [];
     }
 
-    if (element.contextValue === 'favorite_table') {
+    if (
+      element.contextValue === "favorite_table" ||
+      element.contextValue === "favorite_table_starred" ||
+      element.contextValue === "table"
+    ) {
       // Show columns under table
       const table = element.itemData as FavoriteTable;
       const cacheKey = `${table.connectionName}.${table.schema}.${table.name}`;
-      
+
       // Check cache first
       if (this.columnsCache.has(cacheKey)) {
         const columns = this.columnsCache.get(cacheKey)!;
-        return columns.map(column => {
+        return columns.map((column) => {
           return new FavoriteItem(
             column.name,
             vscode.TreeItemCollapsibleState.None,
             column,
-            'favorite_column'
+            "favorite_column"
           );
         });
       }
 
       try {
         // Fetch columns using getFetchColumns method
-        const columnsResponse = await this.getColumnsSummary(table.connectionName, table.schema, table.name);
+        const columnsResponse = await this.getColumnsSummary(
+          table.connectionName,
+          table.schema,
+          table.name
+        );
         const columns = this.parseColumnsSummary(columnsResponse, table);
-        
+
         // Cache the results
         this.columnsCache.set(cacheKey, columns);
-        
-        return columns.map(column => {
+
+        return columns.map((column) => {
           return new FavoriteItem(
             column.name,
             vscode.TreeItemCollapsibleState.None,
             column,
-            'favorite_column'
+            "favorite_column"
           );
         });
       } catch (error) {
@@ -276,137 +330,161 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
   }
 
   // Helper method to get schema tables with favorites prioritized
-  private async getSchemaTablesWithFavorites(schema: SchemaFavorite, favoriteTablesInSchema: TableFavorite[], cacheKey: string): Promise<FavoriteItem[]> {
+  private async getSchemaTablesWithFavorites(
+    schema: SchemaFavorite,
+    favoriteTablesInSchema: TableFavorite[],
+    cacheKey: string
+  ): Promise<FavoriteItem[]> {
     // Check cache first
     if (this.tableCache.has(cacheKey)) {
       const allTables = this.tableCache.get(cacheKey)!;
-      const favoriteTableNames = favoriteTablesInSchema.map(ft => ft.tableName);
-      return this.createTableItems(allTables, schema, favoriteTableNames);
+      const favoriteTableNames = favoriteTablesInSchema.map((ft) => ft.tableName);
+      return this.createTableItems(allTables, schema, favoriteTableNames, true);
     }
 
     try {
       // Fetch all tables from the database with retry logic
-      const tablesResponse = await this.getTablesWithRetry(schema.connectionName, schema.schemaName);
+      const tablesResponse = await this.getTablesWithRetry(
+        schema.connectionName,
+        schema.schemaName
+      );
       const allTables = tablesResponse.tables || [];
-      
+
       // Cache the results
       this.tableCache.set(cacheKey, allTables);
-      
-      const favoriteTableNames = favoriteTablesInSchema.map(ft => ft.tableName);
-      return this.createTableItems(allTables, schema, favoriteTableNames);
+
+      const favoriteTableNames = favoriteTablesInSchema.map((ft) => ft.tableName);
+      return this.createTableItems(allTables, schema, favoriteTableNames, true);
     } catch (error) {
       console.error(`Failed to get tables for ${schema.schemaName}:`, error);
-      
+
       // If we have favorite tables, show them even if we can't get all tables
       if (favoriteTablesInSchema.length > 0) {
-        const favoriteTableNames = favoriteTablesInSchema.map(ft => ft.tableName);
-        return this.createTableItems(favoriteTableNames, schema, favoriteTableNames);
+        const favoriteTableNames = favoriteTablesInSchema.map((ft) => ft.tableName);
+        return this.createTableItems(favoriteTableNames, schema, favoriteTableNames, true);
       }
-      
+
       // Show error message but don't block the UI
-      vscode.window.showWarningMessage(`Database connection issue for ${schema.schemaName}. Showing cached data if available.`);
+      vscode.window.showWarningMessage(
+        `Database connection issue for ${schema.schemaName}. Showing cached data if available.`
+      );
       return [];
     }
   }
 
   // Helper method with retry logic for database operations
-  private async getTablesWithRetry(connectionName: string, schemaName: string, maxRetries: number = 2): Promise<any> {
+  private async getTablesWithRetry(
+    connectionName: string,
+    schemaName: string,
+    maxRetries: number = 2
+  ): Promise<any> {
     let lastError: any;
-    
+
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
         if (attempt > 0) {
           // Wait before retry (exponential backoff)
-          await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+          await new Promise((resolve) => setTimeout(resolve, Math.pow(2, attempt) * 1000));
         }
-        
+
         return await this.getTablesSummary(connectionName, schemaName);
       } catch (error) {
         lastError = error;
         console.warn(`Attempt ${attempt + 1} failed for ${connectionName}.${schemaName}:`, error);
-        
+
         // If it's a connection issue, try again
         if (this.isConnectionError(error)) {
           continue;
         }
-        
+
         // If it's not a connection issue, don't retry
         throw error;
       }
     }
-    
+
     throw lastError;
   }
 
   // Helper method to check if error is connection-related
   private isConnectionError(error: any): boolean {
-    const errorMessage = error?.message || error?.toString() || '';
+    const errorMessage = error?.message || error?.toString() || "";
     const connectionErrorPatterns = [
-      'could not open database',
-      'connection refused',
-      'timeout',
-      'network error',
-      'connection lost',
-      'database/sql/driver'
+      "could not open database",
+      "connection refused",
+      "timeout",
+      "network error",
+      "connection lost",
+      "database/sql/driver",
     ];
-    
-    return connectionErrorPatterns.some(pattern => 
+
+    return connectionErrorPatterns.some((pattern) =>
       errorMessage.toLowerCase().includes(pattern.toLowerCase())
     );
   }
 
   // Helper method to create table items with favorites at top
-  private createTableItems(allTables: string[], schema: SchemaFavorite, favoriteTableNames: string[]): FavoriteItem[] {
+  private createTableItems(
+    allTables: string[],
+    schema: SchemaFavorite,
+    favoriteTableNames: string[],
+    isSchemaFavorited: boolean = true
+  ): FavoriteItem[] {
     const items: FavoriteItem[] = [];
     const favoriteSet = new Set(favoriteTableNames);
-    
-    // Add favorite tables first with star icon
-    favoriteTableNames.forEach(tableName => {
+
+    // Add favorite tables first with appropriate context
+    favoriteTableNames.forEach((tableName) => {
       if (allTables.includes(tableName)) {
         const table: FavoriteTable = {
           name: tableName,
           schema: schema.schemaName,
-          connectionName: schema.connectionName
+          connectionName: schema.connectionName,
         };
+        // Use starred context only if schema is also favorited
+        const contextValue = isSchemaFavorited ? "favorite_table_starred" : "favorite_table";
         const favoriteTableItem = new FavoriteItem(
           tableName,
           vscode.TreeItemCollapsibleState.Collapsed,
           table,
-          'favorite_table'
+          contextValue
         );
-        favoriteTableItem.iconPath = new vscode.ThemeIcon('star-full');
         items.push(favoriteTableItem);
       }
     });
-    
-    // Add other tables (non-favorites)
-    allTables.forEach(tableName => {
-      if (!favoriteSet.has(tableName)) {
-        const table: FavoriteTable = {
-          name: tableName,
-          schema: schema.schemaName,
-          connectionName: schema.connectionName
-        };
-        items.push(new FavoriteItem(
-          tableName,
-          vscode.TreeItemCollapsibleState.Collapsed,
-          table,
-          'favorite_table'
-        ));
-      }
-    });
-    
+
+    // Add other tables (non-favorites) only if schema is favorited
+    if (isSchemaFavorited) {
+      allTables.forEach((tableName) => {
+        if (!favoriteSet.has(tableName)) {
+          const table: FavoriteTable = {
+            name: tableName,
+            schema: schema.schemaName,
+            connectionName: schema.connectionName,
+          };
+          items.push(
+            new FavoriteItem(tableName, vscode.TreeItemCollapsibleState.Collapsed, table, "table")
+          );
+        }
+      });
+    }
+
     return items;
   }
 
   private async getTablesSummary(connectionName: string, database: string): Promise<any> {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || this.extensionPath;
+    const workspaceFolder =
+      vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || this.extensionPath;
     const command = new BruinDBTCommand("bruin", workspaceFolder);
     return command.getFetchTables(connectionName, database);
   }
 
-  private async getColumnsSummary(connectionName: string, database: string, table: string): Promise<any> {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || this.extensionPath;
+  private async getColumnsSummary(
+    connectionName: string,
+    database: string,
+    table: string
+  ): Promise<any> {
+    const workspaceFolder =
+      vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || this.extensionPath;
     const command = new BruinDBTCommand("bruin", workspaceFolder);
     return command.getFetchColumns(connectionName, database, table);
   }
@@ -415,27 +493,29 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
     const columnsArray = Array.isArray(summary) ? summary : summary?.columns;
 
     if (!Array.isArray(columnsArray)) {
-      throw new Error("Invalid columns summary format: not an array or object with a 'columns' property.");
+      throw new Error(
+        "Invalid columns summary format: not an array or object with a 'columns' property."
+      );
     }
 
-    return columnsArray.map(item => {
-      if (typeof item === 'string') {
+    return columnsArray.map((item) => {
+      if (typeof item === "string") {
         return {
           name: item,
-          type: 'unknown',
+          type: "unknown",
           table: table.name,
           schema: table.schema,
-          connectionName: table.connectionName
+          connectionName: table.connectionName,
         };
       }
-      
+
       return {
-        name: item.name || item.column_name || 'Unknown Column',
-        type: item.type || item.data_type || 'unknown',
+        name: item.name || item.column_name || "Unknown Column",
+        type: item.type || item.data_type || "unknown",
         table: table.name,
         schema: table.schema,
-        connectionName: table.connectionName
+        connectionName: table.connectionName,
       };
     });
   }
-} 
+}

--- a/src/providers/FavoritesProvider.ts
+++ b/src/providers/FavoritesProvider.ts
@@ -81,7 +81,7 @@ class FavoriteItem extends vscode.TreeItem {
       this.command = {
         command: "bruin.showTableDetails",
         title: "Show Table Details",
-        arguments: [table.name, table.schema, table.connectionName],
+        arguments: [table.name, table.schema, table.connectionName, table.environment],
       };
     } else if (this.contextValue === "favorite_column") {
       this.iconPath = new vscode.ThemeIcon("symbol-field");

--- a/src/providers/FavoritesProvider.ts
+++ b/src/providers/FavoritesProvider.ts
@@ -1,17 +1,50 @@
 import * as vscode from 'vscode';
 import { getSchemaFavorites, saveSchemaFavorites, SchemaFavorite, createFavoriteKey } from "../extension/configuration";
+import { BruinDBTCommand } from '../bruin/bruinDBTCommand';
+
+// Define interfaces for the hierarchical structure
+interface FavoriteConnection {
+  name: string;
+  schemas: SchemaFavorite[];
+}
+
+interface FavoriteTable {
+  name: string;
+  schema: string;
+  connectionName: string;
+}
+
+type FavoriteItemData = FavoriteConnection | SchemaFavorite | FavoriteTable;
 
 class FavoriteItem extends vscode.TreeItem {
   constructor(
     public readonly label: string,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-    public readonly favorite: SchemaFavorite,
-    public readonly contextValue: string = 'favorite'
+    public readonly itemData: FavoriteItemData,
+    public readonly contextValue: 'favorite_connection' | 'favorite_schema' | 'favorite_table'
   ) {
     super(label, collapsibleState);
     this.contextValue = contextValue;
-    this.iconPath = new vscode.ThemeIcon('star-full');
-    this.tooltip = `${favorite.connectionName}.${favorite.schemaName}`;
+    
+    // Set appropriate icons
+    if (this.contextValue === 'favorite_connection') {
+      this.iconPath = new vscode.ThemeIcon('plug');
+      this.tooltip = `Connection: ${label}`;
+    } else if (this.contextValue === 'favorite_schema') {
+      this.iconPath = new vscode.ThemeIcon('database');
+      const schema = itemData as SchemaFavorite;
+      this.tooltip = `${schema.connectionName}.${schema.schemaName}`;
+    } else if (this.contextValue === 'favorite_table') {
+      this.iconPath = new vscode.ThemeIcon('table');
+      const table = itemData as FavoriteTable;
+      this.tooltip = `${table.connectionName}.${table.schema}.${table.name}`;
+      // Add command for table details
+      this.command = {
+        command: 'bruin.showTableDetails',
+        title: 'Show Table Details',
+        arguments: [table.name, table.schema, table.connectionName]
+      };
+    }
   }
 }
 
@@ -20,8 +53,11 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
   readonly onDidChangeTreeData: vscode.Event<FavoriteItem | undefined | null | void> = this._onDidChangeTreeData.event;
 
   private favorites: SchemaFavorite[] = [];
+  private extensionPath: string;
+  private tableCache = new Map<string, string[]>(); // Cache for tables per schema
 
   constructor() {
+    this.extensionPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
     this.loadFavorites();
   }
 
@@ -30,6 +66,7 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
   }
 
   public refresh(): void {
+    this.tableCache.clear();
     this.loadFavorites();
     this._onDidChangeTreeData.fire();
   }
@@ -44,24 +81,110 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> 
     this._onDidChangeTreeData.fire();
   }
 
+  // Group favorites by connection name
+  private groupFavoritesByConnection(): FavoriteConnection[] {
+    const connectionMap = new Map<string, SchemaFavorite[]>();
+    
+    this.favorites.forEach(favorite => {
+      if (!connectionMap.has(favorite.connectionName)) {
+        connectionMap.set(favorite.connectionName, []);
+      }
+      connectionMap.get(favorite.connectionName)!.push(favorite);
+    });
+
+    return Array.from(connectionMap.entries()).map(([connectionName, schemas]) => ({
+      name: connectionName,
+      schemas: schemas
+    }));
+  }
+
   getTreeItem(element: FavoriteItem): vscode.TreeItem {
     return element;
   }
 
-  getChildren(element?: FavoriteItem): Thenable<FavoriteItem[]> {
+  async getChildren(element?: FavoriteItem): Promise<FavoriteItem[]> {
     if (!element) {
-      // Root level - return all favorites
-      return Promise.resolve(this.favorites.map(favorite => {
-        const displayName = `${favorite.schemaName} (${favorite.connectionName})`;
+      // Root level - return connections grouped by connection name
+      const groupedConnections = this.groupFavoritesByConnection();
+      return groupedConnections.map(connection => {
         return new FavoriteItem(
-          displayName,
-          vscode.TreeItemCollapsibleState.None,
-          favorite,
-          'favorite'
+          connection.name,
+          vscode.TreeItemCollapsibleState.Collapsed,
+          connection,
+          'favorite_connection'
         );
-      }));
+      });
     }
-    
-    return Promise.resolve([]);
+
+    if (element.contextValue === 'favorite_connection') {
+      // Show schemas under connection
+      const connection = element.itemData as FavoriteConnection;
+      return connection.schemas.map(schema => {
+        return new FavoriteItem(
+          schema.schemaName,
+          vscode.TreeItemCollapsibleState.Collapsed,
+          schema,
+          'favorite_schema'
+        );
+      });
+    }
+
+    if (element.contextValue === 'favorite_schema') {
+      // Show tables under schema
+      const schema = element.itemData as SchemaFavorite;
+      const cacheKey = `${schema.connectionName}.${schema.schemaName}`;
+      
+      // Check cache first
+      if (this.tableCache.has(cacheKey)) {
+        const tables = this.tableCache.get(cacheKey)!;
+        return tables.map(tableName => {
+          const table: FavoriteTable = {
+            name: tableName,
+            schema: schema.schemaName,
+            connectionName: schema.connectionName
+          };
+          return new FavoriteItem(
+            tableName,
+            vscode.TreeItemCollapsibleState.None,
+            table,
+            'favorite_table'
+          );
+        });
+      }
+
+      try {
+        // Fetch tables using the same method as ActivityBarConnectionsProvider
+        const tablesResponse = await this.getTablesSummary(schema.connectionName, schema.schemaName);
+        const tables = tablesResponse.tables || [];
+        
+        // Cache the results
+        this.tableCache.set(cacheKey, tables);
+        
+        return tables.map((tableName: string) => {
+          const table: FavoriteTable = {
+            name: tableName,
+            schema: schema.schemaName,
+            connectionName: schema.connectionName
+          };
+          return new FavoriteItem(
+            tableName,
+            vscode.TreeItemCollapsibleState.None,
+            table,
+            'favorite_table'
+          );
+        });
+      } catch (error) {
+        vscode.window.showErrorMessage(`Failed to get tables for ${schema.schemaName}: ${error}`);
+        return [];
+      }
+    }
+
+    return [];
+  }
+
+  private async getTablesSummary(connectionName: string, database: string): Promise<any> {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || this.extensionPath;
+    const command = new BruinDBTCommand("bruin", workspaceFolder);
+    return command.getFetchTables(connectionName, database);
   }
 } 

--- a/src/providers/FavoritesProvider.ts
+++ b/src/providers/FavoritesProvider.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+import { getSchemaFavorites, saveSchemaFavorites, SchemaFavorite, createFavoriteKey } from "../extension/configuration";
+
+class FavoriteItem extends vscode.TreeItem {
+  constructor(
+    public readonly label: string,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly favorite: SchemaFavorite,
+    public readonly contextValue: string = 'favorite'
+  ) {
+    super(label, collapsibleState);
+    this.contextValue = contextValue;
+    this.iconPath = new vscode.ThemeIcon('star-full');
+    this.tooltip = `${favorite.connectionName}.${favorite.schemaName}`;
+  }
+}
+
+export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteItem> {
+  private _onDidChangeTreeData: vscode.EventEmitter<FavoriteItem | undefined | null | void> = new vscode.EventEmitter<FavoriteItem | undefined | null | void>();
+  readonly onDidChangeTreeData: vscode.Event<FavoriteItem | undefined | null | void> = this._onDidChangeTreeData.event;
+
+  private favorites: SchemaFavorite[] = [];
+
+  constructor() {
+    this.loadFavorites();
+  }
+
+  private loadFavorites(): void {
+    this.favorites = getSchemaFavorites();
+  }
+
+  public refresh(): void {
+    this.loadFavorites();
+    this._onDidChangeTreeData.fire();
+  }
+
+  public async removeFavorite(favorite: SchemaFavorite): Promise<void> {
+    const favoriteKey = createFavoriteKey(favorite.schemaName, favorite.connectionName);
+    this.favorites = this.favorites.filter(f => 
+      createFavoriteKey(f.schemaName, f.connectionName) !== favoriteKey
+    );
+    
+    await saveSchemaFavorites(this.favorites);
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: FavoriteItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: FavoriteItem): Thenable<FavoriteItem[]> {
+    if (!element) {
+      // Root level - return all favorites
+      return Promise.resolve(this.favorites.map(favorite => {
+        const displayName = `${favorite.schemaName} (${favorite.connectionName})`;
+        return new FavoriteItem(
+          displayName,
+          vscode.TreeItemCollapsibleState.None,
+          favorite,
+          'favorite'
+        );
+      }));
+    }
+    
+    return Promise.resolve([]);
+  }
+} 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -5297,9 +5297,9 @@ suite(" Query export Tests", () => {
       sinon.restore();
     });
 
-    test("getDbSummary should call run with correct flags", async () => {
+    test("getFetchDatabases should call run with correct flags", async () => {
       const { BruinDBTCommand } = require("../bruin/bruinDBTCommand");
-      const mockResult = '{"schemas": [{"name": "public", "tables": ["users", "orders"]}]}';
+      const mockResult = '{"databases": ["db1", "db2"]}';
       
       runStub.resolves(mockResult);
       
@@ -5307,13 +5307,13 @@ suite(" Query export Tests", () => {
       
       const instanceRunStub = sinon.stub(command, "run").resolves(mockResult);
       
-      const result = await command.getDbSummary("test-connection");
+      const result = await command.getFetchDatabases("test-connection");
       
       assert.ok(instanceRunStub.calledOnce, "run method should be called once");
       assert.deepStrictEqual(
         instanceRunStub.firstCall.args[0], 
-        ["db-summary", "--connection", "test-connection", "-o", "json"],
-        "Should call run with correct db-summary flags"
+        ["fetch-databases", "-c", "test-connection", "-o", "json"],
+        "Should call run with correct fetch-databases flags"
       );
       assert.deepStrictEqual(
         instanceRunStub.firstCall.args[1],
@@ -5499,7 +5499,7 @@ suite(" Query export Tests", () => {
         });
 
         const BruinDBTCommandStub = sinon.stub().returns({
-          getDbSummary: sinon.stub().resolves(mockDbSummary)
+          getFetchDatabases: sinon.stub().resolves(mockDbSummary)
         });
 
         const originalBruinConnections = require("../bruin/bruinConnections").BruinConnections;
@@ -5574,7 +5574,7 @@ suite(" Query export Tests", () => {
         });
 
         const BruinDBTCommandStub = sinon.stub().returns({
-          getDbSummary: sinon.stub().resolves(mockDbSummary)
+          getFetchDatabases: sinon.stub().resolves(mockDbSummary)
         });
 
         const originalBruinConnections = require("../bruin/bruinConnections").BruinConnections;

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -5758,7 +5758,7 @@ suite(" Query export Tests", () => {
         assert.ok(usersTableItem, "Should find users table");
         
         // Verify table properties
-        assert.strictEqual(usersTableItem.contextValue, 'table', "Table should have correct context value");
+        assert.strictEqual(usersTableItem.contextValue, 'table_unfavorite', "Table should have correct context value");
         assert.strictEqual(usersTableItem.collapsibleState, 1, "Table should be collapsible"); // TreeItemCollapsibleState.Collapsed = 1
         
         // Verify command is set correctly
@@ -5839,7 +5839,7 @@ suite(" Query export Tests", () => {
 
         // Check table item properties
         const tableItem = tableItems[0];
-        assert.strictEqual(tableItem.contextValue, 'table', "Table should have correct context value");
+        assert.strictEqual(tableItem.contextValue, 'table_unfavorite', "Table should have correct context value");
         assert.ok(tableItem.iconPath, "Table should have icon");
         assert.strictEqual(tableItem.collapsibleState, 1, "Table should be collapsible"); // TreeItemCollapsibleState.Collapsed = 1
 
@@ -5857,8 +5857,8 @@ suite(" Query export Tests", () => {
         assert.ok(orderHistoryItem, "Should find order_history table");
         
         // Verify both tables have correct context and command
-        assert.strictEqual(customerDataItem.contextValue, 'table', "customer_data should have table context");
-        assert.strictEqual(orderHistoryItem.contextValue, 'table', "order_history should have table context");
+        assert.strictEqual(customerDataItem.contextValue, 'table_unfavorite', "customer_data should have table context");
+        assert.strictEqual(orderHistoryItem.contextValue, 'table_unfavorite', "order_history should have table context");
         
         assert.ok(customerDataItem.command, "customer_data should have command");
         assert.ok(orderHistoryItem.command, "order_history should have command");


### PR DESCRIPTION
## Pull Request Summary

### Changes

- **Refactored Loading Logic in Activity Bar**  
  The previous loading mechanism has been fully replaced. New dedicated methods have been introduced:  
  - `fetchDatabases()`  
  - `fetchTables()`  
  - `fetchColumns()`  

- **Introduced a New TreeView: `Favorites`**  
  A separate TreeView named `Favorites` has been added to allow users quick access to their preferred schemas and tables.

### Favorites Functionality

- Favoriting behavior is now context-sensitive and handled independently for databases and tables:
  - **Database favorited** → Only the database name is saved in settings. When rendering the Favorites TreeView, all tables under that database are fetched dynamically.
  - **Table favorited** → The table name, along with its database and connection info, is saved in settings.
  - **Both database and a table within it favorited** → All tables under the database are displayed, but favorited tables appear at the top of the list.
  
 The changes may seem more, i used to prettier


![image](https://github.com/user-attachments/assets/6c668657-ae08-4a1e-a09a-a65a239868f8)
![image](https://github.com/user-attachments/assets/d5643d5e-cdce-400c-b03e-7b139369be54)

