### PR TITLE
Fix Environment Handling in Query Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.67.3] - [2025-09-26]
+- Fixed the query preview panel environment display issue.
+
 ## [0.67.2] - [2025-09-16]
 - Improved connection test ui.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 ### Recent Update
+- **0.67.3**: Fixed the query preview panel environment display issue.
 - **0.67.2**: Improved connection test ui.
 - **0.67.1**: Allow YAML assets to be rendered.
 - **0.67.0**: Added a "Create in-place" checkbox to the project creation UI, allowing projects to be created directly in the selected folder.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.67.2",
+  "version": "0.67.3",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -988,7 +988,6 @@ export class BruinPanel {
           case "bruin.refocusActiveEditor":
             if (window.activeTextEditor && this._lastRenderedDocumentUri) {
               await this._handleAssetDetection(this._lastRenderedDocumentUri);
-              getEnvListCommand(this._lastRenderedDocumentUri);
             }
             break;
         }

--- a/webview-ui/src/QueryPreviewApp.vue
+++ b/webview-ui/src/QueryPreviewApp.vue
@@ -50,18 +50,18 @@ const handleMessage = (event) => {
       } else {
         QueryOutput.value = updateValue(message, "success");
         triggerRef(QueryOutput);
-        console.log("QueryOutput.value inside message handler", QueryOutput.value);
         QueryError.value = updateValue(message, "error");
       }
       break;
     case "init-environment":
-      const payload = updateValue(message, "success").payload;
-      initEnvironment.value = JSON.parse(payload);
-      currentEnvironment.value = initEnvironment.value?.selected_environment;
+      const envData = updateValue(message, "success");
+      if (envData && envData.payload) {
+        initEnvironment.value = JSON.parse(envData.payload);
+        currentEnvironment.value = initEnvironment.value?.selected_environment;
+      }
       break;
     case "set-environment":
       currentEnvironment.value = updateValue(message, "success");
-      console.log("Setting environment", currentEnvironment.value);
       break;
     case "query-export-message":
       if (message.payload.status === "export-loading") {

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -201,6 +201,7 @@ export interface TabData extends Tab {
   isEditing: boolean;
   limit: number;
   environment: string;
+  executedEnvironment: string;
   connectionName: string;
   showQuery: boolean;
   selectedQuery?: string;


### PR DESCRIPTION
# PR Overview

This PR refactors environment handling in `QueryPreview` components to correctly reflect the selected environment instead of always showing **"running in default"**.

### Changes
* **Refactored** environment handling logic in `QueryPreview`.
* Fixed a bug where the preview always defaulted to `"running in default"`.


![env-query-preview](https://github.com/user-attachments/assets/300db88b-0e0e-45a1-8246-872a827c22f6)
