### PR TITLE
Support extracted query from selection or full document for non-asset files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
+## [0.59.3] - [2025-07-24]
+- Updated query extraction logic for non-asset files and added pagination to the query preview.
+
 ## [0.59.2] - [2025-07-24]
-- Display CodeLens only when selection starts outside Bruin block.
+- Displayed CodeLens only when selection starts outside Bruin block.
 
 ## [0.59.1] - [2025-07-23]
-- Add highlighing to the column level lineage view.
+- Added highlighting to the column level lineage view.
 
 ## [0.59.0] - [2025-07-23]
 - Added column level lineage view.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 ### Recent Update
+- **0.59.3**: Updated query extraction logic for non-asset files and added pagination to the query preview.
 - **0.59.2**: Display CodeLens only when selection starts outside Bruin block.
 - **0.59.1**: Add highlighing to the column level lineage view.
 - **0.59.0**: Added column level lineage view.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.59.2",
+  "version": "0.59.3",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -3239,15 +3239,26 @@ suite(" Query export Tests", () => {
       getQueryOutputStub = sinon.stub();
       exportQueryResultsStub = sinon.stub();
       
+      // Mock VSCode workspace methods
+      const mockDocument = {
+        getText: sinon.stub().returns("SELECT * FROM test_table"),
+      };
+      sinon.stub(vscode.workspace, "openTextDocument").resolves(mockDocument as any);
+      
       // Mock the module imports
       const queryCommandsModule = {
         getQueryOutput: getQueryOutputStub,
         exportQueryResults: exportQueryResultsStub,
       };
       
+      const helperUtilsModule = {
+        isBruinSqlAsset: sinon.stub().resolves(false),
+      };
+      
       // Use proxyquire to mock the imports
       const QueryPreviewPanelModule = proxyquire("../panels/QueryPreviewPanel", {
         "../extension/commands/queryCommands": queryCommandsModule,
+        "../utilities/helperUtils": helperUtilsModule,
       });
 
       queryPreviewPanel = new QueryPreviewPanelModule.QueryPreviewPanel(mockExtensionUri, mockExtensionContext);

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -259,14 +259,14 @@
               </thead>
               <tbody>
                 <tr
-                  v-for="(row, index) in currentTab.filteredRows"
-                  :key="index"
+                  v-for="(row, index) in paginatedRows"
+                  :key="(currentPage - 1) * pageSize + index"
                   class="hover:bg-menu-hoverBackground transition-colors duration-150"
                 >
                   <td
                     class="p-1 opacity-50 text-editor-fg font-mono border border-commandCenter-border"
                   >
-                    {{ index + 1 }}
+                    {{ (currentPage - 1) * pageSize + index + 1 }}
                   </td>
                   <td
                     v-for="(value, colIndex) in row"
@@ -321,6 +321,21 @@
                 </tr>
               </tbody>
             </table>
+            <div v-if="totalPages > 1" class="flex justify-center items-center my-2 gap-2">
+              <button @click="currentPage = 1" :disabled="currentPage === 1" title="First Page">
+                <span class="codicon codicon-chevron-double-left"></span>
+              </button>
+              <button @click="currentPage--" :disabled="currentPage === 1" title="Previous Page">
+                <span class="codicon codicon-chevron-left"></span>
+              </button>
+              <span>Page {{ currentPage }} of {{ totalPages }}</span>
+              <button @click="currentPage++" :disabled="currentPage === totalPages" title="Next Page">
+                <span class="codicon codicon-chevron-right"></span>
+              </button>
+              <button @click="currentPage = totalPages" :disabled="currentPage === totalPages" title="Last Page">
+                <span class="codicon codicon-chevron-double-right"></span>
+              </button>
+            </div>
           </div>
         </div>
       </template>
@@ -339,6 +354,7 @@ import {
   nextTick,
   shallowRef,
   triggerRef,
+  reactive,
 } from "vue";
 import { TableCellsIcon } from "@heroicons/vue/24/outline";
 import { vscode } from "@/utilities/vscode";
@@ -365,6 +381,7 @@ const hoveredTab = ref("");
 const copied = ref(false);
 // State for expanded cells
 const expandedCells = ref(new Set<string>());
+
 const defaultTab = {
   id: "tab-1",
   label: "Tab 1",
@@ -1101,6 +1118,25 @@ const formatCellValue = (value) => {
   }
   return { text: value, isNull: false };
 };
+
+const pageSize = 50;
+const currentPage = ref(1);
+
+const totalRows = computed(() => currentTab.value?.filteredRows?.length || 0);
+const totalPages = computed(() => Math.ceil(totalRows.value / pageSize));
+
+const paginatedRows = computed(() => {
+  if (!currentTab.value?.filteredRows) return [];
+  const start = (currentPage.value - 1) * pageSize;
+  return currentTab.value.filteredRows.slice(start, start + pageSize);
+});
+
+watch(
+  () => currentTab.value?.filteredRows,
+  () => {
+    currentPage.value = 1;
+  }
+);
 </script>
 
 <style scoped>


### PR DESCRIPTION
# PR Overview
This PR updates query extraction logic for non-asset files to use the selected text if available, or fall back to the entire document content.
Also adds pagination to the `QueryPreview` component, including basic navigation controls to handle multi-result queries.
