### PR TITLE
fix: friendly error when bruin CLI cannot find a git repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.80.1",
+      "version": "0.80.2",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^3.0.3",

--- a/src/bruin/bruinConnections.ts
+++ b/src/bruin/bruinConnections.ts
@@ -1,7 +1,7 @@
 import { BruinCommandOptions } from "../types";
 import { BruinCommand } from "./bruinCommand";
 import { BruinPanel } from "../panels/BruinPanel";
-import { extractNonNullConnections } from "../utilities/helperUtils";
+import { extractNonNullConnections, friendlifyBruinError } from "../utilities/helperUtils";
 
 /**
  * Extends the BruinCommand class to implement the Bruin 'connections list' command.
@@ -58,7 +58,7 @@ export class BruinConnections extends BruinCommand {
             } catch {
               // If not JSON, use the original error
             }
-            this.postMessageToPanels("error", errorMessage);
+            this.postMessageToPanels("error", friendlifyBruinError(errorMessage));
           }
         }
       )

--- a/src/bruin/bruinRender.ts
+++ b/src/bruin/bruinRender.ts
@@ -2,6 +2,7 @@ import { BruinPanel } from "../panels/BruinPanel";
 import { BruinCommand } from "./bruinCommand";
 import { BruinCommandOptions } from "../types";
 import {
+  friendlifyBruinError,
   isBruinAsset,
   isBruinPipeline,
   isBruinYaml,
@@ -116,12 +117,23 @@ export class BruinRender extends BruinCommand {
   private parseError(error: unknown): string {
     if (typeof error === 'object' && error !== null) {
       const err = error as Error;
-      return JSON.stringify({ error: err.message });
+      return JSON.stringify({ error: friendlifyBruinError(err.message) });
     }
     if (typeof error === 'string') {
-      return error.startsWith("{") ? error : JSON.stringify({ error });
+      if (error.startsWith("{")) {
+        try {
+          const parsed = JSON.parse(error);
+          if (typeof parsed?.error === "string") {
+            return JSON.stringify({ ...parsed, error: friendlifyBruinError(parsed.error) });
+          }
+        } catch {
+          // fall through to wrapping the raw string
+        }
+        return error;
+      }
+      return JSON.stringify({ error: friendlifyBruinError(error) });
     }
-    return JSON.stringify({ error: String(error) });
+    return JSON.stringify({ error: friendlifyBruinError(String(error)) });
   }
 
   private async isBruinPipeline(filePath: string): Promise<boolean> {

--- a/src/bruin/bruinValidate.ts
+++ b/src/bruin/bruinValidate.ts
@@ -2,6 +2,7 @@ import { BruinCommand } from "./bruinCommand";
 import { BruinPanel } from "../panels/BruinPanel";
 import { BruinCommandOptions } from "../types";
 import { platform } from "os";
+import { friendlifyBruinError } from "../utilities/helperUtils";
 /**
  * Extends the BruinCommand class to implement the bruin validate command on Bruin assets.
  */
