### PR TITLE
Fix Live SQL Preview Without Full Panel Re-render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.64.7] - [2025-08-21]
+- Fixed the SQL preview rendering issue.
+
 ## [0.64.6] - [2025-08-21]
 - Updated the environment list command to create bruin.yml if it does not already exist.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 ### Recent Update
+- **0.64.7**: Fixed the SQL preview rendering issue.
 - **0.64.6**: Updated the environment list command to create bruin.yml if it does not already exist.
 - **0.64.5**: Improved the .bruin.yml file handling to only show settings tab and fixed the convert message flickering issue.
 - **0.64.4**: Fixed the checkbox and dates state persisting issue.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.64.6",
+  "version": "0.64.7",
   "engines": {
     "vscode": "^1.87.0"
   },


### PR DESCRIPTION
# PR Overview 

This PR introduces a **SQL-only render** to improve live SQL preview responsiveness without requiring a full panel re-render.

### Key Changes
* Added a render with flags for **SQL previews** that updates in-place on text changes.
* Updated `renderCommandWithFlags` to reuse current checkbox flags and the active file path.
* Preserved `_handleAssetDetection` logic to avoid conflicts with asset detection.
* Bumped version to `0.64.7` and updated **CHANGELOG** + **README**.
