### PR TITLE
Fix Inline Preview Query to Use Limit 

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -378,7 +378,13 @@ export async function activate(context: ExtensionContext) {
           tabId: activeTabId,
         });
         await QueryPreviewPanel.focusSafely();
-        await getQueryOutput("", "", uri, activeTabId); 
+        
+        // Send message to webview to execute query with current limit
+        QueryPreviewPanel.postMessage("bruin.executePreviewQuery", { 
+          status: "success",
+          message: "",
+          tabId: activeTabId
+        }); 
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`Error running query: ${errorMessage}`);

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -587,6 +587,21 @@ window.addEventListener("message", (event) => {
       expandedCells.value = new Set(state.expandedCells || []);
       showSearchInput.value = state.showSearchInput || false;
     }
+  } else if (message.command === "bruin.executePreviewQuery") {
+    // Handle preview intellisense query execution with current limit
+    const tabId = message.payload.tabId || activeTab.value;
+    const selectedEnvironment = currentEnvironment.value;
+    
+    // Send query execution request with current limit from UI
+    vscode.postMessage({
+      command: "bruin.getQueryOutput",
+      payload: {
+        environment: selectedEnvironment,
+        limit: limit.value.toString(),
+        query: "",
+        tabId: tabId,
+      },
+    });
   }
 
   // Handle tab-specific query results


### PR DESCRIPTION
# Ovreview 

The inline query preview wasn’t respecting the limit set in the input. This PR fixes that — now both the Run Query button and the IntelliSense preview use the user-defined limit correctly.

