### PR TITLE
Fix single-query detection bug in multi-query SQL files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [0.58.7] - [2025-07-15]
+- Fixed the query preview for the first query in multiple queries file.
+
 ## [0.58.6] - [2025-07-15]
 - Fixed the query preview code lens. 
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 ### Recent Update
+- **0.58.7**: Fixed the query preview for the first query in multiple queries file.
 - **0.58.6**: Fixed the query preview code lens. 
 - **0.58.5**: Recovered the partition by and cluster ui and fixed the columns actions being hidden.
 - **0.58.4**: Enhanced the environment management UI with delete and update actions.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.58.6",
+  "version": "0.58.7",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/providers/queryCodeLensProvider.ts
+++ b/src/providers/queryCodeLensProvider.ts
@@ -38,7 +38,7 @@ export class QueryCodeLensProvider implements vscode.CodeLensProvider {
     // This regex finds statements that end with semicolon or end of file
     const statements = this.parseStatements(maskedText);
 
-    for (const statement of statements) {
+    for (const [idx, statement] of statements.entries()) {
       if (token.isCancellationRequested) {
         return codeLenses;
       }
@@ -69,17 +69,13 @@ export class QueryCodeLensProvider implements vscode.CodeLensProvider {
       const statementText = statement.text;
       const lines = statementText.split('\n');
       let sqlStartLine = 0;
-      
       for (let i = 0; i < lines.length; i++) {
         const trimmedLine = lines[i].trim();
-        
         if (trimmedLine && !trimmedLine.startsWith('--') && !(trimmedLine.startsWith('/*') && trimmedLine.endsWith('*/'))) {
-          // Found the first non-comment line
           sqlStartLine = i;
           break;
         }
       }
-      
       // Calculate the position in the document
       const statementStartPos = document.positionAt(statement.startOffset);
       const sqlStartPos = new vscode.Position(statementStartPos.line + sqlStartLine, 0);
@@ -91,7 +87,7 @@ export class QueryCodeLensProvider implements vscode.CodeLensProvider {
         new vscode.CodeLens(queryRange, {
           title: "Preview",
           command: "bruin.runQuery",
-          arguments: [document.uri, queryRange, isAsset, codeLenses.length + 1, statement.text],
+          arguments: [document.uri, queryRange, isAsset, statements.length, statement.text],
         })
       );
     }


### PR DESCRIPTION
# PR Overview
 
This PR fixes an issue where, in files containing multiple SQL queries, only the first query was treated as if it were the only one in the file.