@@ -100,17 +101,17 @@ export class BruinValidate extends BruinCommand {
 
       // More comprehensive error handling
       if (typeof error === "string") {
-        errorMessage = error;
+        errorMessage = friendlifyBruinError(error);
       } else if (error instanceof Error) {
         errorMessage = JSON.stringify({
-          error: error.message || "An unknown error occurred",
+          error: friendlifyBruinError(error.message || "An unknown error occurred"),
           stack: error.stack,
         });
       } else if (typeof error === "object" && error !== null) {
         try {
           // Attempt to extract meaningful error information
           errorMessage = JSON.stringify({
-            error: error.error || error.message || JSON.stringify(error),
+            error: friendlifyBruinError(error.error || error.message || JSON.stringify(error)),
           });
         } catch {
           errorMessage = JSON.stringify({ error: "An unknown error occurred" });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -24,6 +24,8 @@ import {
   prepareFlags,
   cronToHumanReadable,
   buildRenderFlags,
+  friendlifyBruinError,
+  FRIENDLY_NO_GIT_REPO_MESSAGE,
 } from "../utilities/helperUtils";
 import * as configuration from "../extension/configuration";
 import * as bruinUtils from "../bruin/bruinUtils";
@@ -1091,6 +1093,48 @@ suite("Render Command Helper functions", () => {
   test("processLineageData should extract the name property", () => {
     const lineageString = { name: "example-name" };
     assert.strictEqual(processLineageData(lineageString), "example-name");
+  });
+
+  suite("friendlifyBruinError", () => {
+    test("maps 'no git repository found' to the friendly message", () => {
+      assert.strictEqual(
+        friendlifyBruinError("no git repository found"),
+        FRIENDLY_NO_GIT_REPO_MESSAGE
+      );
+    });
+
+    test("maps 'failed to find the git repository root' to the friendly message", () => {
+      assert.strictEqual(
+        friendlifyBruinError("Failed to find the git repository root: no git repository found"),
+        FRIENDLY_NO_GIT_REPO_MESSAGE
+      );
+    });
+
+    test("matches patterns case-insensitively", () => {
+      assert.strictEqual(
+        friendlifyBruinError("NO GIT REPOSITORY FOUND"),
+        FRIENDLY_NO_GIT_REPO_MESSAGE
+      );
+    });
+
+    test("passes through unrelated error strings unchanged", () => {
+      assert.strictEqual(
+        friendlifyBruinError("validation failed: syntax error at line 1"),
+        "validation failed: syntax error at line 1"
+      );
+    });
+
+    test("extracts message from Error instances", () => {
+      assert.strictEqual(
+        friendlifyBruinError(new Error("no git repository found")),
+        FRIENDLY_NO_GIT_REPO_MESSAGE
+      );
+    });
+
+    test("handles null/undefined safely", () => {
+      assert.strictEqual(friendlifyBruinError(null), "");
+      assert.strictEqual(friendlifyBruinError(undefined), "");
+    });
   });
 });
 

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -136,6 +136,24 @@ export const removeAnsiColors = (str: string): string => {
   return str.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
 };
 
+export const FRIENDLY_NO_GIT_REPO_MESSAGE =
+  "Bruin requires a git repository. Run `git init` at your project root, then reload the window.";
+
+const NO_GIT_REPO_PATTERNS = [
+  /no git repository found/i,
+  /failed to find the git repository root/i,
+];
+
+export const friendlifyBruinError = (raw: unknown): string => {
+  const text =
+    typeof raw === "string"
+      ? raw
+      : raw instanceof Error
+        ? raw.message
+        : String(raw ?? "");
+  return NO_GIT_REPO_PATTERNS.some((re) => re.test(text)) ? FRIENDLY_NO_GIT_REPO_MESSAGE : text;
+};
+
 /* export const processLineageData =(lineageString : string): any => {
   if (lineageString.startsWith('"') && lineageString.endsWith('"')) {
   lineageString = lineageString.substring(1, lineageString.length - 1);


### PR DESCRIPTION
## Summary
- Detect `no git repository found` / `failed to find the git repository root` in bruin CLI output and replace with a single actionable message: *"Bruin requires a git repository. Run `git init` at your project root, then reload the window."*
- New helper `friendlifyBruinError` + constant `FRIENDLY_NO_GIT_REPO_MESSAGE` in `src/utilities/helperUtils.ts`.
- Wired into validate (`bruinValidate.ts`), connections list (`bruinConnections.ts`), and render `parseError` (`bruinRender.ts`).
- 6 unit tests covering both patterns, case-insensitivity, pass-through, `Error` inputs, and `null`/`undefined`.

## Context
Related to BRU-2675. The ticket's "incorrect workspace root folder" framing turned out to be a red herring — bruin CLI walks up from the file path (not cwd/workspace) to find `.git`, so the workspace root location does not matter. The real cause was a missing git repo in the user's project, and the CLI errors surfaced today are unfriendly. This PR doesn't change the CLI requirement; it just makes the failure actionable.

Render currently keeps showing the generic "failed to mutate the asset" because the CLI itself drops the underlying cause for the `render` subcommand — that's a separate upstream fix in `bruin-data/bruin`. Once fixed there, this PR's helper will cover render automatically with no further extension changes.

## Test plan
- [x] `tsc -p ./ --noEmit` clean
- [x] `eslint` clean on all touched files
- [x] Helper unit tests pass (7 assertions verified against compiled output)
- [ ] Manual: open a folder with no `.git` ancestor, click **Validate** → expect friendly message instead of `no git repository found`
- [ ] Manual: open Settings → Connections in same folder → expect friendly message instead of `failed to find the git repository root`
- [ ] Manual: open a folder with `.git` → confirm normal flows still work (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)