### PR TITLE
Increase query preview limit

### DIFF
--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -28,7 +28,7 @@
               v-model="limit"
               class="w-12 h-6 text-3xs rounded bg-editorWidget-bg text-editor-fg hover:bg-input-background focus:bg-input-background focus:outline-none px-1"
               min="1"
-              max="1000"
+              max="50000"
             />
           </div>
           <div class="flex items-center space-x-1">
@@ -514,7 +514,7 @@ const connectionsStore = useConnectionsStore();
 const currentEnvironment = ref<string>(props.environment);
 const modifierKey = ref("⌘"); // Default to Mac symbol
 const currentConnectionName = ref("");
-const limit = ref(100);
+const limit = ref(1000);
 const showSearchInput = ref(false);
 const hoveredTab = ref("");
 const copied = ref(false);
@@ -540,7 +540,7 @@ const defaultTab = {
   error: null,
   isLoading: false,
   searchInput: "",
-  limit: 100,
+  limit: 1000,
   filteredRows: [],
   totalRowCount: 0,
   filteredRowCount: 0,
@@ -654,7 +654,7 @@ const addTab = () => {
     label: newTabLabel,
     parsedOutput: undefined,
     error: null,
-    limit: 100,
+    limit: 1000,
     isLoading: false,
     searchInput: "",
     filteredRows: [],
@@ -1021,7 +1021,7 @@ const closeTab = (tabId: string) => {
         error: null,
         isLoading: false,
         searchInput: "",
-        limit: 100,
+        limit: 1000,
         filteredRows: [],
         totalRowCount: 0,
         filteredRowCount: 0,
@@ -1233,7 +1233,7 @@ const updateFilteredRows = () => {
 const runQuery = () => {
   // Reset cell expansions when running a new query
   expandedCells.value.clear();
-  if (limit.value > 1000 || limit.value < 1) {
+  if (limit.value > 50000 || limit.value < 1) {
     limit.value = 1000;
   }
   


### PR DESCRIPTION
Increase the query preview maximum result limit to 50000 and set the default limit to 1000.

---
[Slack Thread](https://bruintalk.slack.com/archives/C094932THFW/p1764851880462639?thread_ts=1764851880.462639&cid=C094932THFW)

<a href="https://cursor.com/background-agent?bcId=bc-5b1a6e4f-1711-4759-ad21-1cd883d96915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b1a6e4f-1711-4759-ad21-1cd883d96915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

