### PR TITLE
Column level lineage2

### DIFF
--- a/bruinPythonAsset.py
+++ b/bruinPythonAsset.py
@@ -1,0 +1,7 @@
+""" @bruin 
+name: example
+ type: python
+ depends:
+ - raw.example
+"""
+print("Hello World")

--- a/example.txt
+++ b/example.txt
@@ -1,0 +1,1 @@
+print("Hello World")

--- a/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
+++ b/webview-ui/src/components/lineage-flow/asset-lineage/AssetLineage.vue
@@ -35,6 +35,7 @@
           @node-click="onNodeClick"
           :selected-node-id="selectedNodeId"
           :show-expand-buttons="filterType === 'direct'"
+          :show-columns="filterType === 'column'"
         />
       </template>
       
@@ -72,6 +73,10 @@
             </vscode-radio>
               <vscode-radio value="direct" class="radio-item" @click="handleDirectFilter">
                 <span class="radio-label text-editor-fg">Direct Dependencies</span>
+              </vscode-radio>
+
+              <vscode-radio value="column" class="radio-item" @click="handleColumnFilter">
+                <span class="radio-label text-editor-fg">Column Level Lineage</span>
               </vscode-radio>
 
               <vscode-radio value="all" class="radio-item" @click="handleAllFilter">
@@ -171,7 +176,7 @@ const isLayouting = ref(false);
 const error = ref<string | null>(props.LineageError);
 
 // Filter state
-const filterType = ref<"direct" | "all">("direct");
+const filterType = ref<"direct" | "all" | "column">("direct");
 const expandAllDownstreams = ref(false);
 const expandAllUpstreams = ref(false);
 const expandedNodes = ref<{ [key: string]: boolean }>({});
