### PR TITLE
improve: MSSQL options in YAML + collapsible connection environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.80.4] - [2026-06-04]
+- Allowed `options` property on MSSQL/Synapse connections in `.bruin.yml`.
+- Made environment groups in the connections webview collapsible (collapsed by default) with a per-environment connection count.
+
 ## [0.80.3] - [2026-06-02]
 - Added Fabric as a valid ingestr destination.
 - Updated dependencies (vitest, tmp, qs, brace-expansion, js-cookie).

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 ## Release Notes
 
 ### Recent Update
+- **0.80.4**: Allowed `options` on MSSQL/Synapse connections in `.bruin.yml`; made connection environments collapsible (collapsed by default) with a connection count per environment.
 - **0.80.3**: Added Fabric as a valid ingestr destination; updated dependencies.
 - **0.80.2**: Added a connection picker to "Fill from DB" so columns can be filled from the source (or any other) connection, with auto-suggestion on ingestr assets.
 - **0.80.1**: Added warning for `interval_modifiers` typos.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.80.3",
+  "version": "0.80.4",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/schemas/config-schema.json
+++ b/schemas/config-schema.json
@@ -352,6 +352,9 @@
                 },
                 "database": {
                     "type": "string"
+                },
+                "options": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/src/ui-test/webview-tests.test.ts
+++ b/src/ui-test/webview-tests.test.ts
@@ -3776,6 +3776,43 @@ describe("Bruin Webview Test", function () {
 
 
   describe("Advanced Settings tests", function () {
+    const isWindowsAdv = process.platform === 'win32';
+    const isCIAdv = process.env.CI === 'true';
+    const getAdvDelay = (baseDelay: number) => (isWindowsAdv || isCIAdv) ? baseDelay * 3 : baseDelay;
+
+    // Re-locate the element on every attempt so we don't hold a stale reference
+    // when Vue re-renders the form after a value change.
+    const safeElementInteraction = async <T>(
+      elementId: string,
+      action: (element: WebElement) => Promise<T>,
+      maxRetries: number = 3,
+    ): Promise<T | undefined> => {
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+          const element = await driver.wait(
+            until.elementLocated(By.id(elementId)),
+            getAdvDelay(5000),
+            `Element ${elementId} not found`,
+          );
+          return await action(element);
+        } catch (err: any) {
+          const isStale = err?.name === 'StaleElementReferenceError' ||
+            String(err?.message || '').includes('stale element');
+          if (!isStale || attempt === maxRetries - 1) throw err;
+          console.log(`Element ${elementId} became stale on attempt ${attempt + 1}, retrying...`);
+          await sleep(getAdvDelay(200));
+        }
+      }
+    };
+
+    const selectOptionByValue = async (selectId: string, value: string) => {
+      await safeElementInteraction(selectId, async (select) => {
+        await select.click();
+        const option = await select.findElement(By.css(`option[value="${value}"]`));
+        await option.click();
+      });
+    };
+
     beforeEach(async function () {
       this.timeout(25000);
       
@@ -3828,49 +3865,47 @@ describe("Bruin Webview Test", function () {
     });
 
     it("should configure interval modifiers", async function () {
-      this.timeout(25000);
-      
+      this.timeout(getAdvDelay(25000));
+
       try {
         // Ensure Advanced Settings section is still expanded
-        const advancedHeader = await driver.findElement(By.id("advanced-section-header"));
-        const chevron = await advancedHeader.findElement(By.id("advanced-section-chevron"));
-        const chevronClass = await chevron.getAttribute("class");
-        
-        if (chevronClass.includes("codicon-chevron-right")) {
-          await advancedHeader.click();
-          await sleep(3000);
-          console.log("✓ Re-expanded Advanced Settings section for interval modifiers test");
-        }
-        
-        // Test start interval configuration
-        const startIntervalInput = await driver.wait(
+        await safeElementInteraction("advanced-section-header", async (header) => {
+          const chevron = await header.findElement(By.id("advanced-section-chevron"));
+          const chevronClass = await chevron.getAttribute("class");
+          if (chevronClass.includes("codicon-chevron-right")) {
+            await header.click();
+            await sleep(getAdvDelay(3000));
+            console.log("✓ Re-expanded Advanced Settings section for interval modifiers test");
+          }
+        });
+
+        // Wait for the section content to be present before interacting
+        await driver.wait(
           until.elementLocated(By.id("start-interval-input")),
-          10000,
-          "Start interval input not found"
+          getAdvDelay(10000),
+          "Start interval input not found",
         );
-        
-        await startIntervalInput.clear();
-        await startIntervalInput.sendKeys("-2");
+
+        // Test start interval configuration
+        await safeElementInteraction("start-interval-input", async (input) => {
+          await input.clear();
+          await input.sendKeys("-2");
+        });
         console.log("✓ Set start interval value");
-        
-        const startIntervalUnit = await driver.findElement(By.id("start-interval-unit"));
-        await startIntervalUnit.click();
-        const dayOption = await startIntervalUnit.findElement(By.css('option[value="days"]'));
-        await dayOption.click();
+
+        await selectOptionByValue("start-interval-unit", "days");
         console.log("✓ Set start interval unit to days");
-        
+
         // Test end interval configuration
-        const endIntervalInput = await driver.findElement(By.id("end-interval-input"));
-        await endIntervalInput.clear();
-        await endIntervalInput.sendKeys("1");
+        await safeElementInteraction("end-interval-input", async (input) => {
+          await input.clear();
+          await input.sendKeys("1");
+        });
         console.log("✓ Set end interval value");
-        
-        const endIntervalUnit = await driver.findElement(By.id("end-interval-unit"));
-        await endIntervalUnit.click();
-        const endDayOption = await endIntervalUnit.findElement(By.css('option[value="days"]'));
-        await endDayOption.click();
+
+        await selectOptionByValue("end-interval-unit", "days");
         console.log("✓ Set end interval unit to days");
-        
+
       } catch (error) {
         console.log("Error in interval modifiers test:", error);
         throw error;

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -11,11 +11,20 @@
             </p>
           </div>
           <div class="flex items-center space-x-2">
-            <vscode-button id="add-environment-button" @click="addNewEnvironment" 
+            <button
+              v-if="environmentNames.length > 1"
+              id="toggle-all-environments-button"
+              @click="toggleAllEnvironments"
+              class="text-xs text-descriptionFg hover:text-editor-fg px-2 py-1 cursor-pointer"
+              :title="allCollapsed ? 'Expand all environments' : 'Collapse all environments'"
+            >
+              {{ allCollapsed ? "Expand all" : "Collapse all" }}
+            </button>
+            <vscode-button id="add-environment-button" @click="addNewEnvironment"
             class="font-semibold"
             appearance="secondary">
               <div class="flex items-center">
-                <span class="codicon codicon-plus"></span> 
+                <span class="codicon codicon-plus"></span>
                 <span class="ml-1">Environment</span>
               </div>
             </vscode-button>
@@ -119,6 +128,18 @@
       <div class="flex items-center justify-between mb-2 group hover:bg-editor-hoverBackground rounded px-2 py-1 -mx-2 -my-1">
         <div class="flex flex-col items-start space-y-1">
           <div class="flex items-center space-x-2">
+            <button
+              :id="`toggle-environment-${environment}`"
+              v-if="editingEnvironment !== environment"
+              @click="toggleEnvironment(environment)"
+              class="text-descriptionFg hover:text-editor-fg p-0.5"
+              :title="isCollapsed(environment) ? 'Expand' : 'Collapse'"
+            >
+              <span
+                class="codicon"
+                :class="isCollapsed(environment) ? 'codicon-chevron-right' : 'codicon-chevron-down'"
+              ></span>
+            </button>
             <input
               id="edit-environment-input"
               v-if="editingEnvironment === environment"
@@ -131,13 +152,17 @@
               :class="{ 'border-editorError-foreground': editEnvironmentError }"
               ref="environmentInput"
             />
-            <h3 
+            <h3
               v-else
               :id="`environment-header-${environment}`"
+              @click="toggleEnvironment(environment)"
               @dblclick="startEditingEnvironment(environment)"
-              class="text-sm font-medium text-editor-fg font-mono cursor-pointer px-1 py-0.5"
+              class="text-sm font-medium text-editor-fg font-mono cursor-pointer px-1 py-0.5 select-none"
             >
               {{ environment === defaultEnvironment ? `${environment} (default)` : environment }}
+              <span class="ml-1 text-xs text-descriptionFg opacity-70">
+                ({{ connections.filter(c => !c.isEmpty).length }})
+              </span>
             </h3>
             <div class="flex items-center space-x-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
               <button
@@ -171,7 +196,7 @@
           </div>
         </vscode-button>
       </div>
-      <div class="relative bg-editorWidget-bg">
+      <div v-show="!isCollapsed(environment)" class="relative bg-editorWidget-bg">
         <div class="overflow-x-auto">
           <table id="connections-table" class="min-w-full divide-y divide-commandCenter-border">
             <thead>
@@ -335,6 +360,21 @@ const newEnvironmentName = ref('');
 const newEnvironmentInput = ref(null);
 const newEnvironmentError = ref('');
 
+// Track which environments are collapsed
+const collapsedEnvironments = ref(new Set());
+
+const isCollapsed = (environment) => collapsedEnvironments.value.has(environment);
+
+const toggleEnvironment = (environment) => {
+  const next = new Set(collapsedEnvironments.value);
+  if (next.has(environment)) {
+    next.delete(environment);
+  } else {
+    next.add(environment);
+  }
+  collapsedEnvironments.value = next;
+};
+
 const groupedConnections = computed(() => {
   return connections.value.reduce((grouped, connection) => {
     const environment = connection.environment;
@@ -352,15 +392,30 @@ const existingEnvironments = computed(() => {
 
 const environmentsWithConnections = computed(() => {
   const result = {};
-  
+
   const environments = props.environments || Object.keys(groupedConnections.value);
-  
+
   environments.forEach(environment => {
     result[environment] = groupedConnections.value[environment] || [];
   });
-  
+
   return result;
 });
+
+const environmentNames = computed(() => Object.keys(environmentsWithConnections.value));
+
+const allCollapsed = computed(() =>
+  environmentNames.value.length > 0 &&
+  environmentNames.value.every((env) => collapsedEnvironments.value.has(env))
+);
+
+const toggleAllEnvironments = () => {
+  if (allCollapsed.value) {
+    collapsedEnvironments.value = new Set();
+  } else {
+    collapsedEnvironments.value = new Set(environmentNames.value);
+  }
+};
 
 const toggleMenu = (connectionName, event) => {
   activeMenu.value = activeMenu.value === connectionName ? null : connectionName;

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -11,15 +11,6 @@
             </p>
           </div>
           <div class="flex items-center space-x-2">
-            <button
-              v-if="environmentNames.length > 1"
-              id="toggle-all-environments-button"
-              @click="toggleAllEnvironments"
-              class="text-xs text-descriptionFg hover:text-editor-fg px-2 py-1 cursor-pointer"
-              :title="allCollapsed ? 'Expand all environments' : 'Collapse all environments'"
-            >
-              {{ allCollapsed ? "Expand all" : "Collapse all" }}
-            </button>
             <vscode-button id="add-environment-button" @click="addNewEnvironment"
             class="font-semibold"
             appearance="secondary">
@@ -306,7 +297,7 @@
 
 <script setup>
 import { useConnectionsStore } from "@/store/bruinStore";
-import { computed, onMounted, ref, defineEmits, onUnmounted } from "vue";
+import { computed, onMounted, ref, defineEmits, onUnmounted, watch } from "vue";
 import {
   TrashIcon,
   PencilIcon,
@@ -360,8 +351,9 @@ const newEnvironmentName = ref('');
 const newEnvironmentInput = ref(null);
 const newEnvironmentError = ref('');
 
-// Track which environments are collapsed
+// Track which environments are collapsed (collapsed by default)
 const collapsedEnvironments = ref(new Set());
+const initializedCollapsed = ref(false);
 
 const isCollapsed = (environment) => collapsedEnvironments.value.has(environment);
 
@@ -402,20 +394,14 @@ const environmentsWithConnections = computed(() => {
   return result;
 });
 
-const environmentNames = computed(() => Object.keys(environmentsWithConnections.value));
-
-const allCollapsed = computed(() =>
-  environmentNames.value.length > 0 &&
-  environmentNames.value.every((env) => collapsedEnvironments.value.has(env))
-);
-
-const toggleAllEnvironments = () => {
-  if (allCollapsed.value) {
-    collapsedEnvironments.value = new Set();
-  } else {
-    collapsedEnvironments.value = new Set(environmentNames.value);
+// Initialize all environments as collapsed by default
+watch(environmentsWithConnections, (newVal) => {
+  const envKeys = Object.keys(newVal);
+  if (envKeys.length > 0 && !initializedCollapsed.value) {
+    collapsedEnvironments.value = new Set(envKeys);
+    initializedCollapsed.value = true;
   }
-};
+}, { immediate: true });
 
 const toggleMenu = (connectionName, event) => {
   activeMenu.value = activeMenu.value === connectionName ? null : connectionName;

--- a/webview-ui/src/components/connections/ConnectionList.vue
+++ b/webview-ui/src/components/connections/ConnectionList.vue
@@ -120,6 +120,7 @@
         <div class="flex flex-col items-start space-y-1">
           <div class="flex items-center space-x-2">
             <button
+              type="button"
               :id="`toggle-environment-${environment}`"
               v-if="editingEnvironment !== environment"
               @click="toggleEnvironment(environment)"


### PR DESCRIPTION
## Summary
- **BRU-4846**: `mssqlConnection` in `schemas/config-schema.json` now allows an `options` string property, so `.bruin.yml` accepts e.g. `options: TrustServerCertificate=true`. Synapse picks this up too since it reuses the same definition.
- **BRU-4847**: Environment groups in the connections webview are now collapsible — each header has a chevron toggle and shows a connection count `(n)`. Environments are collapsed by default to keep the list scannable when there are many environments/connections.

## Test plan
- [ ] Open a `.bruin.yml` with an `mssql` connection that has `options: TrustServerCertificate=true` and confirm no "Property options is not allowed" warning.
- [ ] Same check for a `synapse` connection.
- [ ] Open the Connections webview: environments should appear collapsed by default with `(n)` count next to each name.
- [ ] Clicking the chevron (or the environment name) expands/collapses that environment.
- [ ] Double-clicking the environment name still enters rename mode.
- [ ] Edit / delete / add-connection / add-environment flows still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)