### PR TITLE
Fix/reset date button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.79.7] - [2026-04-02]
+- Fixed reset date button for continuous pipelines: now resets to today's date range (start of day to now) instead of throwing an error.
+- Improved reset date button tooltip to clarify behavior based on pipeline schedule.
+
 ## [0.79.6] - [2026-03-31]
 - Fixed "Fill from Query" command failing due to unsupported `--environment` flag being passed to `fill-asset-dependencies`.
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Bruin is a unified analytics platform that enables data professionals to work en
 ## Release Notes
 
 ### Recent Update
+- **0.79.7**: Fixed reset date button for continuous pipelines; improved tooltip to clarify behavior.
 - **0.79.6**: Fixed "Fill from Query" command failing due to unsupported `--environment` flag.
 - **0.79.5**: Added interval modifiers preview tooltip on the checkbox.
 - **0.79.4**: Fixed "Fill from DB" to use selected environment; fixed start date input on full refresh.
 - **0.79.3**: Added ability to select and run SQL text directly in Query Preview.
-- **0.79.2**: Added cancel button for export query operations, allowing users to stop long-running exports.
 
 For a full changelog, see Bruin Extension [Changelog](https://github.com/bruin-data/bruin-vscode/blob/main/CHANGELOG.md).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.79.6",
+  "version": "0.79.7",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -14,7 +14,7 @@
               <DateInput label="Start Date" v-model="startDate" />
               <DateInput label="End Date" v-model="endDate" />
               <div class="flex items-center gap-1 self-start xs:self-end">
-                <button type="button" @click="resetDatesOnSchedule" :title="`Reset Start and End Date`"
+                <button type="button" @click="resetDatesOnSchedule" :title="props.schedule === 'continuous' ? 'Reset dates to today (start of day to now)' : `Reset dates to the previous ${props.schedule || 'scheduled'} run interval`"
                   class="rounded-sm bg-editor-button-bg p-1 text-editor-button-fg hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed">
                   <ArrowPathRoundedSquareIcon class="h-3 w-3" aria-hidden="true" />
                 </button>

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -395,6 +395,14 @@ suite("testing webview", () => {
     assert.strictEqual(endDateExclusive, "2023-07-10T19:59:59.999999999Z");
   });
 
+  test('test reset Start End Date for "continuous" schedule', () => {
+    schedule = "continuous";
+    resetStartEndDate(schedule, today, startDate, endDate);
+    // For continuous: start = start of today (00:00 UTC), end = now
+    assert.strictEqual(startDate.value, "2024-07-08T00:00:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-08T05:23:00.000Z");
+  });
+
   test("test get previous run for invalid schedule", () => {
     schedule = "invalid";
     try {

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -216,14 +216,29 @@ export const getPreviousRun = (schedule: string, timestamp: number) => {
   return { startTime, endTime };
 };
 
-export const resetStartEndDate = (schedule: string, today: number, startDate: { value: string }, endDate: { value: string }) => {
+export const resetStartEndDate = (schedule: string, today: number | Date, startDate: { value: string }, endDate: { value: string }) => {
+  // Convert Date to timestamp if needed
+  const timestamp = typeof today === "number" ? today : today.getTime();
+
+  // For continuous schedules, use sensible defaults: start of today to now
+  if (schedule === "continuous") {
+    const now = DateTime.fromMillis(timestamp).toUTC();
+    const startOfDay = now.startOf("day");
+
+    startDate.value = startOfDay.toISO({ includeMillis: false });
+    endDate.value = now.toISO({ includeMillis: false });
+
+    console.log("Continuous schedule - start:", startDate.value, "end:", endDate.value);
+    return;
+  }
+
   const { startTime, endTime } = getPreviousRun(schedule, today);
   console.log("start date:", startDate.value, "end date:", endDate.value);
   console.log("today", today, "start time:", startTime, "end time:", endTime);
 
   startDate.value = DateTime.fromMillis(startTime).toUTC().toISO({ includeMillis: false });
   endDate.value = DateTime.fromMillis(endTime).toUTC().toISO({ includeMillis: false });
-  
+
   console.log("start:", startDate.value, "end:", endDate.value);
 };
 


### PR DESCRIPTION
# PR Overview 
For a continuous schedule, the reset date button wouldn't work, this pr improves it so it resets to the current date/time and improves the button title for clarity