### PR TITLE
chore(deps): patch dependabot vulnerabilities (axios, fast-uri, uuid)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.79.8",
+  "version": "0.80.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.79.8",
+      "version": "0.80.1",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^3.0.3",
@@ -2431,13 +2431,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2451,6 +2452,31 @@
       },
       "peerDependencies": {
         "axios": "0.x || 1.x"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/azure-devops-node-api": {
@@ -3502,7 +3528,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4225,9 +4250,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -485,7 +485,9 @@
     "http-proxy-agent": "^7.0.2",
     "serialize-javascript": "^7.0.5",
     "diff": "^8.0.3",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "axios": "^1.15.2",
+    "fast-uri": "^3.1.2"
   },
   "dependencies": {
     "@rudderstack/analytics-js": "^3.11.15",

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -22,7 +22,7 @@
         "pinia": "^2.2.2",
         "tailwind-merge": "^2.2.2",
         "tailwindcss-animate": "^1.0.7",
-        "uuid": "^10.0.0",
+        "uuid": "^11.1.1",
         "vue": "^3.4.21"
       },
       "devDependencies": {
@@ -3592,14 +3592,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -26,7 +26,7 @@
     "pinia": "^2.2.2",
     "tailwind-merge": "^2.2.2",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^10.0.0",
+    "uuid": "^11.1.1",
     "vue": "^3.4.21"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Resolve 5 of 6 open Dependabot alerts:

| Alert | Package | Fix | Manifest |
|---|---|---|---|
| #113, #116 | axios | `^1.15.2` via root `overrides` (resolves to 1.16.1) | `package.json` |
| #114, #115 | fast-uri | `^3.1.2` via root `overrides` | `package.json` |
| #122 | uuid | `^10.0.0` → `^11.1.1` (direct dep) | `webview-ui/package.json` |

- `axios` was pinned exactly to `1.15.1` by `@rudderstack/rudder-sdk-node`, so a transitive bump via `npm update` was not possible — added to `overrides`.
- `fast-uri` was already constrained as `^3.0.1` by `ajv`, but added to `overrides` to be explicit.
- `uuid` is a major bump (10 → 11). Only the `v4` named import is used (4 call sites: `bruinStore.ts`, `BruinSettings.vue`, `AssetColumns.vue`, `CustomChecks.vue`), and that API has been stable since v7.

## Not included
**Alert #119 — `js-cookie` (high)**: patched at `3.0.7`, published 2026-05-16, which is past the team's `npm config before` supply-chain cutoff (2026-05-15). It is a dev-only transitive dep via `@vue/test-utils → js-beautify` and never reaches the webview runtime. Suggest a follow-up once the cutoff naturally rolls forward.

## Test plan
- [x] `npm run compile` (root) — clean
- [x] `vitest run` (webview-ui) — 156/156 pass
- [x] `npm audit` confirms the 4 root + 1 webview Dependabot CVEs are gone
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)