### PR TITLE
Remove unsupported --environment flag from fillDependencies call and add unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.79.6] - [2026-03-31]
+- Fixed "Fill from Query" command failing due to unsupported `--environment` flag being passed to `fill-asset-dependencies`.
+
 ## [0.79.5] - [2026-03-23]
 - Added interval modifiers preview tooltip: hover over the "Interval-modifiers" checkbox to see how start/end dates will be modified.
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Bruin is a unified analytics platform that enables data professionals to work en
 ## Release Notes
 
 ### Recent Update
+- **0.79.6**: Fixed "Fill from Query" command failing due to unsupported `--environment` flag.
 - **0.79.5**: Added interval modifiers preview tooltip on the checkbox.
 - **0.79.4**: Fixed "Fill from DB" to use selected environment; fixed start date input on full refresh.
 - **0.79.3**: Added ability to select and run SQL text directly in Query Preview.
 - **0.79.2**: Added cancel button for export query operations, allowing users to stop long-running exports.
-- **0.79.1**: Fixed SQL Editor syntax highlighting.
 
 For a full changelog, see Bruin Extension [Changelog](https://github.com/bruin-data/bruin-vscode/blob/main/CHANGELOG.md).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.79.5",
+  "version": "0.79.6",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -788,10 +788,8 @@ export class BruinPanel {
               getBruinExecutablePath(),
               assetWorkspaceDir
             );
-            const fillDependenciesFlags = this._currentEnvironment
-              ? ["--environment", this._currentEnvironment]
-              : [];
-            await fillDependencies.fillDependencies(assetPath, { flags: fillDependenciesFlags });
+            // Note: fill-asset-dependencies does not support --environment flag (only fill-columns-from-db does)
+            await fillDependencies.fillDependencies(assetPath);
 
             return;
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -2208,22 +2208,50 @@ suite("BruinPanel Tests", () => {
         fillDependencies: fillDependenciesStub
       });
       const postMessageStub = sinon.stub(BruinPanel, "postMessage");
-      
+
       // Mock the modules
       const bruinExecutableServiceModule = await import("../providers/BruinExecutableService");
       sinon.replace(bruinExecutableServiceModule, "getBruinExecutablePath", getBruinExecutablePathStub);
-      
+
       const bruinFillModule = await import("../bruin/bruinFill");
       sinon.replace(bruinFillModule, "BruinFill", BruinFillStub as any);
-      
-      await (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0]({ 
+
+      await (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0]({
         command: "bruin.fillAssetDependency" });
 
       // Verify workspace directory lookup and BruinFill instantiation
       assert.ok(bruinWorkspaceDirectoryStub.calledOnceWith(mockDocumentUri.fsPath));
       assert.ok(BruinFillStub.calledOnceWith("/path/to/bruin", "/mock/workspace"));
       assert.ok(fillDependenciesStub.calledOnceWith(mockDocumentUri.fsPath));
-      
+
+      postMessageStub.restore();
+    });
+
+    test("handles bruin.fillAssetDependency command does not pass environment flag", async () => {
+      // fill-asset-dependencies CLI command does not support --environment flag (only fill-columns-from-db does)
+      const getBruinExecutablePathStub = sinon.stub().returns("/path/to/bruin");
+      const fillDependenciesStub = sinon.stub();
+      const BruinFillStub = sinon.stub().returns({
+        fillDependencies: fillDependenciesStub
+      });
+      const postMessageStub = sinon.stub(BruinPanel, "postMessage");
+
+      // Mock the modules
+      const bruinExecutableServiceModule = await import("../providers/BruinExecutableService");
+      sinon.replace(bruinExecutableServiceModule, "getBruinExecutablePath", getBruinExecutablePathStub);
+
+      const bruinFillModule = await import("../bruin/bruinFill");
+      sinon.replace(bruinFillModule, "BruinFill", BruinFillStub as any);
+
+      await (windowCreateWebviewPanelStub.returnValues[0].webview.onDidReceiveMessage as sinon.SinonStub).firstCall.args[0]({
+        command: "bruin.fillAssetDependency" });
+
+      // Verify fillDependencies is called with only the file path (no options with environment flags)
+      assert.ok(fillDependenciesStub.calledOnce, "fillDependencies should be called once");
+      const callArgs = fillDependenciesStub.firstCall.args;
+      assert.strictEqual(callArgs.length, 1, "fillDependencies should be called with only one argument (the file path)");
+      assert.strictEqual(callArgs[0], mockDocumentUri.fsPath, "First argument should be the file path");
+
       postMessageStub.restore();
     });
     test("handles bruin.fillAssetColumn command", async () => {


### PR DESCRIPTION
# PR Overview
This PR removes the unsupported `--environment` flag from the `fillDependencies` call and adds comprehensive unit tests for the `bruin.fillAssetDependency` command handling.

## Key Changes
- Removed unsupported `--environment` flag that was causing issues in the fillDependencies call
- Added unit tests to verify `bruin.fillAssetDependency` command behavior
- Improved test coverage for asset dependency handling logic

