### PR TITLE
Improve/update cli experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.62.6] - [2025-08-06]
+- Prevent the terminal from closing after CLI installation and update.
+
 ## [0.62.5] - [2025-08-06]
 - Added a setting to toggle the inline “Preview Selected Query” CodeLens on or off.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 ### Recent Update
+- **0.62.6**: Prevent the terminal from closing after CLI installation and update.
 - **0.62.5**: Added a setting to toggle the inline “Preview Selected Query” CodeLens on or off.
 - **0.62.4**: Added custom checks completions and improved the indentation issues.
 - **0.62.3**: Improved the column property completions and fixed materialization validation.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.62.5",
+  "version": "0.62.6",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/bruin/bruinInstallCli.ts
+++ b/src/bruin/bruinInstallCli.ts
@@ -36,7 +36,7 @@ export class BruinInstallCLI {
       reveal: vscode.TaskRevealKind.Always,
       panel: vscode.TaskPanelKind.Shared,
       showReuseMessage: true,
-      close: true,
+      close: false,
     };
   
     return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
# PR Overview 
Previously, when a user clicked the “Update CLI” button, the extension launched a terminal task, closed the terminal automatically after it completed, and then updated the UI status. This made it unclear whether the update actually succeeded or failed.

This PR changes that behaviour by keeping the terminal open after the update or install runs, allowing users to see the update output and understand what happened.
