### PR TITLE
fix: preserve default Run action on non-Bruin files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.80.3] - [2026-06-02]
+- Moved the Bruin Render button out of the editor title Run split-button group so it no longer overrides the default Run action (e.g. "Run Python File") on non-Bruin files. The Bruin icon remains in the editor title bar for one-click access to the side panel.
+
 ## [0.80.2] - [2026-05-22]
 - Added a connection picker to the "Fill from DB" button on the Columns tab so users can fill columns from a source (or any other) connection instead of only the destination. The new dropdown auto-suggests the source connection on ingestr assets and passes `--connection <name>` to `bruin patch fill-columns-from-db`.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 ## Release Notes
 
 ### Recent Update
+- **0.80.3**: Moved the Bruin Render button out of the editor title Run split-button group so it no longer overrides the default Run action on non-Bruin files. The Bruin icon stays visible in the editor title bar.
 - **0.80.2**: Added a connection picker to "Fill from DB" so columns can be filled from the source (or any other) connection, with auto-suggestion on ingestr assets.
 - **0.80.1**: Added warning for `interval_modifiers` typos.
 - **0.80.0**: Added variant selector to the asset panel for pipelines that declare variants. The selected variant is passed to `bruin run` as `--variant <name>`.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.80.2",
+  "version": "0.80.3",
   "engines": {
     "vscode": "^1.87.0"
   },
@@ -278,7 +278,7 @@
       }
     ],
     "menus": {
-      "editor/title/run": [
+      "editor/title": [
         {
           "command": "bruin.renderSQL",
           "group": "navigation"


### PR DESCRIPTION
## Summary
- Moves the `bruin.renderSQL` menu contribution from `editor/title/run` to `editor/title` in `package.json` so the Bruin icon no longer participates in VS Code's Run split-button.
- The pink Bruin icon stays visible in the editor title bar on every file (still one-click to open the side panel / convert files to assets), but VS Code's default Run action (e.g. "Run Python File") is preserved on non-Bruin files.
- Bumps version to `0.80.3`, with matching CHANGELOG and README release-notes entries.

## Why
A user reported that after installing the Bruin extension, the Bruin Render button replaced their default Python Run action in the editor title bar. Because `bruin.renderSQL` was contributed to `editor/title/run` with no `when` clause, clicking it once made it the new default for the split-button across all file types — surprising for non-Bruin development.

## Test plan
- [ ] Install the packaged extension on a workspace with a Python file open — confirm the Bruin icon appears in the title bar and the Run button still defaults to "Run Python File".
- [ ] Click the Bruin icon on a non-Bruin file — confirm the side panel opens (so users can still convert the file to a Bruin asset).
- [ ] Open a Bruin asset (SQL/Python) — confirm the Bruin icon still works as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)