### PR TITLE
Catchup attribute default

### DIFF
--- a/schemas/pipeline-schema.json
+++ b/schemas/pipeline-schema.json
@@ -119,7 +119,7 @@
     },
     "catchup": {
       "type": "boolean",
-      "default": "true"
+      "default": false
     },
     "retries": {
       "type": "integer"


### PR DESCRIPTION
Correct the default value for the `catchup` attribute in the pipeline schema to `false` to align with documentation.

---
[Slack Thread](https://bruintalk.slack.com/archives/C067JTCQS2D/p1769579631827099?thread_ts=1769579631.827099&cid=C067JTCQS2D)

<a href="https://cursor.com/background-agent?bcId=bc-b9b6de31-c4ec-40fd-9535-6612a244ccd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9b6de31-c4ec-40fd-9535-6612a244ccd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

