### PR TITLE
Improve first-time activation experience and add settings-only mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -472,13 +472,16 @@
         "when": "editorTextFocus && editorHasSelection && resourceExtname == .sql"
       }
     ],
+    "welcomePage": {
+      "walkthrough": "bruin.bruin-getting-started"
+    },
     "walkthroughs": [
       {
         "id": "bruin-getting-started",
         "title": "Getting Started with Bruin",
         "description": "Learn the essential features and keyboard shortcuts to be productive with Bruin",
         "primary": true,
-        "when": "workspaceFolderCount == 0 || workspaceFolderCount > 0",
+        "featured": true,
         "steps": [
           {
             "id": "keyboard-shortcuts",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "publisher": "bruin",
   "activationEvents": [
+    "*",
     "workspaceContains:.bruin.yml",
     "workspaceContains:pipeline.yml"
   ],
@@ -455,6 +456,12 @@
         "category": "Bruin",
         "icon": "$(play)",
         "description": "Preview the selected SQL query in the Query Preview panel."
+      },
+      {
+        "command": "bruin.showWalkthrough",
+        "title": "Show Getting Started Walkthrough",
+        "category": "Bruin",
+        "description": "Show the Bruin getting started walkthrough."
       }
     ],
     "keybindings": [
@@ -470,6 +477,8 @@
         "id": "bruin-getting-started",
         "title": "Getting Started with Bruin",
         "description": "Learn the essential features and keyboard shortcuts to be productive with Bruin",
+        "primary": true,
+        "when": "workspaceFolderCount == 0 || workspaceFolderCount > 0",
         "steps": [
           {
             "id": "keyboard-shortcuts",

--- a/src/extension/commands/renderCommand.ts
+++ b/src/extension/commands/renderCommand.ts
@@ -9,20 +9,24 @@ export const renderCommand = async (extensionUri: vscode.Uri) => {
   BruinPanel.render(extensionUri);
 
   const activeEditor = vscode.window.activeTextEditor;
+  
+  // Always render the panel
+  BruinPanel.render(extensionUri);
+  
   if (activeEditor) {
+    // Normal file rendering when there's an active editor
     const bruinSqlRenderer = new BruinRender(
       getBruinExecutablePath(),
       vscode.workspace.workspaceFolders?.[0].uri.fsPath!!
     );
 
     const filePath = activeEditor.document.fileName;
-
     await bruinSqlRenderer.render(filePath);
   } else {
-    // When no active editor, show a message in the panel that no file is open
-    BruinPanel.postMessage("render-message", {
-      status: "no-file",
-      message: "Create a Bruin asset file or a bruin pipeline from a template"
+    // Settings-only mode when no active editor
+    BruinPanel.postMessage("settings-only-mode", {
+      status: "success",
+      message: "Showing settings only"
     });
   }
 };

--- a/src/extension/commands/renderCommand.ts
+++ b/src/extension/commands/renderCommand.ts
@@ -5,10 +5,11 @@ import { prepareFlags } from "../../utilities/helperUtils";
 import { getBruinExecutablePath } from "../../providers/BruinExecutableService";
 
 export const renderCommand = async (extensionUri: vscode.Uri) => {
+  // Always render the panel, even if no active editor
+  BruinPanel.render(extensionUri);
+
   const activeEditor = vscode.window.activeTextEditor;
   if (activeEditor) {
-    BruinPanel.render(extensionUri);
-
     const bruinSqlRenderer = new BruinRender(
       getBruinExecutablePath(),
       vscode.workspace.workspaceFolders?.[0].uri.fsPath!!
@@ -17,6 +18,12 @@ export const renderCommand = async (extensionUri: vscode.Uri) => {
     const filePath = activeEditor.document.fileName;
 
     await bruinSqlRenderer.render(filePath);
+  } else {
+    // When no active editor, show a message in the panel that no file is open
+    BruinPanel.postMessage("render-message", {
+      status: "no-file",
+      message: "Create a Bruin asset file or a bruin pipeline from a template"
+    });
   }
 };
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -121,7 +121,9 @@ export async function activate(context: ExtensionContext) {
   const startTime = Date.now();
   console.time("Bruin Activation Total");
   
-
+  // Check if this is first time activation
+  const isFirstActivation = !context.globalState.get('bruin.hasActivated', false);
+  
   // Initialize TableDetailsPanel
   TableDetailsPanel.initialize(context.subscriptions);
 
@@ -624,6 +626,15 @@ export async function activate(context: ExtensionContext) {
         vscode.window.showErrorMessage(`Error triggering completions: ${errorMessage}`);
       }
     }),
+    commands.registerCommand("bruin.showWalkthrough", async () => {
+      try {
+        trackEvent("Command Executed", { command: "showWalkthrough" });
+        await vscode.commands.executeCommand('workbench.action.openWalkthrough', 'bruin.bruin-getting-started');
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error showing walkthrough: ${errorMessage}`);
+      }
+    }),
   ];
 
   context.subscriptions.push(...commandDisposables);
@@ -635,6 +646,14 @@ export async function activate(context: ExtensionContext) {
   const activationTime = Date.now() - startTime;
   console.debug(`Bruin activated successfully in ${activationTime}ms`);
   console.timeEnd("Bruin Activation Total");
+
+  // Show walkthrough on first activation
+  if (isFirstActivation) {
+    await context.globalState.update('bruin.hasActivated', true);
+    setTimeout(() => {
+      vscode.commands.executeCommand('workbench.action.openWalkthrough', 'bruin.bruin-getting-started');
+    }, 1000);
+  }
 
   TableDetailsPanel.initialize(context.subscriptions);
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -650,9 +650,19 @@ export async function activate(context: ExtensionContext) {
   // Show walkthrough on first activation
   if (isFirstActivation) {
     await context.globalState.update('bruin.hasActivated', true);
+    
+    // Show walkthrough when extension is first installed
+    // Use a longer delay to ensure VS Code is fully loaded
     setTimeout(() => {
-      vscode.commands.executeCommand('workbench.action.openWalkthrough', 'bruin.bruin-getting-started');
-    }, 1000);
+      vscode.commands.executeCommand('workbench.action.openWalkthrough', 'bruin.bruin-getting-started', true);
+    }, 3000);
+    
+    // Also show immediately if welcome tab is active
+    if (vscode.window.tabGroups.activeTabGroup.activeTab?.label === 'Welcome') {
+      setTimeout(() => {
+        vscode.commands.executeCommand('workbench.action.openWalkthrough', 'bruin.bruin-getting-started', true);
+      }, 500);
+    }
   }
 
   TableDetailsPanel.initialize(context.subscriptions);

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -224,12 +224,12 @@ export class BruinPanel {
    * @param extensionUri The URI of the directory containing the extension.
    */
   public static render(extensionUri: Uri) {
-    const column = window.activeTextEditor ? ViewColumn.Beside : undefined;
+    const column = window.activeTextEditor ? ViewColumn.Beside : ViewColumn.One;
 
     if (this.currentPanel) {
       this.currentPanel._panel.reveal(column, true);
     } else {
-      const panel = window.createWebviewPanel(this.viewId, "Bruin", column || ViewColumn.Active, {
+      const panel = window.createWebviewPanel(this.viewId, "Bruin", column, {
         enableScripts: true,
         retainContextWhenHidden: true,
         localResourceRoots: [

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -371,6 +371,7 @@ export class BruinPanel {
         ? this._lastRenderedDocumentUri.fsPath
         : null,
       checkboxState: this._checkboxState,
+      settingsOnlyMode: !window.activeTextEditor,
     });
 
     webview.onDidReceiveMessage(

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -166,7 +166,8 @@ const handleMessage = (event: MessageEvent) => {
   try {
     switch (message.command) {
       case "init":
-        lastRenderedDocument.value = message.lastRenderedDocument; 
+        lastRenderedDocument.value = message.lastRenderedDocument;
+        settingsOnlyMode.value = message.settingsOnlyMode || false;
         break;
       case "environments-list-message":
         environments.value = updateValue(message, "success");
@@ -294,6 +295,10 @@ const handleMessage = (event: MessageEvent) => {
         break;
       case "file-changed":
         lastRenderedDocument.value = message.filePath;
+        settingsOnlyMode.value = false; // Reset when file changes
+        break;
+      case "settings-only-mode":
+        settingsOnlyMode.value = true;
         break;
     }
   } catch (error) {
@@ -311,6 +316,7 @@ const showConvertMessage = ref(false);
 const nonAssetFileType = ref("");
 const nonAssetFilePath = ref("");
 const activeTab = ref(0); // Tracks the currently active tab
+const settingsOnlyMode = ref(false); // Tracks if we're in settings-only mode
 
 // Computed property to parse the list of environments
 const environmentsList = computed(() => {
@@ -530,6 +536,7 @@ const tabs = ref([
       isBruinInstalled: computed(() => isBruinInstalled.value),
       environments: computed(() => environmentsList.value),
       versionStatus: computed(() => versionStatus.value),
+      settingsOnlyMode: computed(() => settingsOnlyMode.value),
     },
   },
 ]);
@@ -540,6 +547,12 @@ const visibleTabs = computed(() => {
   if (isBruinInstalled.value === null || isBruinInstalled.value === false) {
     console.log("CLI status unknown or not installed, showing no tabs.");
     return [];
+  }
+  
+  // If in settings-only mode, show only Settings tab
+  if (settingsOnlyMode.value) {
+    console.log("Settings-only mode, showing only Settings tab.");
+    return tabs.value.filter((tab) => tab.label === "Settings");
   }
   
   if (isBruinYml.value) {

--- a/webview-ui/src/components/bruin-settings/BruinSettings.vue
+++ b/webview-ui/src/components/bruin-settings/BruinSettings.vue
@@ -4,9 +4,8 @@
       <BruinCLI :versionStatus="versionStatus" />
     </div>
 
-    <div class="bg-editorWidget-bg shadow sm:rounded-lg">
+    <div v-if="isBruinInstalled && !settingsOnlyMode" class="bg-editorWidget-bg shadow sm:rounded-lg">
       <ConnectionsList
-        v-if="isBruinInstalled"
         :connections="connections"
         @new-connection="showConnectionForm"
         @edit-connection="showConnectionForm"
@@ -73,7 +72,7 @@
 
     
 
-    <div v-if="showForm" class="mt-6 bg-editorWidget-bg shadow sm:rounded-lg p-6" ref="formRef">
+    <div v-if="showForm && !settingsOnlyMode" class="mt-6 bg-editorWidget-bg shadow sm:rounded-lg p-6" ref="formRef">
       <ConnectionForm
         :key="connectionFormKey"
         :connection="connectionToEdit"
@@ -86,7 +85,7 @@
     </div>
 
     <DeleteAlert
-      v-if="showDeleteAlert"
+      v-if="showDeleteAlert && !settingsOnlyMode"
       title="Delete Connection"
       :message="`Are you sure you want to delete the connection ${connectionToDelete?.name}? This action cannot be undone.`"
       confirm-text="Delete"
@@ -95,7 +94,7 @@
     />
 
     <DeleteAlert
-      v-if="showEnvironmentDeleteAlert"
+      v-if="showEnvironmentDeleteAlert && !settingsOnlyMode"
       title="Delete Environment"
       :message="`Are you sure you want to delete environment '${environmentToDelete}'? This action cannot be undone.`"
       confirm-text="Delete"
@@ -119,6 +118,10 @@ const props = defineProps({
   isBruinInstalled: Boolean,
   environments: Array,
   versionStatus: Object,
+  settingsOnlyMode: {
+    type: Boolean,
+    default: false
+  },
 });
 
 const connectionsStore = useConnectionsStore();
@@ -152,8 +155,12 @@ const connectionFormKey = computed(() => {
 
 onMounted(() => {
   window.addEventListener("message", handleMessage);
-  vscode.postMessage({ command: "bruin.getConnectionsList" });
-  vscode.postMessage({ command: "bruin.getConnectionsSchema" });
+  
+  // Only load connections data if not in settings-only mode
+  if (!props.settingsOnlyMode) {
+    vscode.postMessage({ command: "bruin.getConnectionsList" });
+    vscode.postMessage({ command: "bruin.getConnectionsSchema" });
+  }
   
   // Load templates if Bruin is installed
   if (props.isBruinInstalled) {


### PR DESCRIPTION
# PR Overview
This PR enhances the Bruin extension's onboarding and UI flexibility with the following updates:

* **Walkthrough page configuration**
  * Configured a welcome page entry to help guide first-time users.

* **Settings-only mode**
  * Implemented `settings-only` mode in `App.vue` and `BruinSettings.vue` to control UI behavior and limit data loading when no active editor is present.
  * Enhanced `renderCommand` logic to support this mode seamlessly.
![walktrough-and-activation](https://github.com/user-attachments/assets/407bcf46-1a84-41a0-8eb4-6ac89c5a94f3)
