### PR TITLE
Improve QueryPreview Panel Initialization and Configuration Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.62.5] - [2025-08-06]
+- Added a setting to toggle the inline “Preview Selected Query” CodeLens on or off.
+
 ## [0.62.4] - [2025-08-06]
 - Added custom checks completions and improved the indentation issues.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 ### Recent Update
+- **0.62.5**: Added a setting to toggle the inline “Preview Selected Query” CodeLens on or off.
 - **0.62.4**: Added custom checks completions and improved the indentation issues.
 - **0.62.3**: Improved the column property completions and fixed materialization validation.
 - **0.62.2**: Implemented preview functionality for queries within custom checks.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.62.4",
+  "version": "0.62.5",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/package.json
+++ b/package.json
@@ -212,6 +212,11 @@
           "default": [],
           "description": "List of favorite tables with their schema and connection names."
         },
+        "bruin.query.previewSelectedQuery.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show 'Preview selected query' CodeLens when text is selected in SQL files"
+        },
         "bruin.query.timeout": {
           "type": "number",
           "default": 1000,

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -29,6 +29,11 @@ export function getQueryTimeout(): number {
   return config.get<number>("timeout", 1000); // Default to 1000 seconds
 }
 
+export function isPreviewSelectedQueryEnabled(): boolean {
+  const config = vscode.workspace.getConfiguration("bruin.query");
+  return config.get<boolean>("previewSelectedQuery.enabled", true); // Default to enabled
+}
+
 let documentInitState = new Map();
 
 export async function toggleFoldingsCommand(toggled: boolean): Promise<void> {
@@ -129,10 +134,13 @@ function resetDocumentStates(): void {
  * default folding state is changed.
  @returns void
 */
-export function subscribeToConfigurationChanges() {
+export function subscribeToConfigurationChanges(onPreviewSelectionSettingChange?: () => void) {
   vscode.workspace.onDidChangeConfiguration((e) => {
     if (e.affectsConfiguration("bruin.FoldingState")) {
       resetDocumentStates();
+    }
+    if (e.affectsConfiguration("bruin.query.previewSelectedQuery.enabled") && onPreviewSelectionSettingChange) {
+      onPreviewSelectionSettingChange();
     }
   });
 }

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -622,6 +622,11 @@ window.addEventListener("message", (event) => {
       expandedCells.value = new Set(state.expandedCells || []);
       showSearchInput.value = state.showSearchInput || false;
     }
+  } else if (message.command === "init") {
+    // When webview becomes visible again (e.g., switching back from terminal)
+    // Re-request the saved state to restore the UI
+    vscode.postMessage({ command: "bruin.requestState" });
+    vscode.postMessage({ command: "bruin.requestTimeout" });
   } else if (message.command === "bruin.timeoutResponse") {
     if (message.payload && typeof message.payload.timeout === "number") {
       queryTimeout.value = message.payload.timeout;


### PR DESCRIPTION
# PR Overview
This PR improves the `QueryPreview` feature by restoring UI state on panel visibility and adding configurability for the preview selected query behavior.

### Key Updates:
* Fix a problem in the query panel and restore the previous UI state when the panel becomes visible again.
* Introduced a configuration option to enable/disable the **“Preview selected query”** inline codelens feature.
* Updated CodeLens provider registration logic to respect the new configuration setting.
* Updated the changelog and README.
<img width="553" height="382" alt="Screenshot 2025-08-06 at 16 17 12" src="https://github.com/user-attachments/assets/1f64e970-b1d6-4d6b-ad0b-7956f96b98e7" />

![disable-selected-query-preview](https://github.com/user-attachments/assets/4c728ce0-8447-455a-a5c4-23505bcdd883)
