### PR TITLE
Loosen tableau connection authentication requirements

### DIFF
--- a/webview-ui/src/components/connections/ConnectionsForm.vue
+++ b/webview-ui/src/components/connections/ConnectionsForm.vue
@@ -5,6 +5,9 @@
         <h3 id="connection-form-title" class="text-lg font-medium text-editor-fg">
           {{ isEditing ? "Edit Connection" : "New Connection" }}
         </h3>
+        <p class="text-sm text-descriptionFg mt-1">
+          Most fields are optional. Provide either username/password OR personal access token/API key for authentication.
+        </p>
         <div class="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-6">
           <FormField
             v-for="field in formFields"
@@ -299,6 +302,28 @@ const validateForm = () => {
       errors.password = errorMsg;
       errors.private_key = errorMsg;
       errors.private_key_path = errorMsg;
+    }
+  }
+  
+  // More permissive validation for authentication fields
+  // Check if connection has any authentication method (password/username OR PAT/token fields)
+  const connectionType = form.value.connection_type;
+  if (connectionType && connectionType !== "snowflake") {
+    const hasPasswordAuth = form.value.password && form.value.username;
+    const hasPATAuth = form.value.pat || form.value.personal_access_token || form.value.token;
+    const hasAPIKey = form.value.api_key;
+    
+    // Only show authentication errors if no authentication method is provided at all
+    // This makes the validation more permissive - you can have either type of auth
+    const hasAnyAuth = hasPasswordAuth || hasPATAuth || hasAPIKey;
+    
+    // For connections that typically need authentication, warn if none provided
+    // But don't block the form submission - let the backend handle it
+    if (!hasAnyAuth && (form.value.password !== undefined || form.value.username !== undefined || 
+                        form.value.pat !== undefined || form.value.personal_access_token !== undefined || 
+                        form.value.token !== undefined || form.value.api_key !== undefined)) {
+      // Only add a soft warning, don't prevent submission
+      console.warn(`No authentication method provided for ${connectionType} connection`);
     }
   }
   

--- a/webview-ui/src/components/connections/connectionUtility.ts
+++ b/webview-ui/src/components/connections/connectionUtility.ts
@@ -31,14 +31,25 @@ export const generateConnectionConfig = (schema: any) => {
           let cols: number | undefined = undefined;
           let required = connectionDef.required.includes(prop);
 
+          // Make connections more permissive - reduce strict requirements
           // Endpoint URL and Layout are optional for S3 connections
           if (prop === "endpoint_url" || prop === "layout") {
             required = false;
           }
           
+          // Make API version optional for all connection types (especially Tableau)
+          if (prop === "api_version" || prop === "api-version") {
+            required = false;
+          }
+          
+          // Make authentication fields more flexible - allow either password/username OR PAT fields
+          if (prop === "password" || prop === "username" || prop === "pat" || prop === "personal_access_token" || prop === "token") {
+            required = false;
+          }
+          
           if (prop === "players" && type === "chess") {
             inputType = "csv";
-          } else if (prop === "password" || prop === "secret") {
+          } else if (prop === "password" || prop === "secret" || prop === "pat" || prop === "personal_access_token" || prop === "token" || prop === "api_key") {
             inputType = "password";
           } else if (propDef.type === "string") {
             inputType = "text";


### PR DESCRIPTION
Make connection authentication fields and `api_version` optional to improve flexibility and user experience for various connection types, especially Tableau.

The original connection form validation was overly strict, particularly for Tableau connections. It incorrectly enforced `api_version` as required and created conflicting requirements for authentication fields (e.g., demanding both username/password and PAT fields simultaneously). This PR addresses these issues by making these fields optional and implementing a more permissive validation logic, allowing users to provide either username/password or PAT/token for authentication.

---
[Slack Thread](https://bruintalk.slack.com/archives/D092PT1QB89/p1758903258823529?thread_ts=1758903258.823529&cid=D092PT1QB89)

<a href="https://cursor.com/background-agent?bcId=bc-15ddbbc3-6e2a-4af1-93f6-6f7ff9b1a6c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15ddbbc3-6e2a-4af1-93f6-6f7ff9b1a6c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

