### PR TITLE
fix: race conditions in query, export, validate, render, and asset detection

### DIFF
--- a/src/bruin/bruinValidate.ts
+++ b/src/bruin/bruinValidate.ts
@@ -34,6 +34,10 @@ export class BruinValidate extends BruinCommand {
   ): Promise<void> {
     if (BruinValidate.isLoading) {
       console.log("Validation already in progress, skipping.");
+      BruinPanel.postMessage("validation-message", {
+        status: "info",
+        message: "Validation already in progress, please wait...",
+      });
       return;
     }
     BruinValidate.isLoading = true;

--- a/src/bruin/bruinValidate.ts
+++ b/src/bruin/bruinValidate.ts
@@ -15,7 +15,7 @@ export class BruinValidate extends BruinCommand {
     return "validate";
   }
 
-  public isLoading: boolean = false;
+  public static isLoading: boolean = false;
 
   /**
    * Validates a Bruin Asset based on it's path with optional flags and error handling.
@@ -32,7 +32,11 @@ export class BruinValidate extends BruinCommand {
     excludeTag: string = "",
     fullRefresh: boolean = false
   ): Promise<void> {
-    this.isLoading = true;
+    if (BruinValidate.isLoading) {
+      console.log("Validation already in progress, skipping.");
+      return;
+    }
+    BruinValidate.isLoading = true;
     BruinPanel.postMessage("validation-message", {
       status: "loading",
       message: "Validating asset...",
@@ -119,7 +123,7 @@ export class BruinValidate extends BruinCommand {
         message: errorMessage,
       });
     } finally {
-      this.isLoading = false; // Reset loading state when validation completes or fails
+      BruinValidate.isLoading = false; // Reset loading state when validation completes or fails
     }
   }
 }

--- a/src/bruin/exportQueryOutput.ts
+++ b/src/bruin/exportQueryOutput.ts
@@ -91,6 +91,8 @@ export class BruinExportQueryOutput extends BruinCommand {
     // Use provided flags or fallback to constructed flags
     const finalFlags = flags.length > 0 ? flags : constructedFlags;
 
+    let currentProcess: child_process.ChildProcess | undefined;
+
     try {
       // Cancel any existing export for this tab right before starting a new one
       // (moved here to minimize async gap - no awaits between cancel and process registration)
@@ -99,6 +101,7 @@ export class BruinExportQueryOutput extends BruinCommand {
       }
 
       const { promise, process } = this.runCancellable(finalFlags, { ignoresErrors });
+      currentProcess = process;
 
       // Store the process for potential cancellation immediately after spawning
       if (tabId) {
@@ -144,9 +147,10 @@ export class BruinExportQueryOutput extends BruinCommand {
       }
       this.postMessageToPanels("success", message);
     } catch (error: any) {
-      // Check if a newer export has started for this tab - if so, skip cleanup messages
-      // to avoid overwriting the new export's UI state
-      const newerExportStarted = tabId && BruinExportQueryOutput.runningProcesses.has(tabId);
+      // Check if a newer export has started by comparing process references
+      // (not just existence - our own errored process would still be in the map)
+      const processInMap = tabId ? BruinExportQueryOutput.runningProcesses.get(tabId) : undefined;
+      const newerExportStarted = processInMap !== undefined && processInMap !== currentProcess;
 
       // Only delete from tracking if no newer export has taken over
       if (tabId && !newerExportStarted) {
@@ -171,7 +175,8 @@ export class BruinExportQueryOutput extends BruinCommand {
       }
     } finally {
       // Skip posting loading:false if a newer export has started
-      const newerExportStarted = tabId && BruinExportQueryOutput.runningProcesses.has(tabId);
+      const processInMap = tabId ? BruinExportQueryOutput.runningProcesses.get(tabId) : undefined;
+      const newerExportStarted = processInMap !== undefined && processInMap !== currentProcess;
       if (!newerExportStarted) {
         this.isLoading = false;
         this.postMessageToPanels("export-loading", this.isLoading);

--- a/src/bruin/exportQueryOutput.ts
+++ b/src/bruin/exportQueryOutput.ts
@@ -52,6 +52,12 @@ export class BruinExportQueryOutput extends BruinCommand {
     // Construct base flags dynamically
     this.isLoading = true;
     this.postMessageToPanels("export-loading", this.isLoading);
+
+    // Cancel any existing export for this tab before starting a new one
+    if (tabId) {
+      BruinExportQueryOutput.cancelExport(tabId);
+    }
+
     const constructedFlags = ["-export"];
 
     const hasExplicitQuery = query && query.trim().length > 0;

--- a/src/bruin/exportQueryOutput.ts
+++ b/src/bruin/exportQueryOutput.ts
@@ -53,11 +53,6 @@ export class BruinExportQueryOutput extends BruinCommand {
     this.isLoading = true;
     this.postMessageToPanels("export-loading", this.isLoading);
 
-    // Cancel any existing export for this tab before starting a new one
-    if (tabId) {
-      BruinExportQueryOutput.cancelExport(tabId);
-    }
-
     const constructedFlags = ["-export"];
 
     const hasExplicitQuery = query && query.trim().length > 0;
@@ -97,9 +92,15 @@ export class BruinExportQueryOutput extends BruinCommand {
     const finalFlags = flags.length > 0 ? flags : constructedFlags;
 
     try {
+      // Cancel any existing export for this tab right before starting a new one
+      // (moved here to minimize async gap - no awaits between cancel and process registration)
+      if (tabId) {
+        BruinExportQueryOutput.cancelExport(tabId);
+      }
+
       const { promise, process } = this.runCancellable(finalFlags, { ignoresErrors });
 
-      // Store the process for potential cancellation
+      // Store the process for potential cancellation immediately after spawning
       if (tabId) {
         BruinExportQueryOutput.runningProcesses.set(tabId, process);
       }
@@ -143,12 +144,22 @@ export class BruinExportQueryOutput extends BruinCommand {
       }
       this.postMessageToPanels("success", message);
     } catch (error: any) {
-      // Remove process from tracking on error
-      if (tabId) {
+      // Check if a newer export has started for this tab - if so, skip cleanup messages
+      // to avoid overwriting the new export's UI state
+      const newerExportStarted = tabId && BruinExportQueryOutput.runningProcesses.has(tabId);
+
+      // Only delete from tracking if no newer export has taken over
+      if (tabId && !newerExportStarted) {
         BruinExportQueryOutput.runningProcesses.delete(tabId);
       }
 
       console.error("Error occurred while exporting query results:", error);
+
+      // Skip posting messages if a newer export is running
+      if (newerExportStarted) {
+        return;
+      }
+
       const errorMessage = error.message || error.toString();
 
       // Check if the export was cancelled
@@ -159,8 +170,12 @@ export class BruinExportQueryOutput extends BruinCommand {
         this.postMessageToPanels("error", errorMessage);
       }
     } finally {
-      this.isLoading = false;
-      this.postMessageToPanels("export-loading", this.isLoading);
+      // Skip posting loading:false if a newer export has started
+      const newerExportStarted = tabId && BruinExportQueryOutput.runningProcesses.has(tabId);
+      if (!newerExportStarted) {
+        this.isLoading = false;
+        this.postMessageToPanels("export-loading", this.isLoading);
+      }
     }
   }
 

--- a/src/bruin/queryOutput.ts
+++ b/src/bruin/queryOutput.ts
@@ -91,11 +91,13 @@ export class BruinQueryOutput extends BruinCommand {
     console.log("Final CLI command: bruin query", finalFlags.join(" "));
 
     let consoleMessages: Array<{type: 'stdout' | 'stderr' | 'info', message: string, timestamp: string}> = [];
-    
+    let currentProcess: child_process.ChildProcess | undefined;
+
     try {
       const { promise, process, consoleMessages: cmdConsoleMessages } = this.runCancellable(finalFlags, { ignoresErrors });
+      currentProcess = process;
       consoleMessages = cmdConsoleMessages; // Store console messages for use in catch block
-      
+
       // Store the process for potential cancellation
       if (tabId) {
         BruinQueryOutput.runningProcesses.set(tabId, process);
@@ -119,9 +121,10 @@ export class BruinQueryOutput extends BruinCommand {
       }
       this.postMessageToPanels("success", result, tabId, consoleMessages);
     } catch (error: any) {
-      // Check if a newer query has started for this tab - if so, skip cleanup messages
-      // to avoid overwriting the new query's UI state
-      const newerQueryStarted = tabId && BruinQueryOutput.runningProcesses.has(tabId);
+      // Check if a newer query has started for this tab by comparing process references
+      // (not just existence - our own errored process would still be in the map)
+      const processInMap = tabId ? BruinQueryOutput.runningProcesses.get(tabId) : undefined;
+      const newerQueryStarted = processInMap !== undefined && processInMap !== currentProcess;
 
       // Only delete from tracking if no newer query has taken over
       if (tabId && !newerQueryStarted) {
@@ -151,7 +154,8 @@ export class BruinQueryOutput extends BruinCommand {
     }
     finally {
       // Skip posting loading:false if a newer query has started
-      const newerQueryStarted = tabId && BruinQueryOutput.runningProcesses.has(tabId);
+      const processInMap = tabId ? BruinQueryOutput.runningProcesses.get(tabId) : undefined;
+      const newerQueryStarted = processInMap !== undefined && processInMap !== currentProcess;
       if (!newerQueryStarted) {
         this.isLoading = false;
         this.postMessageToPanels("loading", this.isLoading, tabId, []);

--- a/src/bruin/queryOutput.ts
+++ b/src/bruin/queryOutput.ts
@@ -119,16 +119,26 @@ export class BruinQueryOutput extends BruinCommand {
       }
       this.postMessageToPanels("success", result, tabId, consoleMessages);
     } catch (error: any) {
-      // Remove process from tracking on error
-      if (tabId) {
+      // Check if a newer query has started for this tab - if so, skip cleanup messages
+      // to avoid overwriting the new query's UI state
+      const newerQueryStarted = tabId && BruinQueryOutput.runningProcesses.has(tabId);
+
+      // Only delete from tracking if no newer query has taken over
+      if (tabId && !newerQueryStarted) {
         BruinQueryOutput.runningProcesses.delete(tabId);
       }
-      
+
       console.error("Error occurred while running query:", error);
+
+      // Skip posting messages if a newer query is running
+      if (newerQueryStarted) {
+        return;
+      }
+
       const errorMessage = error.message || error.toString();
-      
+
       // Use the console messages we captured before the error occurred
-      if (errorMessage.includes("Command was cancelled") || 
+      if (errorMessage.includes("Command was cancelled") ||
           errorMessage.includes("context canceled") ||
           errorMessage.includes("query execution failed: failed to initiate query read: context canceled")) {
         this.postMessageToPanels("cancelled", "Query cancelled by user.", tabId, consoleMessages);
@@ -140,8 +150,12 @@ export class BruinQueryOutput extends BruinCommand {
       }
     }
     finally {
-      this.isLoading = false;
-      this.postMessageToPanels("loading", this.isLoading, tabId, []);
+      // Skip posting loading:false if a newer query has started
+      const newerQueryStarted = tabId && BruinQueryOutput.runningProcesses.has(tabId);
+      if (!newerQueryStarted) {
+        this.isLoading = false;
+        this.postMessageToPanels("loading", this.isLoading, tabId, []);
+      }
     }
   }
 

--- a/src/bruin/queryOutput.ts
+++ b/src/bruin/queryOutput.ts
@@ -42,6 +42,12 @@ export class BruinQueryOutput extends BruinCommand {
     // Construct base flags dynamically
     this.isLoading = true;
     this.postMessageToPanels("loading", this.isLoading, tabId);
+
+    // Cancel any existing query for this tab before starting a new one
+    if (tabId) {
+      BruinQueryOutput.cancelQuery(tabId);
+    }
+
     const constructedFlags = ["-o", "json"];
 
     if (connectionName && query) {

--- a/src/extension/commands/renderCommand.ts
+++ b/src/extension/commands/renderCommand.ts
@@ -5,11 +5,8 @@ import { buildRenderFlags } from "../../utilities/helperUtils";
 import { getBruinExecutablePath } from "../../providers/BruinExecutableService";
 
 export const renderCommand = async (extensionUri: vscode.Uri) => {
-  // Always render the panel, even if no active editor
-  BruinPanel.render(extensionUri);
-
   const activeEditor = vscode.window.activeTextEditor;
-  
+
   // Always render the panel
   BruinPanel.render(extensionUri);
   

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -84,6 +84,7 @@ export class BruinPanel {
   private _lastRenderedDocumentUri: Uri | undefined;
   private _flags: string = "";
   private _assetDetectionDebounceTimer: NodeJS.Timeout | undefined;
+  private _assetDetectionGeneration: number = 0;
   private _renderDebounceTimer: NodeJS.Timeout | undefined;
   private _cliInstalled: boolean | null = null;
   private _initialSettingsOnlyMode: boolean = false;
@@ -1568,23 +1569,26 @@ export class BruinPanel {
       clearTimeout(this._assetDetectionDebounceTimer);
     }
 
+    // Increment generation to invalidate any in-flight detection
+    const generation = ++this._assetDetectionGeneration;
+
     const isFileSwitch = this._lastRenderedDocumentUri?.fsPath !== filePath;
-    
+
     if (isFileSwitch) {
-      await this._performAssetDetection(filePath, fileUri);
+      await this._performAssetDetection(filePath, fileUri, generation);
     } else {
       this._assetDetectionDebounceTimer = setTimeout(async () => {
         if (window.activeTextEditor?.document.uri.fsPath === filePath) {
-          await this._performAssetDetection(filePath, fileUri);
+          await this._performAssetDetection(filePath, fileUri, generation);
         }
       }, 500);
     }
   }
 
-  private async _performAssetDetection(filePath: string, fileUri: Uri): Promise<void> {
+  private async _performAssetDetection(filePath: string, fileUri: Uri, generation: number): Promise<void> {
     try {
       console.log("_performAssetDetection: Starting detection for", filePath);
-      
+
       // Check for config files first (highest priority)
       const isConfigFile =
         filePath.endsWith("pipeline.yml") ||
@@ -1593,6 +1597,7 @@ export class BruinPanel {
         filePath.endsWith(".bruin.yaml");
 
       if (isConfigFile) {
+        if (this._assetDetectionGeneration !== generation) { return; }
         console.log("_performAssetDetection: File is a config file", filePath);
         this._panel.webview.postMessage({
           command: "clear-convert-message",
@@ -1607,6 +1612,7 @@ export class BruinPanel {
       }
 
       const isAsset = await this._isAssetFile(filePath);
+      if (this._assetDetectionGeneration !== generation) { return; }
       console.log("_performAssetDetection: CLI determined file is an asset:", filePath, isAsset);
       if (isAsset) {
         this._panel.webview.postMessage({
@@ -1623,6 +1629,7 @@ export class BruinPanel {
 
       // Only check for conversion if it's NOT an asset and NOT a config file
       const inAssetsFolder = await this._isInAssetsFolder(filePath);
+      if (this._assetDetectionGeneration !== generation) { return; }
       const fileExt = this._getFileExtension(filePath);
       const isSupportedFileType = ["yml", "yaml", "py", "sql"].includes(fileExt);
 
@@ -1645,6 +1652,7 @@ export class BruinPanel {
       }
     } catch (error) {
       console.error("_performAssetDetection: Error in asset detection flow:", error);
+      if (this._assetDetectionGeneration !== generation) { return; }
       // On error, clear convert message to prevent stale UI
       this._panel.webview.postMessage({
         command: "clear-convert-message",

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -1652,6 +1652,8 @@ export class BruinPanel {
       }
     } catch (error) {
       console.error("_performAssetDetection: Error in asset detection flow:", error);
+      // Only update UI if this is still the current detection request
+      // (prevents stale error handlers from clearing the UI for a newer file)
       if (this._assetDetectionGeneration !== generation) { return; }
       // On error, clear convert message to prevent stale UI
       this._panel.webview.postMessage({

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -807,6 +807,7 @@ suite("BruinValidate Tests", () => {
   });
 
   teardown(() => {
+    BruinValidate.isLoading = false;
     sinon.restore();
   });
 
@@ -854,7 +855,7 @@ suite("BruinValidate Tests", () => {
 
     // Assert loading state before completion
     assert.strictEqual(
-      bruinValidate.isLoading,
+      BruinValidate.isLoading,
       true,
       "Loading state should be true during validation"
     );
@@ -863,7 +864,7 @@ suite("BruinValidate Tests", () => {
 
     // Assert loading state after completion
     assert.strictEqual(
-      bruinValidate.isLoading,
+      BruinValidate.isLoading,
       false,
       "Loading state should be false after validation"
     );
@@ -889,7 +890,7 @@ suite("BruinValidate Tests", () => {
     await bruinValidate.validate(filePath);
 
     assert.strictEqual(
-      bruinValidate.isLoading,
+      BruinValidate.isLoading,
       false,
       "Loading state should be false after validation"
     );


### PR DESCRIPTION
## Summary

Fixes 5 race conditions that can cause orphaned bruin CLI processes, stale UI results, or duplicate work:

- **queryOutput.ts**: Cancel the previous query process before starting a new one for the same tab. Previously, the old `ChildProcess` reference in `runningProcesses` was silently overwritten, orphaning the old process.
- **exportQueryOutput.ts**: Same fix for exports — cancel previous export before starting a new one for the same tab.
- **bruinValidate.ts**: Make `isLoading` a static property and add an early-return guard. The old instance property was always `false` on new instances, so concurrent validates were never blocked.
- **renderCommand.ts**: Remove duplicate `BruinPanel.render()` call (copy-paste artifact).
- **BruinPanel.ts**: Add a generation counter to `_performAssetDetection` so stale results from previous file switches are discarded after every `await` boundary.

All 405 existing tests pass.

---

## Remaining issues found during audit (not yet fixed)

### High Priority — Stale Results / Race Conditions

**1. `bruinRender.ts` — render results can show SQL for the wrong file**
The `render()` method posts results to `BruinPanel` without checking if the active document has changed since the render started. Multiple `setTimeout()` calls (lines 79, 102) with variable delays mean render results for file A could arrive after file B, showing the wrong SQL.

**2. `BruinPanel.ts:1665-1681` — `_scheduleSqlPreviewRender()` has no generation tracking**
Unlike `_performAssetDetection` (which is fixed in this PR), the SQL preview render debounce has no generation counter. Stale render results can overwrite the current file's preview.

**3. `LineagePanel.ts:123` — `initPanel()` rejection leaves `isRefreshing` stuck forever**
```ts
this.initPanel(event).then(() => { this.isRefreshing = false; })
```
No `.catch()` — if `initPanel()` rejects, `isRefreshing` stays `true` and the panel locks up.

### Medium Priority — Resource Leaks

**4. `QueryPreviewPanel.ts:185` — `onDidChangeVisibility` listener not added to disposables**
The listener persists after the panel is disposed, causing a memory leak.

**5. `TableDiffPanel.ts:130` — same issue: `onDidChangeVisibility` not disposed**

**6. `LineagePanel.ts:8-32` — singleton instance accumulates listeners, never cleared**
`addListener()` pushes callbacks that survive panel disposal. `dispose()` is a no-op.

**7. `RunHistoryPanel.ts:70-74` — rapid `setupFileWatcher()` calls stack watchers**
Each call pushes a new watcher to `disposables` without removing the old entry from the array, so old watchers pile up.

**8. Static maps in `queryOutput.ts` / `exportQueryOutput.ts` never cleared on deactivation**
`runningProcesses` maps keep process references if the extension deactivates with running queries.

### Medium Priority — Missing Error Handling

**9. `TableDiffPanel.ts:234,262,288,397` — `postMessage` in catch blocks without null check**
If the view is disposed during an async operation, these error handlers crash.

**10. `bruinConnections.ts` — multiple methods silently swallow errors**
`testConnection()`, `createConnection()`, `deleteConnection()` all `.catch()` to `console.error()` only — no user notification.

**11. `bruinLineage.ts:29-36` — `.then()` without `.catch()`**
Errors silently vanish.

### Low Priority — Code Quality

**12. `BruinPanel.ts:481-1485` — ~50-case switch with no `default` case**
Unknown message types are silently ignored, making debugging harder.

**13. `extension.ts:689-695` — `deactivate()` doesn't clear panel static state**
`QueryPreviewPanel.tabQueries`, `tabAssetPaths`, etc. survive extension reloads.

**14. `bruinUtils.ts:414-457` — terminal pileup potential**
If a user closes the "Bruin Terminal" manually and triggers another command quickly, a new one is created without cleaning up orphaned references.

## Test plan

- [x] All 405 existing tests pass
- [ ] Manual: open a SQL asset, trigger query, quickly trigger another query on same tab — verify only one result appears
- [ ] Manual: rapidly switch between files — verify the panel always shows the correct file's asset status
- [ ] Manual: click Validate multiple times rapidly — verify only one validation runs at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)