### PR TITLE
fix: warn on interval_modifier typo

### DIFF
--- a/src/language-server/providers/materializationValidator.ts
+++ b/src/language-server/providers/materializationValidator.ts
@@ -120,22 +120,36 @@ export class MaterializationValidator {
         let topLevelIntervalModifiers = -1;
         let intervalModifiersUnderDefault = -1;
         let defaultStart = -1;
-        
+
         // Find top-level interval_modifiers and default section
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            
+
             if (line.match(/^interval_modifiers:\s*$/)) {
                 topLevelIntervalModifiers = i;
             }
-            
+
             if (line.match(/^default:\s*$/)) {
                 defaultStart = i;
             }
-            
+
             // Look for interval_modifiers under default
             if (defaultStart !== -1 && line.match(/^\s+interval_modifiers:\s*$/)) {
                 intervalModifiersUnderDefault = i;
+            }
+
+            // Flag common misspellings (e.g. singular "interval_modifier")
+            const typoMatch = line.match(/^(\s*)(interval_modifier|intervalmodifiers?|interval-modifiers?)\s*:/i);
+            if (typoMatch && typoMatch[2] !== 'interval_modifiers') {
+                const keyStart = typoMatch[1].length;
+                const keyEnd = keyStart + typoMatch[2].length;
+                const range = new vscode.Range(i, keyStart, i, keyEnd);
+                const diagnostic = new vscode.Diagnostic(
+                    range,
+                    `Unknown key "${typoMatch[2]}". Did you mean "interval_modifiers"?`,
+                    vscode.DiagnosticSeverity.Warning
+                );
+                diagnostics.push(diagnostic);
             }
         }
         


### PR DESCRIPTION
## Summary
- The validator only matched the exact key `interval_modifiers:`, so common typos like the singular `interval_modifier:` were silently dropped by the CLI with no diagnostic.
- Added a typo-detection branch in `materializationValidator.ts` that flags `interval_modifier`, `intervalmodifier(s)`, and `interval-modifier(s)` with a warning suggesting the correct key.

Closes BRU-3764.

## Test plan
- [ ] Open a pipeline.yml with `interval_modifier:` (singular) at top level — expect a yellow squiggle with "Unknown key 'interval_modifier'. Did you mean 'interval_modifiers'?"
- [ ] Open a SQL/Python asset with `interval_modifier:` inside a `@bruin` block — same warning appears.
- [ ] Correct spelling `interval_modifiers:` produces no false positive.
- [ ] Existing placement/format checks still fire for the canonical key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)