### PR TITLE
Simplify file extension retrieval method

### DIFF
--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -47,7 +47,7 @@ export const getFileExtension = (fileName: string) => {
   }
 
   let fileExtension = fileName.split(".").pop() || "";
-  return "." + fileExtension.toLowerCase();
+  return fileExtension ? "." + fileExtension.toLowerCase() : "";
 };
 
 export const isPythonBruinAsset = async (fileName: string): Promise<boolean> =>


### PR DESCRIPTION
Currently I have a problem where my assets have to contain a `.` within the folder path. I am on a company machine which is setup as `/Users/firstname.lastname/...`.

The isAsset logic does not work for me because of the multiple dots in the file path.

Sadly `"/Users/mark.dessain/projects/assets/abc.sql".match(/(\.[^.]+(?:\.[^.]+)?$)/)` does not give `.sql` but matches the first dot and gives `.dessain/projects/assets/abc.sql` as the extension.

This change I have made removes the regex and instead just does a pop after the last . in the fileName.