@@ -182,6 +187,7 @@ const elk = new ELK();
 // Computed properties for performance
 const filterLabel = computed(() => {
   if (filterType.value === "direct") return "Direct Dependencies";
+  if (filterType.value === "column") return "Column Level Lineage";
   if (expandAllUpstreams.value && expandAllDownstreams.value) return "All Dependencies";
   if (expandAllDownstreams.value) return "All Downstreams";
   return "All Upstreams";
@@ -214,6 +220,11 @@ const allUpstreamAssets = computed(() => {
 // Computed graph data based on current filter
 const currentGraphData = computed(() => {
   if (filterType.value === "direct") {
+    return baseGraphData.value;
+  }
+  
+  if (filterType.value === "column") {
+    // Column level lineage logic will be implemented here
     return baseGraphData.value;
   }
   
@@ -562,6 +573,16 @@ const handleAllFilter = (event: Event) => {
   filterType.value = "all";
   expandAllUpstreams.value = true;
   expandAllDownstreams.value = true;
+  // updateGraph will be called automatically via watcher
+};
+
+const handleColumnFilter = (event: Event) => {
+  event.stopPropagation();
+  filterType.value = "column";
+  expandAllUpstreams.value = false;
+  expandAllDownstreams.value = false;
+  // Clear expansion state when switching to column level lineage
+  expandedNodes.value = {};
   // updateGraph will be called automatically via watcher
 };
 

--- a/webview-ui/src/components/lineage-flow/column-lineage/ColumnLineage.vue
+++ b/webview-ui/src/components/lineage-flow/column-lineage/ColumnLineage.vue
@@ -1,0 +1,225 @@
+<template>
+  <div class="flow">
+    <div v-if="isLayouting" class="loading-overlay">
+      <vscode-progress-ring></vscode-progress-ring>
+      <span class="ml-2">Positioning graph...</span>
+    </div>
+    
+    <VueFlow
+      v-if="!isLayouting"
+      v-model:elements="elements"
+      :fit-view-on-init="false"
+      class="basic-flow"
+      :draggable="true"
+      :node-draggable="true"
+      @nodesDragged="onNodesDragged"
+      ref="flowRef"
+    >
+      <Background />
+
+      <template #node-custom="nodeProps">
+        <CustomNode
+          :expanded-nodes="{}"
+          :data="nodeProps.data"
+          :node-props="nodeProps"
+          :label="nodeProps.data.label"
+          :show-expand-buttons="false"
+          :show-columns="true"
+        />
+      </template>
+      
+      <!-- Filter Panel -->
+      <Panel position="top-right">
+        <div class="navigation-controls">
+          <vscode-button
+            @click="handleViewSwitch"
+            appearance="secondary"
+            class="view-switch-btn"
+          >
+            Asset View
+          </vscode-button>
+        </div>
+      </Panel>
+
+      <Controls
+        :position="PanelPosition.BottomLeft"
+        showZoom
+        showFitView
+        showInteractive
+        class="custom-controls"
+      />
+    </VueFlow>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, nextTick, computed, defineProps, defineEmits } from "vue";
+import { Panel, PanelPosition, VueFlow, useVueFlow } from "@vue-flow/core";
+import { Background } from "@vue-flow/background";
+import { Controls } from "@vue-flow/controls";
+import "@vue-flow/controls/dist/style.css";
+import type { NodeDragEvent, XYPosition } from "@vue-flow/core";
+import ELK from "elkjs/lib/elk.bundled.js";
+import CustomNode from "@/components/lineage-flow/custom-nodes/CustomNodes.vue";
+
+const props = defineProps<{
+  graphData: { nodes: any[]; edges: any[] };
+}>();
+
+const emit = defineEmits(['change-view']);
+
+const { nodes, edges, setNodes, setEdges, fitView } = useVueFlow();
+const elements = computed(() => [...nodes.value, ...edges.value]);
+const isLayouting = ref(false);
+const flowRef = ref(null);
+const elk = new ELK();
+
+const handleViewSwitch = () => {
+  emit('change-view', 'direct');
+};
+
+const applyLayout = async (inputNodes?: any[], inputEdges?: any[]) => {
+  const nodesToLayout = inputNodes || nodes.value;
+  const edgesToLayout = inputEdges || edges.value;
+  
+  if (nodesToLayout.length === 0) return { nodes: [], edges: [] };
+  
+  const elkGraph = {
+    id: "root",
+    layoutOptions: {
+      "elk.algorithm": "layered",
+      "elk.direction": "RIGHT",
+      "elk.layered.spacing.nodeNodeBetweenLayers": "150",
+      "elk.spacing.nodeNode": "50",
+      "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
+      "elk.layered.nodePlacement.bk.fixedAlignment": "BALANCED",
+      "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
+      "elk.layered.cycleBreaking.strategy": "DEPTH_FIRST",
+      "elk.layered.layering.strategy": "NETWORK_SIMPLEX",
+      "elk.layered.considerModelOrder.strategy": "PREFER_NODES",
+      "elk.layered.crossingMinimization.semiInteractive": "true",
+      "elk.layered.unnecessaryBendpoints": "true",
+    },
+    children: nodesToLayout.map((node) => {
+      const columns = node.data.asset.columns || [];
+      const baseHeight = 70; 
+      const heightPerColumn = 15;
+      const newHeight = baseHeight + columns.length * heightPerColumn;
+
+      return {
+        id: node.id,
+        width: 150,
+        height: newHeight,
+        labels: [{ text: node.data.label }],
+      };
+    }),
+    edges: edgesToLayout.map((edge) => ({
+      id: edge.id,
+      sources: [edge.source],
+      targets: [edge.target],
+    })),
+  };
+
+  try {
+    const layout = await elk.layout(elkGraph);
+    
+    if (layout.children && layout.children.length) {
+      const layoutedNodes = nodesToLayout.map((node) => {
+        const layoutNode = layout.children?.find((child: any) => child.id === node.id);
+        return layoutNode
+          ? {
+              ...node,
+              position: {
+                x: layoutNode.x ?? 0,
+                y: layoutNode.y ?? 0,
+              },
+              zIndex: 1,
+            }
+          : node;
+      });
+      
+      return { nodes: layoutedNodes, edges: edgesToLayout };
+    }
+  } catch (error) {
+    console.error("Failed to apply ELK layout:", error);
+  }
+  
+  return { nodes: nodesToLayout, edges: edgesToLayout };
+};
+
+const updateGraph = async () => {
+  isLayouting.value = true;
+  
+  try {
+    if (props.graphData.nodes.length > 0) {
+      const layoutedGraphData = await applyLayout(props.graphData.nodes, props.graphData.edges);
+      
+      setNodes(layoutedGraphData.nodes);
+      setEdges(layoutedGraphData.edges);
+      
+      await nextTick();
+      isLayouting.value = false;
+      
+      await nextTick();
+      fitView({ padding: 0.2, duration: 300 });
+    } else {
+      setNodes([]);
+      setEdges([]);
+      isLayouting.value = false;
+    }
+  } catch (error) {
+    console.error("Error updating graph:", error);
+    isLayouting.value = false;
+  }
+};
+
+const onNodesDragged = (draggedNodes: NodeDragEvent[]) => {
+  setNodes(
+    nodes.value.map((node) => {
+      const draggedNode = draggedNodes.find((n) => n.node.id === node.id);
+      return draggedNode ? { ...node, position: draggedNode.node.position as XYPosition } : node;
+    })
+  );
+};
+
+watch(() => props.graphData, () => {
+  updateGraph();
+}, { deep: true, immediate: true });
+
+</script>
+
+<style scoped>
+@import "@vue-flow/core/dist/style.css";
+@import "@vue-flow/core/dist/theme-default.css";
+
+.flow {
+  @apply flex h-screen w-full p-0 !important;
+}
+
+.vue-flow__controls {
+  bottom: 1rem !important;
+  left: 1rem !important;
+  top: auto !important;
+  right: auto !important;
+  background-color: transparent !important;
+  display: flex !important;
+  flex-direction: row !important;
+  gap: 0.3rem;
+}
+
+.vue-flow__controls-button {
+  @apply flex justify-center items-center p-0 border-solid border-notificationCenter-border bg-transparent rounded-md w-6 h-6 cursor-pointer hover:bg-editor-bg  !important;
+}
+
+.vue-flow__controls-button svg {
+  @apply fill-current text-editor-fg !important;
+}
+
+.custom-controls .vue-flow__controls-button:hover {
+  background-color: #444 !important;
+}
+
+.loading-overlay, .error-message {
+  @apply flex items-center justify-center w-full h-full bg-editor-bg;
+}
+</style> 

--- a/webview-ui/src/components/lineage-flow/column-lineage/useColumnLineage.ts
+++ b/webview-ui/src/components/lineage-flow/column-lineage/useColumnLineage.ts
@@ -1,0 +1,55 @@
+import { ref, onUnmounted } from "vue";
+import { vscode } from "@/utilities/vscode";
+import { generateGraphWithColumnData } from "@/utilities/graphGenerator";
+
+export function useColumnLineage() {
+  const columnLineageData = ref<any>(null);
+  const isLoadingColumnLineage = ref(false);
+  const columnLineageError = ref<string | null>(null);
+  const graphData = ref<{ nodes: any[]; edges: any[] }>({ nodes: [], edges: [] });
+
+  const fetchColumnLineageData = async () => {
+    try {
+      isLoadingColumnLineage.value = true;
+      columnLineageError.value = null;
+      vscode.postMessage({
+        command: "bruin.getColumnLineage",
+        payload: {},
+      });
+    } catch (error: any) {
+      console.error("Error requesting column lineage:", error);
+      columnLineageError.value = error.message || "Failed to fetch column lineage";
+      isLoadingColumnLineage.value = false;
+    }
+  };
+
+  const handleMessage = (event: MessageEvent) => {
+    const message = event.data;
+    if (message.command === "column-lineage-message") {
+      isLoadingColumnLineage.value = false;
+      if (message.payload.status === "success") {
+        columnLineageData.value = message.payload.message;
+        columnLineageError.value = null;
+        graphData.value = generateGraphWithColumnData(columnLineageData.value);
+      } else {
+        columnLineageError.value = message.payload.message;
+        columnLineageData.value = null;
+        graphData.value = { nodes: [], edges: [] };
+      }
+    }
+  };
+
+  window.addEventListener("message", handleMessage);
+
+  onUnmounted(() => {
+    window.removeEventListener("message", handleMessage);
+  });
+
+  return {
+    columnLineageData,
+    isLoadingColumnLineage,
+    columnLineageError,
+    graphData,
+    fetchColumnLineageData,
+  };
+} 

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodes.vue
@@ -62,31 +62,41 @@
         </div>
 
         <!-- Columns Section -->
-        <div v-if="showColumns" class="columns-section border border-white/20 border-t-0 rounded-b bg-editor-bg p-3">
-          <div class="text-xs font-semibold text-editor-fg mb-3 opacity-70 flex items-center">
-            <span>Columns</span>
-            <span v-if="nodeColumns && nodeColumns.length > 0" class="ml-1 text-2xs opacity-50">({{ nodeColumns.length }})</span>
+        <div v-if="showColumns" class="columns-section border border-white/20 border-t-0 rounded-b p-2" :class="selectedStyle.main">
+          <div class="text-xs font-semibold mb-2 opacity-70 flex items-center justify-between px-1 cursor-pointer" @click.stop="toggleColumnsExpanded">
+            <div class="flex items-center">
+              <span>Columns</span>
+              <span v-if="nodeColumns && nodeColumns.length > 0" class="ml-1 text-2xs opacity-50">({{ nodeColumns.length }})</span>
+            </div>
+            <div class="transform transition-transform duration-200" :class="{ 'rotate-180': columnsExpanded }">
+              <svg class="w-3 h-3 opacity-60" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+              </svg>
+            </div>
           </div>
-          <div v-if="nodeColumns && nodeColumns.length > 0" class="space-y-1.5 max-h-96 overflow-y-auto">
-            <div 
-              v-for="(column, index) in nodeColumns" 
-              :key="index"
-              class="flex items-center text-xs py-1.5 px-2 rounded hover:bg-input-background transition-colors"
-            >
-              <div class="w-2.5 h-2.5 rounded-full mr-3 flex-shrink-0 shadow-sm" :class="getColumnTypeColor(column.type)"></div>
-              <div class="flex-1 min-w-0">
-                <div class="font-medium text-editor-fg truncate">{{ column.name }}</div>
-                <div class="text-2xs text-editor-fg opacity-60 mt-0.5">{{ column.type }}</div>
-              </div>
-              <div v-if="column.primary_key" class="ml-2 flex-shrink-0">
-                <div class="w-3.5 h-3.5 rounded bg-yellow-500 flex items-center justify-center">
-                  <span class="text-white text-2xs font-bold">K</span>
+          <div v-if="columnsExpanded" class="transition-all duration-200 ease-in-out">
+            <div v-if="nodeColumns && nodeColumns.length > 0" class="space-y-1 max-h-96 overflow-y-auto">
+              <div 
+                v-for="(column, index) in nodeColumns" 
+                :key="index"
+                class="flex items-center text-xs py-1 px-2 rounded border border-white/10 transition-colors font-mono"
+                :class="selectedStyle.main"
+              >
+                <div class="w-2 h-2 rounded-full mr-2 flex-shrink-0" :class="getColumnTypeColor(column.type)"></div>
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium truncate">{{ column.name }}</div>
+                </div>
+                <div class="text-2xs opacity-60 ml-2 flex-shrink-0">{{ column.type }}</div>
+                <div v-if="column.primary_key" class="ml-2 flex-shrink-0">
+                  <div class="w-3 h-3 rounded bg-yellow-500 flex items-center justify-center">
+                    <span class="text-white text-2xs font-bold">K</span>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div v-else class="text-xs text-editor-fg opacity-50 italic px-2">
-            No columns defined
+            <div v-else class="text-xs opacity-50 italic px-2 font-mono">
+              No columns defined
+            </div>
           </div>
         </div>
       </div>
@@ -149,6 +159,8 @@ const props = defineProps<BruinNodeProps & {
 }>();
 const emit = defineEmits(["add-upstream", "add-downstream", "node-click", "toggle-node-expand"]);
 
+const columnsExpanded = ref(false);
+
 const selectedStyle = computed(() => styles[props.data?.asset?.type || "default"] || defaultStyle);
 const selectedStatusStyle = computed(() => statusStyles[props.status || ""]);
 const isAsset = computed(() => props.data.type === "asset");
@@ -202,10 +214,8 @@ const nodeColumns = computed(() => {
 
 
 const getColumnTypeColor = (type: string) => {
-  // Node tipine göre uyumlu renkler kullan - daha koyu tonlar için 600/700 seviyesi
   const assetType = props.data.asset?.type || 'default';
   
-  // Node label rengine uyumlu column renkleri (daha parlak ve görünür)
   const assetTypeColors: { [key: string]: string } = {
     'bq.sql': 'bg-sky-600',
     'external': 'bg-rose-600', 
@@ -263,6 +273,10 @@ const truncatedLabel = computed(() => {
 
 const toggleExpand = () => {
   emit("toggle-node-expand", props.data.asset?.name);
+};
+
+const toggleColumnsExpanded = () => {
+  columnsExpanded.value = !columnsExpanded.value;
 };
 
 const handleClickOutside = (event) => {

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -42,6 +42,7 @@ export interface Asset {
   hasDownstreams: boolean;
   isFocusAsset?: boolean;
   definition_file?: {path: string};
+  columns?: Array<{ name: string; type: string; primary_key?: boolean; upstreams?: Array<{ table: string; column: string }> }>;
 }
 
 export interface Project {

--- a/webview-ui/src/utilities/getPipelineLineage.ts
+++ b/webview-ui/src/utilities/getPipelineLineage.ts
@@ -19,6 +19,8 @@ export const parsePipelineData = (pipelineJson): PipelineAssets => {
       id: asset.id,
       name: asset.name,
       type: asset.type,
+      pipeline: asset.pipeline || '',
+      path: asset.path || '',
       upstreams: [],
       downstream: [],
     };

--- a/webview-ui/src/utilities/graphGenerator.ts
+++ b/webview-ui/src/utilities/graphGenerator.ts
@@ -79,3 +79,74 @@ export function generateGraphForDownstream(nodeName: string, pipelineData: any) 
     isFocusAsset: false,
   });
 }
+
+
+export const generateGraphWithColumnData = (columnData: any) => {
+  // Create nodes with column information from the column lineage data
+  const asset = columnData.asset;
+  const nodes: any[] = [];
+  const edges: any[] = [];
+  
+  // Create main asset node with columns - using same structure as generateGraphFromJSON
+  const mainNode = {
+    id: asset.name,
+    type: 'custom',
+    position: { x: 0, y: 0 },
+    data: {
+      label: asset.name,
+      type: 'asset',
+      asset: {
+        name: asset.name,
+        type: asset.type || "unknown",
+        pipeline: asset.pipeline || "unknown",
+        path: asset.definition_file?.path || asset.path || "unknown",
+        columns: asset.columns || [],
+        isFocusAsset: true,
+        hasUpstreams: asset.upstreams?.length > 0,
+        hasDownstreams: false
+      },
+      hasUpstreamForClicking: false,
+      hasDownstreamForClicking: false
+    }
+  };
+  nodes.push(mainNode);
+  
+  // Create upstream nodes with their columns - using same structure
+  if (asset.upstreams) {
+    asset.upstreams.forEach((upstream: any, index: number) => {
+      const upstreamNode = {
+        id: upstream.value,
+        type: 'custom',
+        position: { x: -300, y: index * 150 },
+        data: {
+          label: upstream.value,
+          type: 'asset',
+          asset: {
+            name: upstream.value,
+            type: upstream.type || "asset",
+            pipeline: asset.pipeline || "unknown",
+            path: "unknown",
+            columns: upstream.columns || [],
+            isFocusAsset: false,
+            hasUpstreams: false,
+            hasDownstreams: true
+          },
+          hasUpstreamForClicking: false,
+          hasDownstreamForClicking: false
+        }
+      };
+      nodes.push(upstreamNode);
+      
+      // Create edge
+      const edge = {
+        id: `${upstream.value}-${asset.name}`,
+        source: upstream.value,
+        target: asset.name,
+        type: 'default'
+      };
+      edges.push(edge);
+    });
+  }
+  
+  return { nodes, edges };
+};


### PR DESCRIPTION
<img width="800" height="753" alt="image" src="https://github.com/user-attachments/assets/b96ff3eb-513c-4dd6-ad8a-26c855547bfd" />
 Add Column-Level Lineage with Hover Effect


Implemented bruin internal parse-asset -c command support for retrieving column-level lineage.

Columns can now be matched with their corresponding upstream columns.

 Added hover effect to visualize column dependencies clearly.