### PR TITLE
Require Connection for Non-Asset SQL Files with Query Content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.68.2] - [2025-10-02]
+- Fixed the preview query issue when opening a non-asset file.
+
 ## [0.68.1] - [2025-10-02]
 - Fixed rendered query issues related to date input and full refresh start date.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 
 ## Release Notes
 ### Recent Update
+- **0.68.2**: Fixed the preview query issue when opening a non-asset file.
 - **0.68.1**: Fixed rendered query issues related to date input and full refresh start date.
 - **0.68.0**: Added support for BigQuery cost estimate in the SQL editor.
 - **0.67.4**: Fixed lineage display for `pipeline.yml` files and resolved issues with the lineage view not refreshing after updates.
@@ -74,14 +75,6 @@ Bruin is a unified analytics platform that enables data professionals to work en
 - **0.65.2**: Fixed table details panel bug and bruin.yaml bug.
 - **0.65.1**: Add full refresh to render panel.
 - **0.65.0**: Introduced a tags management interface that allows users to toggle the inclusion or exclusion of assets for execution in run commands.
-- **0.64.7**: Fixed the SQL preview rendering issue.
-- **0.64.6**: Updated the environment list command to create bruin.yml if it does not already exist.
-- **0.64.5**: Improved the .bruin.yml file handling to only show settings tab and fixed the convert message flickering issue.
-- **0.64.4**: Fixed the checkbox and dates state persisting issue.
-- **0.64.3**: Added cancel button to the table diff panel and improved the UI.
-- **0.64.2**: Fixed shwoing settings tab when no active editor and improved the UI.
-- **0.64.1**: Add secrets UI to the details tab.
-- **0.64.0**: Added data diff panel to the extension.
 
 For a full changelog, see Bruin Extension [Changelog](https://marketplace.visualstudio.com/items/bruin.bruin/changelog).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.68.1",
+  "version": "0.68.2",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/bruin/queryOutput.ts
+++ b/src/bruin/queryOutput.ts
@@ -37,7 +37,7 @@ export class BruinQueryOutput extends BruinCommand {
     connectionName?: string,
     startDate?: string,
     endDate?: string,
-    { flags = [], ignoresErrors = false, query = "" }: BruinCommandOptions & { query?: string } = {}
+    { flags = [], ignoresErrors = false, query = "", isAsset = true }: BruinCommandOptions & { query?: string; isAsset?: boolean } = {}
   ): Promise<void> {
     // Construct base flags dynamically
     this.isLoading = true;
@@ -48,6 +48,11 @@ export class BruinQueryOutput extends BruinCommand {
       console.log("Using direct query mode: --connection + --query");
       constructedFlags.push("--connection", connectionName);
       constructedFlags.push("--query", query);
+    } else if (query && !isAsset) {
+      // For non-asset files with query content but no connection, we need a connection
+      console.log("Non-asset file detected but no connection specified. Cannot execute query.");
+      this.postMessageToPanels("error", "SQL files in assets folder that are not Bruin assets require a connection to be specified. Add a comment like '-- connection: your-connection-name' at the top of your file.", tabId);
+      return;
     } else if (query) {
       console.log("Using auto-detect mode: --asset + --query");
       constructedFlags.push("--asset", asset);

--- a/src/extension/commands/queryCommands.ts
+++ b/src/extension/commands/queryCommands.ts
@@ -94,7 +94,7 @@ export const getQueryOutput = async (environment: string, limit: string, lastRen
   // For non-asset files: always use the query content
   const queryToPass = selectedQuery;
   
-  await output.getOutput(environment, lastRenderedDocumentUri.fsPath, limit, tabId, detectedConnectionName, startDate, endDate, { query: queryToPass });
+  await output.getOutput(environment, lastRenderedDocumentUri.fsPath, limit, tabId, detectedConnectionName, startDate, endDate, { query: queryToPass, isAsset });
 };
 
 export const exportQueryResults = async (lastRenderedDocumentUri: Uri | undefined, tabId?: string, connectionName?: string) => {


### PR DESCRIPTION
# PR Overview 

This PR fixes a bug where opening a **non-asset SQL file** located within an asset folder and attempting to preview its query would trigger a **panic error**.

### Changes
* Updated the logic to **prevent sending the `--asset` flag and path** when the file is not a recognized Bruin asset.
* Added handling to **detect non-asset SQL files** and display a helpful message.
* Ensures the preview works correctly once the user specifies a valid connection in the comment.

![non-asset-query-preview](https://github.com/user-attachments/assets/1a8019d1-9ab0-4220-8fba-5bd0a840905a)

