### PR TITLE
update: add motherduck as valid destination

### DIFF
--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -116,7 +116,8 @@
                 "gcs",
                 "mongo_atlas",
                 "mysql",
-                "elasticsearch"
+                "elasticsearch",
+                "motherduck"
               ],
               "description": "The destination system",
               "additionalProperties": true


### PR DESCRIPTION
### Summary
Add `motherduck` as a valid destination value in the YAML assets schema.

### Changes
- Added `motherduck` to the `destination` enum in `schemas/yaml-assets-schema.json`

MotherDuck is a supported destination in Bruin CLI, but was missing from the VS Code extension's schema validation. This caused false validation errors when users specified `destination: motherduck` in their asset files, even though the configuration worked correctly at runtime.