### PR TITLE
improve: inline run variables panel (BRU-4848) + stabilize materialization tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.80.5] - [2026-06-04]
+- Flattened the run variables UI: variable overrides now appear in an inline panel under the run controls with all variables, defaults, and override inputs visible at once. The "Variable overrides" toggle auto-enables when an override is entered and turns off when the last one is cleared.
+
 ## [0.80.4] - [2026-06-04]
 - Allowed `options` property on MSSQL/Synapse connections in `.bruin.yml`.
 - Made environment groups in the connections webview collapsible (collapsed by default) with a per-environment connection count.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Bruin is a unified analytics platform that enables data professionals to work en
 ## Release Notes
 
 ### Recent Update
+- **0.80.5**: Flattened the run variables UI — overrides appear inline under the run controls, all variables visible at once, with the "Variable overrides" toggle auto-enabled when an override is entered.
 - **0.80.4**: Allowed `options` on MSSQL/Synapse connections in `.bruin.yml`; made connection environments collapsible (collapsed by default) with a connection count per environment.
 - **0.80.3**: Added Fabric as a valid ingestr destination; updated dependencies.
 - **0.80.2**: Added a connection picker to "Fill from DB" so columns can be filled from the source (or any other) connection, with auto-suggestion on ingestr assets.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.80.4",
+  "version": "0.80.5",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/ui-test/webview-tests.test.ts
+++ b/src/ui-test/webview-tests.test.ts
@@ -2849,10 +2849,11 @@ describe("Bruin Webview Test", function () {
     let ownerContainer: WebElement;
     let tagsContainer: WebElement;
 
-    // Platform-specific timing adjustments
+    // Platform-specific timing adjustments (3x slower on Windows or CI)
     const isWindows = process.platform === 'win32';
-    const getPlatformDelay = (baseDelay: number) => isWindows ? baseDelay * 2 : baseDelay;
-    
+    const isCI = process.env.CI === 'true';
+    const getPlatformDelay = (baseDelay: number) => (isWindows || isCI) ? baseDelay * 3 : baseDelay;
+
     // Helper function to safely interact with elements that might become stale
     const safeElementInteraction = async (elementId: string, action: (element: WebElement) => Promise<any>, maxRetries: number = 3) => {
       for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -2863,12 +2864,49 @@ describe("Bruin Webview Test", function () {
             `Element ${elementId} not found`
           );
           return await action(element);
-        } catch (staleError) {
-          if (attempt === maxRetries - 1) throw staleError;
+        } catch (err: any) {
+          const isStale = err?.name === 'StaleElementReferenceError' ||
+            String(err?.message || '').includes('stale element');
+          if (!isStale || attempt === maxRetries - 1) throw err;
           console.log(`Element ${elementId} became stale on attempt ${attempt + 1}, retrying...`);
           await sleep(getPlatformDelay(200));
         }
       }
+    };
+
+    // Ensures the Details tab is active and the materialization section is expanded.
+    // Used at the top of every test so a flaky beforeEach can't leave a test running
+    // against a missing section.
+    const ensureMaterializationSectionExpanded = async () => {
+      // Navigate to Details tab (idempotent — clicking an already-active tab is a no-op).
+      const detailsTab = await driver.wait(
+        until.elementLocated(By.id("tab-2")),
+        getPlatformDelay(10000),
+        "Details tab not found",
+      );
+      await detailsTab.click();
+      await sleep(getPlatformDelay(1000));
+
+      // Wait for the materialization section to appear before doing anything else.
+      await driver.wait(
+        until.elementLocated(By.id("materialization-section")),
+        getPlatformDelay(15000),
+        "Materialization section not found",
+      );
+
+      // Expand if collapsed. Re-find via the helper so we don't hold a stale ref.
+      await safeElementInteraction("materialization-section-header", async (header) => {
+        try {
+          const chevron = await header.findElement(By.id("materialization-section-chevron"));
+          const chevronClass = await chevron.getAttribute("class");
+          if (chevronClass.includes("codicon-chevron-right")) {
+            await header.click();
+            await sleep(getPlatformDelay(1500));
+          }
+        } catch {
+          // No chevron — assume already expanded.
+        }
+      });
     };
 
     beforeEach(async function () {
@@ -3164,30 +3202,15 @@ describe("Bruin Webview Test", function () {
     // });
 
     it("should test table materialization shows strategy dropdown", async function () {
-      this.timeout(20000);
-      
+      this.timeout(getPlatformDelay(20000));
+
       try {
-        // Ensure materialization section is expanded
-        const materializationSection = await driver.findElement(By.id("materialization-section"));
-        const sectionHeader = await materializationSection.findElement(By.id("materialization-section-header"));
-        
-        // Check if section is collapsed and expand if needed
-        try {
-          const chevron = await sectionHeader.findElement(By.id("materialization-section-chevron"));
-          const chevronClass = await chevron.getAttribute("class");
-          if (chevronClass.includes("codicon-chevron-right")) {
-            await sectionHeader.click();
-            await sleep(1000);
-            console.log("✓ Expanded materialization section");
-          }
-        } catch (chevronError) {
-          // Section may already be expanded
-        }
+        await ensureMaterializationSectionExpanded();
 
         // First set type to table
         const tableRadio = await driver.wait(
           until.elementLocated(By.id("materialization-type-table")),
-          10000,
+          getPlatformDelay(10000),
           "Materialization type table radio not found"
         );
         await tableRadio.click();
@@ -3212,26 +3235,17 @@ describe("Bruin Webview Test", function () {
     });
 
     it("should test view materialization hides strategy dropdown", async function () {
-      this.timeout(20000);
-      
+      this.timeout(getPlatformDelay(20000));
+
       try {
-        // Ensure materialization section is expanded
-        const materializationSection = await driver.findElement(By.id("materialization-section"));
-        const sectionHeader = await materializationSection.findElement(By.id("materialization-section-header"));
-        
-        try {
-          const chevron = await sectionHeader.findElement(By.id("materialization-section-chevron"));
-          const chevronClass = await chevron.getAttribute("class");
-          if (chevronClass.includes("codicon-chevron-right")) {
-            await sectionHeader.click();
-            await sleep(1000);
-          }
-        } catch (chevronError) {
-          // Section may already be expanded
-        }
+        await ensureMaterializationSectionExpanded();
 
         // Set type to view
-        const viewRadio = await driver.findElement(By.id("materialization-type-view"));
+        const viewRadio = await driver.wait(
+          until.elementLocated(By.id("materialization-type-view")),
+          getPlatformDelay(10000),
+          "Materialization type view radio not found"
+        );
         await viewRadio.click();
         await sleep(1000);
         console.log("✓ Selected view materialization type");
@@ -3256,23 +3270,10 @@ describe("Bruin Webview Test", function () {
     });
 
     it("should test switching between materialization strategies", async function () {
-      this.timeout(25000);
-      
+      this.timeout(getPlatformDelay(25000));
+
       try {
-        // Ensure materialization section is expanded and set to table
-        const materializationSection = await driver.findElement(By.id("materialization-section"));
-        const sectionHeader = await materializationSection.findElement(By.id("materialization-section-header"));
-        
-        try {
-          const chevron = await sectionHeader.findElement(By.id("materialization-section-chevron"));
-          const chevronClass = await chevron.getAttribute("class");
-          if (chevronClass.includes("codicon-chevron-right")) {
-            await sectionHeader.click();
-            await sleep(1000);
-          }
-        } catch (chevronError) {
-          // Section may already be expanded
-        }
+        await ensureMaterializationSectionExpanded();
 
         // Ensure we're working with table type
         const tableRadio = await driver.wait(
@@ -3375,28 +3376,17 @@ describe("Bruin Webview Test", function () {
     });
 
     it("should validate that strategy changes update configuration", async function () {
-      this.timeout(20000);
-      
+      this.timeout(getPlatformDelay(20000));
+
       try {
-        // Ensure materialization section is expanded and set to table
-        const materializationSection = await driver.findElement(By.id("materialization-section"));
-        const sectionHeader = await materializationSection.findElement(By.id("materialization-section-header"));
-        
-        try {
-          const chevron = await sectionHeader.findElement(By.id("materialization-section-chevron"));
-          const chevronClass = await chevron.getAttribute("class");
-          if (chevronClass.includes("codicon-chevron-right")) {
-            await sectionHeader.click();
-            await sleep(1000);
-          }
-        } catch (chevronError) {
-          // Section may already be expanded
-        }
+        await ensureMaterializationSectionExpanded();
+        // Keep a reference to the section header for header-text validation below.
+        const sectionHeader = await driver.findElement(By.id("materialization-section-header"));
 
         // Set to table type first
         const tableRadio = await driver.wait(
           until.elementLocated(By.id("materialization-type-table")),
-          10000,
+          getPlatformDelay(10000),
           "Materialization type table radio not found"
         );
         await tableRadio.click();
@@ -3444,28 +3434,15 @@ describe("Bruin Webview Test", function () {
     });
 
     it("should test delete+insert strategy shows incremental key input", async function () {
-      this.timeout(25000);
-      
+      this.timeout(getPlatformDelay(25000));
+
       try {
-        // Ensure materialization section is expanded and set to table
-        const materializationSection = await driver.findElement(By.id("materialization-section"));
-        const sectionHeader = await materializationSection.findElement(By.id("materialization-section-header"));
-        
-        try {
-          const chevron = await sectionHeader.findElement(By.id("materialization-section-chevron"));
-          const chevronClass = await chevron.getAttribute("class");
-          if (chevronClass.includes("codicon-chevron-right")) {
-            await sectionHeader.click();
-            await sleep(1000);
-          }
-        } catch (chevronError) {
-          // Section may already be expanded
-        }
+        await ensureMaterializationSectionExpanded();
 
         // Set to table type first
         const tableRadio = await driver.wait(
           until.elementLocated(By.id("materialization-type-table")),
-          10000,
+          getPlatformDelay(10000),
           "Materialization type table radio not found"
         );
         await tableRadio.click();
@@ -3536,28 +3513,15 @@ describe("Bruin Webview Test", function () {
     });
 
     it("should test create+replace strategy hides incremental key input", async function () {
-      this.timeout(20000);
-      
+      this.timeout(getPlatformDelay(20000));
+
       try {
-        // Ensure materialization section is expanded and set to table
-        const materializationSection = await driver.findElement(By.id("materialization-section"));
-        const sectionHeader = await materializationSection.findElement(By.id("materialization-section-header"));
-        
-        try {
-          const chevron = await sectionHeader.findElement(By.id("materialization-section-chevron"));
-          const chevronClass = await chevron.getAttribute("class");
-          if (chevronClass.includes("codicon-chevron-right")) {
-            await sectionHeader.click();
-            await sleep(1000);
-          }
-        } catch (chevronError) {
-          // Section may already be expanded
-        }
+        await ensureMaterializationSectionExpanded();
 
         // Set to table type
         const tableRadio = await driver.wait(
           until.elementLocated(By.id("materialization-type-table")),
-          10000,
+          getPlatformDelay(10000),
           "Materialization type table radio not found"
         );
         await tableRadio.click();
@@ -3593,28 +3557,15 @@ describe("Bruin Webview Test", function () {
     });
 
     it("should test time_interval strategy shows both incremental key and time granularity inputs", async function () {
-      this.timeout(20000);
-      
+      this.timeout(getPlatformDelay(20000));
+
       try {
-        // Ensure materialization section is expanded and set to table
-        const materializationSection = await driver.findElement(By.id("materialization-section"));
-        const sectionHeader = await materializationSection.findElement(By.id("materialization-section-header"));
-        
-        try {
-          const chevron = await sectionHeader.findElement(By.id("materialization-section-chevron"));
-          const chevronClass = await chevron.getAttribute("class");
-          if (chevronClass.includes("codicon-chevron-right")) {
-            await sectionHeader.click();
-            await sleep(1000);
-          }
-        } catch (chevronError) {
-          // Section may already be expanded
-        }
+        await ensureMaterializationSectionExpanded();
 
         // Set to table type
         const tableRadio = await driver.wait(
           until.elementLocated(By.id("materialization-type-table")),
-          10000,
+          getPlatformDelay(10000),
           "Materialization type table radio not found"
         );
         await tableRadio.click();
@@ -3699,13 +3650,26 @@ describe("Bruin Webview Test", function () {
     });
 
     it("should test merge strategy shows primary key configuration info", async function () {
-      this.timeout(20000);
-      
+      this.timeout(getPlatformDelay(20000));
+
       try {
+        await ensureMaterializationSectionExpanded();
+
+        // Strategy select only appears for the table materialization type, so set it
+        // first to make this test robust against the section starting in a different
+        // state.
+        const tableRadio = await driver.wait(
+          until.elementLocated(By.id("materialization-type-table")),
+          getPlatformDelay(10000),
+          "Materialization type table radio not found"
+        );
+        await tableRadio.click();
+        await sleep(getPlatformDelay(1000));
+
         // Select merge strategy
         const strategySelect = await driver.wait(
           until.elementLocated(By.id("materialization-strategy-select")),
-          10000,
+          getPlatformDelay(10000),
           "Strategy select not found"
         );
         await strategySelect.click();

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -130,33 +130,6 @@
         </div>
       </div>
 
-      <!-- Run-with Summary: always visible, surfaces options hidden behind the
-           collapsible "Options" section so users can see what the next run will
-           include without scrolling/expanding. -->
-      <div
-        v-if="runWithChips.length > 0"
-        id="run-with-summary"
-        class="flex items-center gap-1.5 flex-wrap text-2xs text-editor-fg opacity-90 overflow-x-auto"
-      >
-        <span class="opacity-60 shrink-0">Run with:</span>
-        <button
-          v-for="chip in runWithChips"
-          :key="chip.id"
-          type="button"
-          :class="[
-            'inline-flex items-center gap-1 px-1.5 py-0.5 rounded border whitespace-nowrap font-mono',
-            chip.variant === 'override'
-              ? 'border-editorLink-activeFg text-editor-fg'
-              : 'border-commandCenter-border text-editor-fg opacity-90 hover:opacity-100',
-          ]"
-          :title="chip.tooltip"
-          @click="chip.onClick && chip.onClick()"
-        >
-          <span v-if="chip.icon" :class="['codicon', chip.icon, 'text-[10px]']"></span>
-          <span>{{ chip.label }}</span>
-        </button>
-      </div>
-
       <!-- Action Buttons Row -->
       <div class="flex flex-col xs:flex-row gap-2 justify-end items-start xs:items-end">
         <div
@@ -281,6 +254,77 @@
                 </MenuItems>
               </transition>
             </Menu>
+          </div>
+
+          <!-- Run options summary: ⓘ button next to Run that opens a popover
+               listing the full effective configuration (env, dates, flags,
+               tags, variable overrides). A small dot indicates non-default
+               state so the user notices without having to open it. -->
+          <div ref="runOptionsContainer" class="relative inline-flex items-center">
+            <button
+              type="button"
+              id="run-options-button"
+              class="relative h-7 w-7 inline-flex items-center justify-center rounded-sm text-editor-fg opacity-70 hover:opacity-100 hover:bg-editor-button-hover-bg"
+              :title="isRunOptionsOpen ? 'Hide run options' : 'Show run options'"
+              :aria-expanded="isRunOptionsOpen"
+              aria-controls="run-options-popover"
+              @click="isRunOptionsOpen = !isRunOptionsOpen"
+            >
+              <span class="codicon codicon-info text-[12px]"></span>
+              <span
+                v-if="hasNonDefaultRunOptions"
+                class="absolute top-1 right-1 h-1.5 w-1.5 rounded-full bg-editorLink-activeFg"
+                aria-hidden="true"
+              ></span>
+            </button>
+            <transition
+              enter-active-class="transition ease-out duration-100"
+              enter-from-class="transform opacity-0 scale-95"
+              enter-to-class="transform opacity-100 scale-100"
+              leave-active-class="transition ease-in duration-75"
+              leave-from-class="transform opacity-100 scale-100"
+              leave-to-class="transform opacity-0 scale-95"
+            >
+              <div
+                v-if="isRunOptionsOpen"
+                id="run-options-popover"
+                class="absolute right-0 top-full mt-1 z-[99999] w-[280px] max-w-[90vw] bg-editorWidget-bg border border-commandCenter-border rounded shadow-md"
+                role="dialog"
+                aria-label="Run options"
+              >
+                <div class="px-2 py-1.5 border-b border-commandCenter-border flex items-center justify-between">
+                  <span class="text-xs font-medium text-editor-fg">Run options</span>
+                  <button
+                    type="button"
+                    class="text-descriptionFg opacity-70 hover:opacity-100 h-5 w-5 inline-flex items-center justify-center"
+                    title="Close"
+                    @click="isRunOptionsOpen = false"
+                  >
+                    <span class="codicon codicon-close text-[10px]"></span>
+                  </button>
+                </div>
+                <ul class="py-1 max-h-[320px] overflow-y-auto">
+                  <li
+                    v-for="row in runOptionRows"
+                    :key="row.id"
+                    :class="[
+                      'flex items-start gap-2 px-2 py-1 text-2xs',
+                      row.onClick ? 'cursor-pointer hover:bg-editor-hoverBackground' : '',
+                    ]"
+                    @click="row.onClick && (row.onClick(), isRunOptionsOpen = false)"
+                  >
+                    <span class="text-editor-fg opacity-60 shrink-0 w-[80px]">{{ row.label }}</span>
+                    <span
+                      :class="[
+                        'flex-1 min-w-0 font-mono break-all',
+                        row.active ? 'text-editor-fg' : 'text-editor-fg opacity-50 italic',
+                      ]"
+                      :title="row.tooltip || row.value"
+                    >{{ row.value }}</span>
+                  </li>
+                </ul>
+              </div>
+            </transition>
           </div>
 
           <!-- Run Button Group -->
@@ -1011,18 +1055,12 @@ const isFullRefreshChecked = computed(() => {
 
 const activeTagCount = computed(() => includeTags.value.length + excludeTags.value.length);
 
-// Chips shown in the "Run with:" strip above the action buttons. Surfaces
-// settings that are otherwise hidden behind the collapsible "Options" section
-// (full-refresh, tag filters, variable overrides) so the user can see what the
-// next run will include without expanding anything.
-interface RunWithChip {
-  id: string;
-  label: string;
-  tooltip: string;
-  icon?: string;
-  variant?: "default" | "override";
-  onClick?: () => void;
-}
+// Run-options popover (ⓘ button next to the Run button). Surfaces the full
+// effective configuration — env, dates, flags, tags, variable overrides — so
+// the user can verify what the next run will include without expanding the
+// collapsible Options section.
+const isRunOptionsOpen = ref(false);
+const runOptionsContainer = ref<HTMLElement | null>(null);
 
 function openOptionsAndPanel(target: "variables" | "tags") {
   showCheckboxGroup.value = true;
@@ -1033,49 +1071,92 @@ function openOptionsAndPanel(target: "variables" | "tags") {
   }
 }
 
-const runWithChips = computed<RunWithChip[]>(() => {
-  const chips: RunWithChip[] = [];
+interface RunOptionRow {
+  id: string;
+  label: string;
+  value: string;
+  tooltip?: string;
+  active: boolean; // false for "default" entries (rendered dimmed)
+  onClick?: () => void;
+}
 
-  // Active boolean flags from the "Options" checkbox group (Full-Refresh, etc.)
-  for (const item of checkboxItems.value || []) {
-    if (item?.checked) {
-      chips.push({
-        id: `flag-${item.name}`,
-        label: `--${String(item.name).toLowerCase()}`,
-        tooltip: `${item.name} is enabled for this run`,
-        icon: "codicon-pass",
-        onClick: () => { showCheckboxGroup.value = true; },
-      });
-    }
+const activeFlagLabels = computed(() =>
+  (checkboxItems.value || [])
+    .filter((item: any) => item?.checked)
+    .map((item: any) => String(item.name)),
+);
+
+const hasNonDefaultRunOptions = computed(() => {
+  return (
+    activeFlagLabels.value.length > 0 ||
+    activeTagCount.value > 0 ||
+    (applyVariableOverrides.value && variableOverridesCount.value > 0)
+  );
+});
+
+const runOptionRows = computed<RunOptionRow[]>(() => {
+  const rows: RunOptionRow[] = [];
+
+  rows.push({
+    id: "env",
+    label: "Environment",
+    value: selectedEnv.value || "—",
+    active: !!selectedEnv.value,
+  });
+
+  if (hasVariants.value) {
+    rows.push({
+      id: "variant",
+      label: "Variant",
+      value: selectedVariant.value || "default",
+      active: !!selectedVariant.value,
+    });
   }
 
-  // Tag filters
+  rows.push({
+    id: "dates",
+    label: "Dates",
+    value: startDate.value && endDate.value
+      ? `${startDate.value} → ${endDate.value}`
+      : "—",
+    active: !!(startDate.value && endDate.value),
+  });
+
+  if (activeFlagLabels.value.length > 0) {
+    rows.push({
+      id: "flags",
+      label: "Flags",
+      value: activeFlagLabels.value.map((n) => `--${n.toLowerCase()}`).join(" "),
+      active: true,
+      onClick: () => { showCheckboxGroup.value = true; },
+    });
+  }
+
   if (activeTagCount.value > 0) {
     const parts: string[] = [];
     if (includeTags.value.length > 0) parts.push(`+${includeTags.value.join(", +")}`);
     if (excludeTags.value.length > 0) parts.push(`-${excludeTags.value.join(", -")}`);
-    chips.push({
+    rows.push({
       id: "tags",
-      label: `tags: ${activeTagCount.value}`,
-      tooltip: `Tag filters: ${parts.join("  ")}\n(click to edit)`,
-      icon: "codicon-filter-filled",
+      label: "Tag filters",
+      value: parts.join("  "),
+      active: true,
       onClick: () => openOptionsAndPanel("tags"),
     });
   }
 
-  // Variable overrides — only when they'll actually be applied to the run.
   if (applyVariableOverrides.value && variableOverridesCount.value > 0) {
-    chips.push({
+    rows.push({
       id: "overrides",
-      label: `${variableOverridesCount.value} override${variableOverridesCount.value === 1 ? "" : "s"}`,
+      label: "Overrides",
+      value: `${variableOverridesCount.value} variable${variableOverridesCount.value === 1 ? "" : "s"} overridden`,
       tooltip: activeOverridesSummary.value,
-      icon: "codicon-symbol-variable",
-      variant: "override",
+      active: true,
       onClick: () => openOptionsAndPanel("variables"),
     });
   }
 
-  return chips;
+  return rows;
 });
 const filteredTags = computed(() => {
   const q = tagFilterSearch.value.toLowerCase().trim();
@@ -1098,6 +1179,12 @@ function onWindowClick(e: MouseEvent) {
     const container = tagFilterContainer.value;
     if (container && !container.contains(e.target as Node)) {
       isTagFilterOpen.value = false;
+    }
+  }
+  if (isRunOptionsOpen.value) {
+    const container = runOptionsContainer.value;
+    if (container && !container.contains(e.target as Node)) {
+      isRunOptionsOpen.value = false;
     }
   }
 }

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -15,15 +15,98 @@
             <div class="flex flex-col xs:flex-row gap-1 w-full">
               <DateInput label="Start Date" v-model="startDate" />
               <DateInput label="End Date" v-model="endDate" />
-              <div class="flex items-center gap-1 self-start xs:self-end">
-                <button type="button" @click="resetDatesOnSchedule" :title="props.schedule === 'continuous' ? 'Reset dates to today (start of day to now)' : `Reset dates to the previous ${props.schedule || 'scheduled'} run interval`"
-                  class="rounded-sm bg-editor-button-bg p-1 text-editor-button-fg hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed">
+              <!-- Icon group: reset / run-options ⓘ / expand chevron.
+                   Aligned to the bottom of the date inputs so the icons sit
+                   on the same baseline as the input row, not the label. -->
+              <div class="flex items-center self-start xs:self-end h-[26px] gap-0.5 ml-1">
+                <button
+                  type="button"
+                  @click="resetDatesOnSchedule"
+                  :title="props.schedule === 'continuous' ? 'Reset dates to today (start of day to now)' : `Reset dates to the previous ${props.schedule || 'scheduled'} run interval`"
+                  class="h-5 w-5 inline-flex items-center justify-center rounded-sm text-editor-fg opacity-70 hover:opacity-100 hover:bg-editor-button-hover-bg"
+                >
                   <ArrowPathRoundedSquareIcon class="h-3 w-3" aria-hidden="true" />
                 </button>
-                <div class="relative" id="checkbox-group-chevron">
-                  <ChevronUpIcon v-if="showCheckboxGroup" class="h-4 w-4" @click="updateVisibility" />
-                  <ChevronDownIcon v-else class="h-4 w-4" @click="updateVisibility" />
+                <!-- Run options ⓘ button + popover. Lives here (not next to
+                     Run) so it's visually grouped with the other run-config
+                     icons and the chevron that expands their editors. -->
+                <div ref="runOptionsContainer" class="relative inline-flex items-center">
+                  <button
+                    type="button"
+                    id="run-options-button"
+                    class="relative h-5 w-5 inline-flex items-center justify-center rounded-sm text-editor-fg opacity-70 hover:opacity-100 hover:bg-editor-button-hover-bg"
+                    :title="isRunOptionsOpen ? 'Hide run options' : 'Show run options'"
+                    :aria-expanded="isRunOptionsOpen"
+                    aria-controls="run-options-popover"
+                    @click.stop="isRunOptionsOpen = !isRunOptionsOpen"
+                  >
+                    <span class="codicon codicon-info text-[12px]"></span>
+                    <span
+                      v-if="hasNonDefaultRunOptions"
+                      class="absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full bg-editorLink-activeFg"
+                      aria-hidden="true"
+                    ></span>
+                  </button>
+                  <transition
+                    enter-active-class="transition ease-out duration-100"
+                    enter-from-class="transform opacity-0 scale-95"
+                    enter-to-class="transform opacity-100 scale-100"
+                    leave-active-class="transition ease-in duration-75"
+                    leave-from-class="transform opacity-100 scale-100"
+                    leave-to-class="transform opacity-0 scale-95"
+                  >
+                    <div
+                      v-if="isRunOptionsOpen"
+                      id="run-options-popover"
+                      class="absolute right-0 top-full mt-1 z-[99999] w-[280px] max-w-[calc(100vw-2rem)] bg-editorWidget-bg border border-commandCenter-border rounded shadow-md"
+                      role="dialog"
+                      aria-label="Run options"
+                    >
+                      <div class="px-2 py-1.5 border-b border-commandCenter-border flex items-center justify-between">
+                        <span class="text-xs font-medium text-editor-fg">Run options</span>
+                        <button
+                          type="button"
+                          class="text-descriptionFg opacity-70 hover:opacity-100 h-5 w-5 inline-flex items-center justify-center"
+                          title="Close"
+                          @click="isRunOptionsOpen = false"
+                        >
+                          <span class="codicon codicon-close text-[10px]"></span>
+                        </button>
+                      </div>
+                      <ul class="py-1 max-h-[320px] overflow-y-auto">
+                        <li
+                          v-for="row in runOptionRows"
+                          :key="row.id"
+                          :class="[
+                            'flex items-start gap-2 px-2 py-1 text-2xs',
+                            row.onClick ? 'cursor-pointer hover:bg-editor-hoverBackground' : '',
+                          ]"
+                          @click="row.onClick && (row.onClick(), isRunOptionsOpen = false)"
+                        >
+                          <span class="text-editor-fg opacity-60 shrink-0 w-[80px]">{{ row.label }}</span>
+                          <span
+                            :class="[
+                              'flex-1 min-w-0 font-mono break-all',
+                              row.active ? 'text-editor-fg' : 'text-editor-fg opacity-50 italic',
+                            ]"
+                            :title="row.tooltip || row.value"
+                          >{{ row.value }}</span>
+                        </li>
+                      </ul>
+                    </div>
+                  </transition>
                 </div>
+                <button
+                  type="button"
+                  id="checkbox-group-chevron"
+                  class="h-5 w-5 inline-flex items-center justify-center rounded-sm text-editor-fg opacity-70 hover:opacity-100 hover:bg-editor-button-hover-bg"
+                  :title="showCheckboxGroup ? 'Hide more options' : 'Show more options'"
+                  :aria-expanded="showCheckboxGroup"
+                  @click="updateVisibility"
+                >
+                  <ChevronUpIcon v-if="showCheckboxGroup" class="h-3.5 w-3.5" />
+                  <ChevronDownIcon v-else class="h-3.5 w-3.5" />
+                </button>
               </div>
             </div>
             </div>
@@ -254,77 +337,6 @@
                 </MenuItems>
               </transition>
             </Menu>
-          </div>
-
-          <!-- Run options summary: ⓘ button next to Run that opens a popover
-               listing the full effective configuration (env, dates, flags,
-               tags, variable overrides). A small dot indicates non-default
-               state so the user notices without having to open it. -->
-          <div ref="runOptionsContainer" class="relative inline-flex items-center">
-            <button
-              type="button"
-              id="run-options-button"
-              class="relative h-7 w-7 inline-flex items-center justify-center rounded-sm text-editor-fg opacity-70 hover:opacity-100 hover:bg-editor-button-hover-bg"
-              :title="isRunOptionsOpen ? 'Hide run options' : 'Show run options'"
-              :aria-expanded="isRunOptionsOpen"
-              aria-controls="run-options-popover"
-              @click="isRunOptionsOpen = !isRunOptionsOpen"
-            >
-              <span class="codicon codicon-info text-[12px]"></span>
-              <span
-                v-if="hasNonDefaultRunOptions"
-                class="absolute top-1 right-1 h-1.5 w-1.5 rounded-full bg-editorLink-activeFg"
-                aria-hidden="true"
-              ></span>
-            </button>
-            <transition
-              enter-active-class="transition ease-out duration-100"
-              enter-from-class="transform opacity-0 scale-95"
-              enter-to-class="transform opacity-100 scale-100"
-              leave-active-class="transition ease-in duration-75"
-              leave-from-class="transform opacity-100 scale-100"
-              leave-to-class="transform opacity-0 scale-95"
-            >
-              <div
-                v-if="isRunOptionsOpen"
-                id="run-options-popover"
-                class="absolute right-0 top-full mt-1 z-[99999] w-[280px] max-w-[90vw] bg-editorWidget-bg border border-commandCenter-border rounded shadow-md"
-                role="dialog"
-                aria-label="Run options"
-              >
-                <div class="px-2 py-1.5 border-b border-commandCenter-border flex items-center justify-between">
-                  <span class="text-xs font-medium text-editor-fg">Run options</span>
-                  <button
-                    type="button"
-                    class="text-descriptionFg opacity-70 hover:opacity-100 h-5 w-5 inline-flex items-center justify-center"
-                    title="Close"
-                    @click="isRunOptionsOpen = false"
-                  >
-                    <span class="codicon codicon-close text-[10px]"></span>
-                  </button>
-                </div>
-                <ul class="py-1 max-h-[320px] overflow-y-auto">
-                  <li
-                    v-for="row in runOptionRows"
-                    :key="row.id"
-                    :class="[
-                      'flex items-start gap-2 px-2 py-1 text-2xs',
-                      row.onClick ? 'cursor-pointer hover:bg-editor-hoverBackground' : '',
-                    ]"
-                    @click="row.onClick && (row.onClick(), isRunOptionsOpen = false)"
-                  >
-                    <span class="text-editor-fg opacity-60 shrink-0 w-[80px]">{{ row.label }}</span>
-                    <span
-                      :class="[
-                        'flex-1 min-w-0 font-mono break-all',
-                        row.active ? 'text-editor-fg' : 'text-editor-fg opacity-50 italic',
-                      ]"
-                      :title="row.tooltip || row.value"
-                    >{{ row.value }}</span>
-                  </li>
-                </ul>
-              </div>
-            </transition>
           </div>
 
           <!-- Run Button Group -->

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -10,9 +10,8 @@
             :selectedEnvironment="selectedEnvironment" class="flex-shrink-0" />
           <VariantSelectMenu v-if="hasVariants" :options="variantNames"
             :selectedVariant="selectedVariant" @selectedVariant="onVariantSelect" class="flex-shrink-0"/>
-          <!-- Date Controls and Checkbox Group — pushed to the right so the
-               row uses its full width instead of leaving empty space. -->
-          <div id="controls" class="flex flex-col flex-shrink-0 xs:ml-auto">
+          <!-- Date Controls and Checkbox Group -->
+          <div id="controls" class="flex flex-col flex-shrink-0">
             <div class="flex flex-col xs:flex-row gap-1 w-full">
               <DateInput label="Start Date" v-model="startDate" />
               <DateInput label="End Date" v-model="endDate" />

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -106,7 +106,7 @@
                   </span>
                 </button>
               </div>
-              <div class="flex items-center gap-0">
+              <div class="flex items-center gap-1">
                 <vscode-checkbox :checked="applyVariableOverrides"
                   @change="handleApplyOverridesToggle($event.target.checked)" class="text-xs opacity-70 gap-0">
                   Variable overrides
@@ -114,6 +114,18 @@
                 <span class="text-3xs text-editor-fg opacity-60 -ml-2">
                   ({{ variableOverridesCount }})
                 </span>
+                <!-- Ambient hint: hover to see what's currently overridden. -->
+                <button
+                  v-if="variableOverridesCount > 0"
+                  type="button"
+                  id="active-overrides-hint"
+                  class="text-editor-fg opacity-60 hover:opacity-100 inline-flex items-center"
+                  :title="activeOverridesSummary"
+                  @click="isVariablesOpen = true"
+                  aria-label="Show active overrides"
+                >
+                  <span class="codicon codicon-info text-[10px]"></span>
+                </button>
               </div>
             </div>
           </div>
@@ -125,6 +137,7 @@
             :variables="pipelineVariables"
             :initial-overrides="currentVariableOverrides"
             @save-overrides="handleSaveOverrides"
+            @close="isVariablesOpen = false"
           />
         </div>
       </div>
@@ -956,6 +969,27 @@ const hasActiveTagFilters = computed(
 const isVariablesOpen = ref(false);
 const currentVariableOverrides = ref<Record<string, any>>({});
 const applyVariableOverrides = ref(false);
+
+// Human-readable summary of active overrides, shown on hover of the info icon
+// next to the "Variable overrides" checkbox. Lets users see what's currently
+// being injected without having to expand the variables panel.
+const activeOverridesSummary = computed(() => {
+  const declared = pipelineVariables.value || {};
+  const overrides = currentVariableOverrides.value || {};
+  const lines = Object.keys(declared)
+    .filter((k) => overrides[k] !== undefined && overrides[k] !== null && overrides[k] !== "")
+    .map((k) => {
+      const value = overrides[k];
+      const formatted = typeof value === "string"
+        ? `"${value}"`
+        : typeof value === "object"
+          ? JSON.stringify(value)
+          : String(value);
+      return `${k} = ${formatted}`;
+    });
+  if (lines.length === 0) return "No overrides active";
+  return `Active overrides (click to edit):\n${lines.join("\n")}`;
+});
 const isFullRefreshChecked = computed(() => {
   return checkboxItems.value.find((item) => item.name === "Full-Refresh")?.checked || false;
 });

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -124,8 +124,7 @@
             :is-open="isVariablesOpen"
             :variables="pipelineVariables"
             :initial-overrides="currentVariableOverrides"
-            @render-with-overrides="handleRenderWithOverrides"
-            @apply-overrides-toggle="handleApplyOverridesToggle"
+            @save-overrides="handleSaveOverrides"
           />
         </div>
       </div>
@@ -1641,15 +1640,15 @@ function toggleVariablesOpen() {
   isVariablesOpen.value = !isVariablesOpen.value;
 }
 
-function handleRenderWithOverrides(overrides: Record<string, any>) {
+function handleSaveOverrides(overrides: Record<string, any>, applyOverrides: boolean) {
   currentVariableOverrides.value = { ...overrides };
+  applyVariableOverrides.value = applyOverrides;
 
-  // The inline panel applies edits live, so persist on every change instead of
-  // waiting for an explicit save action.
   const prevState = (vscode.getState() as Record<string, any>) || {};
   vscode.setState({
     ...prevState,
     variableOverrides: { ...overrides },
+    applyVariableOverrides: applyOverrides,
   });
 }
 

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -88,16 +88,23 @@
             </div>
             <div v-if="!isPipelineData" class="flex items-center gap-2">
               <div class="flex items-center gap-[1px]">
-                <label class="text-xs text-editor-fg">Variables</label>
-                <span v-if="pipelineVariables && Object.keys(pipelineVariables).length > 0"
-                  class="text-3xs text-editor-fg opacity-60">
-                  ({{ Object.keys(pipelineVariables).length }})
-                </span>
-                <vscode-button appearance="icon"
-                  class="h-3.5 w-auto p-0 opacity-70 hover:opacity-100 inline-flex items-center" id="variables-button"
-                  title="Add temporary variable overrides for this run" @click="toggleVariablesOpen">
-                  <span class="codicon codicon-settings-gear text-[9px]"></span>
-                </vscode-button>
+                <button
+                  type="button"
+                  id="variables-button"
+                  class="inline-flex items-center gap-1 text-xs text-editor-fg opacity-80 hover:opacity-100 px-1 py-0.5 rounded"
+                  :title="isVariablesOpen ? 'Hide variables' : 'Show variables'"
+                  @click="toggleVariablesOpen"
+                >
+                  <span
+                    class="codicon text-[10px]"
+                    :class="isVariablesOpen ? 'codicon-chevron-down' : 'codicon-chevron-right'"
+                  ></span>
+                  <span>Variables</span>
+                  <span v-if="pipelineVariables && Object.keys(pipelineVariables).length > 0"
+                    class="text-3xs opacity-60">
+                    ({{ Object.keys(pipelineVariables).length }})
+                  </span>
+                </button>
               </div>
               <div class="flex items-center gap-0">
                 <vscode-checkbox :checked="applyVariableOverrides"
@@ -110,6 +117,16 @@
               </div>
             </div>
           </div>
+
+          <!-- Inline Variables Panel -->
+          <AssetVariablesPanel
+            v-if="!isPipelineData"
+            :is-open="isVariablesOpen"
+            :variables="pipelineVariables"
+            :initial-overrides="currentVariableOverrides"
+            @render-with-overrides="handleRenderWithOverrides"
+            @apply-overrides-toggle="handleApplyOverridesToggle"
+          />
         </div>
       </div>
 
@@ -372,11 +389,6 @@
   <AlertWithActions v-if="showFullRefreshAlert" message="Do you want to run with full refresh? This may drop the table"
     confirm-text="Continue" @confirm="confirmFullRefresh" @cancel="cancelFullRefresh" />
 
-  <AssetVariablesPanel v-if="!isPipelineData" :is-open="isVariablesOpen" :variables="pipelineVariables"
-    trigger-element-id="variables-button" :initial-overrides="currentVariableOverrides"
-    :initial-apply-overrides="applyVariableOverrides" @close="closeVariablesPanel"
-    @render-with-overrides="handleRenderWithOverrides" @save-overrides="handleSaveOverrides"
-    @apply-overrides-toggle="handleApplyOverridesToggle" />
 </template>
 <script setup lang="ts">
 import { vscode } from "@/utilities/vscode";
@@ -1629,23 +1641,15 @@ function toggleVariablesOpen() {
   isVariablesOpen.value = !isVariablesOpen.value;
 }
 
-function closeVariablesPanel() {
-  isVariablesOpen.value = false;
-}
-
 function handleRenderWithOverrides(overrides: Record<string, any>) {
   currentVariableOverrides.value = { ...overrides };
-}
 
-function handleSaveOverrides(overrides: Record<string, any>, applyOverrides: boolean) {
-  currentVariableOverrides.value = { ...overrides };
-  applyVariableOverrides.value = applyOverrides;
-
+  // The inline panel applies edits live, so persist on every change instead of
+  // waiting for an explicit save action.
   const prevState = (vscode.getState() as Record<string, any>) || {};
   vscode.setState({
     ...prevState,
     variableOverrides: { ...overrides },
-    applyVariableOverrides: applyOverrides,
   });
 }
 

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -106,7 +106,7 @@
                   </span>
                 </button>
               </div>
-              <div class="flex items-center gap-1">
+              <div class="flex items-center gap-0">
                 <vscode-checkbox :checked="applyVariableOverrides"
                   @change="handleApplyOverridesToggle($event.target.checked)" class="text-xs opacity-70 gap-0">
                   Variable overrides
@@ -114,18 +114,6 @@
                 <span class="text-3xs text-editor-fg opacity-60 -ml-2">
                   ({{ variableOverridesCount }})
                 </span>
-                <!-- Ambient hint: hover to see what's currently overridden. -->
-                <button
-                  v-if="variableOverridesCount > 0"
-                  type="button"
-                  id="active-overrides-hint"
-                  class="text-editor-fg opacity-60 hover:opacity-100 inline-flex items-center"
-                  :title="activeOverridesSummary"
-                  @click="isVariablesOpen = true"
-                  aria-label="Show active overrides"
-                >
-                  <span class="codicon codicon-info text-[10px]"></span>
-                </button>
               </div>
             </div>
           </div>
@@ -140,6 +128,33 @@
             @close="isVariablesOpen = false"
           />
         </div>
+      </div>
+
+      <!-- Run-with Summary: always visible, surfaces options hidden behind the
+           collapsible "Options" section so users can see what the next run will
+           include without scrolling/expanding. -->
+      <div
+        v-if="runWithChips.length > 0"
+        id="run-with-summary"
+        class="flex items-center gap-1.5 flex-wrap text-2xs text-editor-fg opacity-90 overflow-x-auto"
+      >
+        <span class="opacity-60 shrink-0">Run with:</span>
+        <button
+          v-for="chip in runWithChips"
+          :key="chip.id"
+          type="button"
+          :class="[
+            'inline-flex items-center gap-1 px-1.5 py-0.5 rounded border whitespace-nowrap font-mono',
+            chip.variant === 'override'
+              ? 'border-editorLink-activeFg text-editor-fg'
+              : 'border-commandCenter-border text-editor-fg opacity-90 hover:opacity-100',
+          ]"
+          :title="chip.tooltip"
+          @click="chip.onClick && chip.onClick()"
+        >
+          <span v-if="chip.icon" :class="['codicon', chip.icon, 'text-[10px]']"></span>
+          <span>{{ chip.label }}</span>
+        </button>
       </div>
 
       <!-- Action Buttons Row -->
@@ -995,6 +1010,73 @@ const isFullRefreshChecked = computed(() => {
 });
 
 const activeTagCount = computed(() => includeTags.value.length + excludeTags.value.length);
+
+// Chips shown in the "Run with:" strip above the action buttons. Surfaces
+// settings that are otherwise hidden behind the collapsible "Options" section
+// (full-refresh, tag filters, variable overrides) so the user can see what the
+// next run will include without expanding anything.
+interface RunWithChip {
+  id: string;
+  label: string;
+  tooltip: string;
+  icon?: string;
+  variant?: "default" | "override";
+  onClick?: () => void;
+}
+
+function openOptionsAndPanel(target: "variables" | "tags") {
+  showCheckboxGroup.value = true;
+  if (target === "variables") {
+    isVariablesOpen.value = true;
+  } else if (target === "tags") {
+    isTagFilterOpen.value = true;
+  }
+}
+
+const runWithChips = computed<RunWithChip[]>(() => {
+  const chips: RunWithChip[] = [];
+
+  // Active boolean flags from the "Options" checkbox group (Full-Refresh, etc.)
+  for (const item of checkboxItems.value || []) {
+    if (item?.checked) {
+      chips.push({
+        id: `flag-${item.name}`,
+        label: `--${String(item.name).toLowerCase()}`,
+        tooltip: `${item.name} is enabled for this run`,
+        icon: "codicon-pass",
+        onClick: () => { showCheckboxGroup.value = true; },
+      });
+    }
+  }
+
+  // Tag filters
+  if (activeTagCount.value > 0) {
+    const parts: string[] = [];
+    if (includeTags.value.length > 0) parts.push(`+${includeTags.value.join(", +")}`);
+    if (excludeTags.value.length > 0) parts.push(`-${excludeTags.value.join(", -")}`);
+    chips.push({
+      id: "tags",
+      label: `tags: ${activeTagCount.value}`,
+      tooltip: `Tag filters: ${parts.join("  ")}\n(click to edit)`,
+      icon: "codicon-filter-filled",
+      onClick: () => openOptionsAndPanel("tags"),
+    });
+  }
+
+  // Variable overrides — only when they'll actually be applied to the run.
+  if (applyVariableOverrides.value && variableOverridesCount.value > 0) {
+    chips.push({
+      id: "overrides",
+      label: `${variableOverridesCount.value} override${variableOverridesCount.value === 1 ? "" : "s"}`,
+      tooltip: activeOverridesSummary.value,
+      icon: "codicon-symbol-variable",
+      variant: "override",
+      onClick: () => openOptionsAndPanel("variables"),
+    });
+  }
+
+  return chips;
+});
 const filteredTags = computed(() => {
   const q = tagFilterSearch.value.toLowerCase().trim();
   const all = availableTags.value || [];

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -10,8 +10,9 @@
             :selectedEnvironment="selectedEnvironment" class="flex-shrink-0" />
           <VariantSelectMenu v-if="hasVariants" :options="variantNames"
             :selectedVariant="selectedVariant" @selectedVariant="onVariantSelect" class="flex-shrink-0"/>
-          <!-- Date Controls and Checkbox Group -->
-          <div id="controls" class="flex flex-col flex-shrink-0">
+          <!-- Date Controls and Checkbox Group — pushed to the right so the
+               row uses its full width instead of leaving empty space. -->
+          <div id="controls" class="flex flex-col flex-shrink-0 xs:ml-auto">
             <div class="flex flex-col xs:flex-row gap-1 w-full">
               <DateInput label="Start Date" v-model="startDate" />
               <DateInput label="End Date" v-model="endDate" />
@@ -73,7 +74,7 @@
                           <span class="codicon codicon-close text-[10px]"></span>
                         </button>
                       </div>
-                      <ul class="py-1 max-h-[320px] overflow-y-auto">
+                      <ul v-if="runOptionRows.length > 0" class="py-1 max-h-[320px] overflow-y-auto">
                         <li
                           v-for="row in runOptionRows"
                           :key="row.id"
@@ -85,14 +86,14 @@
                         >
                           <span class="text-editor-fg opacity-60 shrink-0 w-[80px]">{{ row.label }}</span>
                           <span
-                            :class="[
-                              'flex-1 min-w-0 font-mono break-all',
-                              row.active ? 'text-editor-fg' : 'text-editor-fg opacity-50 italic',
-                            ]"
+                            class="flex-1 min-w-0 font-mono break-all text-editor-fg"
                             :title="row.tooltip || row.value"
                           >{{ row.value }}</span>
                         </li>
                       </ul>
+                      <div v-else class="px-2 py-3 text-2xs text-editor-fg opacity-60 italic">
+                        No additional flags, tag filters, or variable overrides set.
+                      </div>
                     </div>
                   </transition>
                 </div>
@@ -1088,7 +1089,6 @@ interface RunOptionRow {
   label: string;
   value: string;
   tooltip?: string;
-  active: boolean; // false for "default" entries (rendered dimmed)
   onClick?: () => void;
 }
 
@@ -1106,40 +1106,18 @@ const hasNonDefaultRunOptions = computed(() => {
   );
 });
 
+// Env, variant, and dates each have their own always-visible widgets at the
+// top of the panel, so the popover only surfaces the run config that's
+// otherwise hidden behind the Options collapsible: active flags, tag filters,
+// and applied variable overrides.
 const runOptionRows = computed<RunOptionRow[]>(() => {
   const rows: RunOptionRow[] = [];
-
-  rows.push({
-    id: "env",
-    label: "Environment",
-    value: selectedEnv.value || "—",
-    active: !!selectedEnv.value,
-  });
-
-  if (hasVariants.value) {
-    rows.push({
-      id: "variant",
-      label: "Variant",
-      value: selectedVariant.value || "default",
-      active: !!selectedVariant.value,
-    });
-  }
-
-  rows.push({
-    id: "dates",
-    label: "Dates",
-    value: startDate.value && endDate.value
-      ? `${startDate.value} → ${endDate.value}`
-      : "—",
-    active: !!(startDate.value && endDate.value),
-  });
 
   if (activeFlagLabels.value.length > 0) {
     rows.push({
       id: "flags",
       label: "Flags",
       value: activeFlagLabels.value.map((n) => `--${n.toLowerCase()}`).join(" "),
-      active: true,
       onClick: () => { showCheckboxGroup.value = true; },
     });
   }
@@ -1152,7 +1130,6 @@ const runOptionRows = computed<RunOptionRow[]>(() => {
       id: "tags",
       label: "Tag filters",
       value: parts.join("  "),
-      active: true,
       onClick: () => openOptionsAndPanel("tags"),
     });
   }
@@ -1163,7 +1140,6 @@ const runOptionRows = computed<RunOptionRow[]>(() => {
       label: "Overrides",
       value: `${variableOverridesCount.value} variable${variableOverridesCount.value === 1 ? "" : "s"} overridden`,
       tooltip: activeOverridesSummary.value,
-      active: true,
       onClick: () => openOptionsAndPanel("variables"),
     });
   }

--- a/webview-ui/src/components/ui/variables-panel/AssetVariablesPanel.vue
+++ b/webview-ui/src/components/ui/variables-panel/AssetVariablesPanel.vue
@@ -6,79 +6,93 @@
   >
     <!-- Header -->
     <div class="px-2 py-1.5 border-b border-commandCenter-border flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <h4 class="text-xs font-medium text-editor-fg">Variable overrides</h4>
-        <span class="text-2xs text-editor-fg opacity-60">
-          {{ activeOverrideCount }} / {{ variableCount }} active
+      <div class="flex items-center gap-2 min-w-0">
+        <h4 class="text-xs font-medium text-editor-fg truncate">Variable overrides</h4>
+        <span class="text-2xs text-editor-fg opacity-60 shrink-0">
+          {{ draftActiveCount }} / {{ variableCount }} active
         </span>
+        <span
+          v-if="isDirty"
+          class="text-2xs text-editor-fg opacity-60 shrink-0 italic"
+          title="You have unsaved changes"
+        >• unsaved</span>
       </div>
-      <div class="flex items-center gap-1">
-        <button
-          v-if="activeOverrideCount > 0"
-          type="button"
-          id="clear-all-overrides"
-          class="text-2xs text-editor-fg opacity-70 hover:opacity-100 px-2 py-0.5"
-          title="Clear all overrides"
-          @click="clearAllOverrides"
-        >
-          Clear all
-        </button>
-      </div>
+      <button
+        v-if="draftActiveCount > 0"
+        type="button"
+        id="clear-all-overrides"
+        class="text-2xs text-editor-fg opacity-70 hover:opacity-100 px-2 py-0.5 shrink-0"
+        title="Clear every override in the draft"
+        @click="clearAll"
+      >
+        Clear all
+      </button>
     </div>
 
     <!-- Variables List -->
-    <div class="px-2 py-2 max-h-[320px] overflow-y-auto">
-      <div v-if="variableCount > 0" class="space-y-1">
+    <div class="px-2 py-2 max-h-[360px] overflow-y-auto space-y-2">
+      <template v-if="variableCount > 0">
         <div
           v-for="(variable, varName) in variables"
           :key="varName"
-          class="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1.4fr)_auto] items-center gap-2 py-1 border-b border-commandCenter-border last:border-b-0"
+          class="rounded border border-commandCenter-border bg-editor-bg p-2"
         >
-          <!-- Name + type -->
-          <div class="flex items-center gap-1 min-w-0">
-            <span
-              class="text-xs font-mono text-editor-fg truncate"
-              :title="variable.description || String(varName)"
-            >{{ varName }}</span>
-            <span class="text-2xs px-1 py-0.5 bg-button-bg text-button-fg rounded shrink-0">
-              {{ variable.type }}
-            </span>
+          <!-- Row 1: name, type, clear button -->
+          <div class="flex items-center justify-between gap-2 mb-1">
+            <div class="flex items-center gap-2 min-w-0 flex-1">
+              <span
+                class="text-xs font-mono text-editor-fg font-medium truncate"
+                :title="variable.description || String(varName)"
+              >{{ varName }}</span>
+              <span class="text-2xs px-1.5 py-0.5 bg-button-bg text-button-fg rounded shrink-0">
+                {{ variable.type }}
+              </span>
+            </div>
+            <button
+              v-if="hasDraftOverride(String(varName))"
+              type="button"
+              class="text-descriptionFg opacity-70 hover:opacity-100 h-5 w-5 inline-flex items-center justify-center shrink-0"
+              title="Clear override"
+              @click="clearDraftOverride(String(varName))"
+            >
+              <span class="codicon codicon-close text-[10px]"></span>
+            </button>
           </div>
 
-          <!-- Default value (compact) -->
-          <div class="text-2xs text-editor-fg opacity-60 font-mono whitespace-nowrap">
-            default: {{ formatDisplayValue(variable.default) }}
-          </div>
-
-          <!-- Override input -->
-          <div class="flex items-center gap-1 min-w-0">
-            <input
-              :value="getOverrideValue(String(varName))"
-              type="text"
-              placeholder="Override value"
-              :class="[
-                'flex-1 bg-editorWidget-bg text-editor-fg text-2xs border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg h-6',
-                hasOverride(String(varName))
+          <!-- Row 2: override input -->
+          <input
+            :value="draftInputs[String(varName)] ?? ''"
+            type="text"
+            :placeholder="placeholderFor(variable.type)"
+            :class="[
+              'w-full bg-editorWidget-bg text-editor-fg text-2xs border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg h-6 font-mono',
+              validationErrors[String(varName)]
+                ? 'border-editorError-foreground'
+                : hasDraftOverride(String(varName))
                   ? 'border-editorLink-activeFg'
                   : 'border-commandCenter-border',
-              ]"
-              @input="handleOverrideInput(String(varName), variable, ($event.target as HTMLInputElement).value)"
-            />
+            ]"
+            @input="handleInput(String(varName), variable, ($event.target as HTMLInputElement).value)"
+          />
+
+          <!-- Validation error -->
+          <div
+            v-if="validationErrors[String(varName)]"
+            class="text-2xs text-editorError-foreground mt-1 flex items-center gap-1"
+          >
+            <span class="codicon codicon-error text-[10px]"></span>
+            <span>{{ validationErrors[String(varName)] }}</span>
           </div>
 
-          <!-- Clear single -->
-          <button
-            v-if="hasOverride(String(varName))"
-            type="button"
-            class="text-descriptionFg opacity-70 hover:opacity-100 h-5 w-5 inline-flex items-center justify-center"
-            title="Clear override"
-            @click="clearOverride(String(varName))"
+          <!-- Row 3: default value (compact, below input so it doesn't squash) -->
+          <div
+            class="text-2xs text-editor-fg opacity-60 font-mono mt-1 truncate"
+            :title="`default: ${formatDisplayValue(variable.default)}`"
           >
-            <span class="codicon codicon-close text-[10px]"></span>
-          </button>
-          <span v-else aria-hidden="true" class="w-5"></span>
+            default: {{ formatDisplayValue(variable.default) }}
+          </div>
         </div>
-      </div>
+      </template>
 
       <!-- No variables state -->
       <div v-else class="text-center py-3">
@@ -87,6 +101,33 @@
           <span class="font-mono">pipeline.yml</span> to override them here.
         </div>
       </div>
+    </div>
+
+    <!-- Footer: Save / Revert -->
+    <div
+      v-if="variableCount > 0"
+      class="px-2 py-1.5 border-t border-commandCenter-border flex items-center justify-end gap-2"
+    >
+      <button
+        v-if="isDirty"
+        type="button"
+        id="revert-overrides"
+        class="text-2xs text-editor-fg opacity-70 hover:opacity-100 px-2 py-0.5"
+        title="Discard unsaved changes"
+        @click="revert"
+      >
+        Revert
+      </button>
+      <button
+        type="button"
+        id="save-overrides"
+        class="text-2xs rounded px-3 py-1 bg-editor-button-bg text-editor-button-fg hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed"
+        :disabled="!isDirty || hasValidationErrors"
+        :title="saveButtonTooltip"
+        @click="save"
+      >
+        Save
+      </button>
     </div>
   </div>
 </template>
@@ -107,34 +148,74 @@ interface Props {
 }
 
 interface Emits {
-  (e: "render-with-overrides", overrides: Record<string, any>): void;
-  (e: "apply-overrides-toggle", applyOverrides: boolean): void;
+  (e: "save-overrides", overrides: Record<string, any>, applyOverrides: boolean): void;
 }
 
 const props = defineProps<Props>();
 const emit = defineEmits<Emits>();
 
-// Local mirror of overrides, kept in sync with parent via initialOverrides.
-const variableOverrides = ref<Record<string, any>>({});
+// Draft state — what's in the inputs right now. Only emitted out on Save.
+// `draftInputs` holds raw text per variable (preserves user-typed value even
+// when invalid). `draftOverrides` holds parsed values (only present when
+// valid). `validationErrors` holds the per-field error message, if any.
+const draftInputs = ref<Record<string, string>>({});
+const draftOverrides = ref<Record<string, any>>({});
+const validationErrors = ref<Record<string, string>>({});
+
+// The last saved state, used to compute `isDirty` and to revert.
+const appliedOverrides = ref<Record<string, any>>({});
 
 watch(
   () => props.initialOverrides,
   (val) => {
-    variableOverrides.value = { ...(val || {}) };
+    appliedOverrides.value = { ...(val || {}) };
+    resetDraftFromApplied();
   },
-  { immediate: true },
+  { immediate: true, deep: true },
 );
+
+function resetDraftFromApplied() {
+  const inputs: Record<string, string> = {};
+  const overrides: Record<string, any> = {};
+  for (const [name, value] of Object.entries(appliedOverrides.value)) {
+    if (value === undefined || value === null || value === "") continue;
+    inputs[name] = formatVariableValue(value);
+    overrides[name] = value;
+  }
+  draftInputs.value = inputs;
+  draftOverrides.value = overrides;
+  validationErrors.value = {};
+}
 
 const variableCount = computed(() => Object.keys(props.variables || {}).length);
 
-const activeOverrideCount = computed(() => {
-  const overrides = variableOverrides.value || {};
+const draftActiveCount = computed(() => {
   const declared = Object.keys(props.variables || {});
-  return declared.filter((k) => {
-    const v = overrides[k];
-    return v !== undefined && v !== null && v !== "";
-  }).length;
+  return declared.filter((k) => hasDraftOverride(k)).length;
 });
+
+const isDirty = computed(() => {
+  return JSON.stringify(draftOverrides.value) !== JSON.stringify(appliedOverrides.value);
+});
+
+const hasValidationErrors = computed(() => Object.keys(validationErrors.value).length > 0);
+
+const saveButtonTooltip = computed(() => {
+  if (hasValidationErrors.value) return "Fix invalid values before saving";
+  if (!isDirty.value) return "No changes to save";
+  return "Apply these overrides";
+});
+
+function placeholderFor(type: string): string {
+  switch (type) {
+    case "boolean": return "true / false";
+    case "integer": return "42";
+    case "number": return "3.14";
+    case "array": return '["a","b"]';
+    case "object": return '{"key":"value"}';
+    default: return "Override value";
+  }
+}
 
 function formatDisplayValue(value: any): string {
   if (value === null || value === undefined) return "—";
@@ -150,81 +231,120 @@ function formatVariableValue(value: any): string {
   return String(value);
 }
 
-function getOverrideValue(varName: string): string {
-  const override = variableOverrides.value[varName];
-  if (override === undefined || override === null) return "";
-  return formatVariableValue(override);
+function hasDraftOverride(varName: string): boolean {
+  return Object.prototype.hasOwnProperty.call(draftOverrides.value, varName);
 }
 
-function hasOverride(varName: string): boolean {
-  const v = variableOverrides.value[varName];
-  return v !== undefined && v !== null && v !== "";
-}
-
-function parseValueByType(value: string, type: string): any {
+// Returns { value, error }. `value` is the parsed value on success, undefined
+// on failure. `error` is a human-readable string when the input doesn't match
+// the declared type.
+function parseValueByType(value: string, type: string): { value?: any; error?: string } {
   const trimmed = value.trim();
-  if (!trimmed) return null;
+  if (!trimmed) return {};
 
-  try {
-    switch (type) {
-      case "boolean":
-        return trimmed.toLowerCase() === "true";
-      case "integer": {
-        const intVal = parseInt(trimmed);
-        return isNaN(intVal) ? null : intVal;
-      }
-      case "number": {
-        const numVal = parseFloat(trimmed);
-        return isNaN(numVal) ? null : numVal;
-      }
-      case "array":
-      case "object":
-        return JSON.parse(trimmed);
-      default:
-        return trimmed;
+  switch (type) {
+    case "boolean": {
+      const lower = trimmed.toLowerCase();
+      if (lower === "true") return { value: true };
+      if (lower === "false") return { value: false };
+      return { error: 'Expected "true" or "false"' };
     }
-  } catch {
-    return null;
+    case "integer": {
+      if (!/^-?\d+$/.test(trimmed)) return { error: "Expected an integer (e.g. 42)" };
+      const intVal = parseInt(trimmed, 10);
+      if (Number.isNaN(intVal)) return { error: "Expected an integer (e.g. 42)" };
+      return { value: intVal };
+    }
+    case "number": {
+      const numVal = Number(trimmed);
+      if (!Number.isFinite(numVal)) return { error: "Expected a number (e.g. 3.14)" };
+      return { value: numVal };
+    }
+    case "array": {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (!Array.isArray(parsed)) {
+          return { error: 'Expected a JSON array like ["a","b"]' };
+        }
+        return { value: parsed };
+      } catch {
+        return { error: 'Invalid JSON — expected an array like ["a","b"]' };
+      }
+    }
+    case "object": {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+          return { error: 'Expected a JSON object like {"key":"value"}' };
+        }
+        return { value: parsed };
+      } catch {
+        return { error: 'Invalid JSON — expected an object like {"key":"value"}' };
+      }
+    }
+    default:
+      return { value: trimmed };
   }
 }
 
-function handleOverrideInput(varName: string, variable: Variable, value: string) {
-  if (!value.trim()) {
-    clearOverride(varName);
+function handleInput(varName: string, variable: Variable, raw: string) {
+  draftInputs.value = { ...draftInputs.value, [varName]: raw };
+
+  if (!raw.trim()) {
+    const nextOverrides = { ...draftOverrides.value };
+    delete nextOverrides[varName];
+    draftOverrides.value = nextOverrides;
+    const nextErrors = { ...validationErrors.value };
+    delete nextErrors[varName];
+    validationErrors.value = nextErrors;
     return;
   }
 
-  const parsedValue = parseValueByType(value, variable.type);
-  if (parsedValue === null) {
-    return; // Invalid value, don't update.
+  const { value, error } = parseValueByType(raw, variable.type);
+  if (error) {
+    // Invalid — keep the raw text, record the error, drop the parsed value so
+    // the draft can't be saved with a bad value.
+    const nextOverrides = { ...draftOverrides.value };
+    delete nextOverrides[varName];
+    draftOverrides.value = nextOverrides;
+    validationErrors.value = { ...validationErrors.value, [varName]: error };
+    return;
   }
 
-  const wasEmpty = activeOverrideCount.value === 0;
-  variableOverrides.value = { ...variableOverrides.value, [varName]: parsedValue };
-  emit("render-with-overrides", { ...variableOverrides.value });
-
-  // First override entered — auto-enable the "apply overrides" toggle so users
-  // don't set a value but forget to apply it on the next run.
-  if (wasEmpty) {
-    emit("apply-overrides-toggle", true);
-  }
+  draftOverrides.value = { ...draftOverrides.value, [varName]: value };
+  const nextErrors = { ...validationErrors.value };
+  delete nextErrors[varName];
+  validationErrors.value = nextErrors;
 }
 
-function clearOverride(varName: string): void {
-  const next = { ...variableOverrides.value };
-  delete next[varName];
-  variableOverrides.value = next;
-  emit("render-with-overrides", { ...variableOverrides.value });
+function clearDraftOverride(varName: string) {
+  const nextInputs = { ...draftInputs.value };
+  delete nextInputs[varName];
+  draftInputs.value = nextInputs;
 
-  // No overrides left — turn off the apply toggle.
-  if (activeOverrideCount.value === 0) {
-    emit("apply-overrides-toggle", false);
-  }
+  const nextOverrides = { ...draftOverrides.value };
+  delete nextOverrides[varName];
+  draftOverrides.value = nextOverrides;
+
+  const nextErrors = { ...validationErrors.value };
+  delete nextErrors[varName];
+  validationErrors.value = nextErrors;
 }
 
-function clearAllOverrides(): void {
-  variableOverrides.value = {};
-  emit("render-with-overrides", {});
-  emit("apply-overrides-toggle", false);
+function clearAll() {
+  draftInputs.value = {};
+  draftOverrides.value = {};
+  validationErrors.value = {};
+}
+
+function revert() {
+  resetDraftFromApplied();
+}
+
+function save() {
+  if (hasValidationErrors.value || !isDirty.value) return;
+  const overrides = { ...draftOverrides.value };
+  appliedOverrides.value = overrides;
+  emit("save-overrides", overrides, Object.keys(overrides).length > 0);
 }
 </script>

--- a/webview-ui/src/components/ui/variables-panel/AssetVariablesPanel.vue
+++ b/webview-ui/src/components/ui/variables-panel/AssetVariablesPanel.vue
@@ -5,7 +5,7 @@
     class="mt-2 w-full bg-editorWidget-bg border border-commandCenter-border rounded"
   >
     <!-- Header -->
-    <div class="px-2 py-1.5 border-b border-commandCenter-border flex items-center justify-between">
+    <div class="px-2 py-1.5 border-b border-commandCenter-border flex items-center justify-between gap-2">
       <div class="flex items-center gap-2 min-w-0">
         <h4 class="text-xs font-medium text-editor-fg truncate">Variable overrides</h4>
         <span class="text-2xs text-editor-fg opacity-60 shrink-0">
@@ -17,37 +17,63 @@
           title="You have unsaved changes"
         >• unsaved</span>
       </div>
-      <button
-        v-if="draftActiveCount > 0"
-        type="button"
-        id="clear-all-overrides"
-        class="text-2xs text-editor-fg opacity-70 hover:opacity-100 px-2 py-0.5 shrink-0"
-        title="Clear every override in the draft"
-        @click="clearAll"
-      >
-        Clear all
-      </button>
+      <div class="flex items-center gap-1 shrink-0">
+        <button
+          v-if="draftActiveCount > 0"
+          type="button"
+          id="clear-all-overrides"
+          class="text-2xs text-editor-fg opacity-70 hover:opacity-100 px-2 py-0.5"
+          title="Clear every override in the draft"
+          @click="clearAll"
+        >
+          Clear all
+        </button>
+        <button
+          type="button"
+          id="close-variables-panel"
+          class="text-descriptionFg opacity-70 hover:opacity-100 h-5 w-5 inline-flex items-center justify-center"
+          title="Close"
+          @click="$emit('close')"
+        >
+          <span class="codicon codicon-close text-[10px]"></span>
+        </button>
+      </div>
     </div>
 
     <!-- Variables List -->
-    <div class="px-2 py-2 max-h-[360px] overflow-y-auto space-y-2">
+    <div class="px-2 py-2 max-h-[320px] overflow-y-auto">
       <template v-if="variableCount > 0">
         <div
           v-for="(variable, varName) in variables"
           :key="varName"
-          class="rounded border border-commandCenter-border bg-editor-bg p-2"
+          class="py-1.5 border-b border-commandCenter-border last:border-b-0"
         >
-          <!-- Row 1: name, type, clear button -->
-          <div class="flex items-center justify-between gap-2 mb-1">
-            <div class="flex items-center gap-2 min-w-0 flex-1">
+          <!-- Single row: name | type | input | clear -->
+          <div class="flex items-center gap-2">
+            <div class="flex items-center gap-1.5 min-w-0 w-[180px] shrink-0">
               <span
-                class="text-xs font-mono text-editor-fg font-medium truncate"
-                :title="variable.description || String(varName)"
+                class="text-xs font-mono text-editor-fg truncate"
+                :title="(variable.description ? variable.description + '\n' : '') + 'default: ' + formatDisplayValue(variable.default)"
               >{{ varName }}</span>
-              <span class="text-2xs px-1.5 py-0.5 bg-button-bg text-button-fg rounded shrink-0">
+              <span class="text-2xs px-1 py-0.5 bg-button-bg text-button-fg rounded shrink-0">
                 {{ variable.type }}
               </span>
             </div>
+            <input
+              :value="draftInputs[String(varName)] ?? ''"
+              type="text"
+              :placeholder="placeholderFor(variable)"
+              :title="hasDraftOverride(String(varName)) ? '' : 'default: ' + formatDisplayValue(variable.default)"
+              :class="[
+                'flex-1 min-w-0 bg-editorWidget-bg text-editor-fg text-2xs border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg h-6 font-mono',
+                validationErrors[String(varName)]
+                  ? 'border-editorError-foreground'
+                  : hasDraftOverride(String(varName))
+                    ? 'border-editorLink-activeFg'
+                    : 'border-commandCenter-border',
+              ]"
+              @input="handleInput(String(varName), variable, ($event.target as HTMLInputElement).value)"
+            />
             <button
               v-if="hasDraftOverride(String(varName))"
               type="button"
@@ -57,39 +83,16 @@
             >
               <span class="codicon codicon-close text-[10px]"></span>
             </button>
+            <span v-else aria-hidden="true" class="w-5 shrink-0"></span>
           </div>
-
-          <!-- Row 2: override input -->
-          <input
-            :value="draftInputs[String(varName)] ?? ''"
-            type="text"
-            :placeholder="placeholderFor(variable.type)"
-            :class="[
-              'w-full bg-editorWidget-bg text-editor-fg text-2xs border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg h-6 font-mono',
-              validationErrors[String(varName)]
-                ? 'border-editorError-foreground'
-                : hasDraftOverride(String(varName))
-                  ? 'border-editorLink-activeFg'
-                  : 'border-commandCenter-border',
-            ]"
-            @input="handleInput(String(varName), variable, ($event.target as HTMLInputElement).value)"
-          />
 
           <!-- Validation error -->
           <div
             v-if="validationErrors[String(varName)]"
-            class="text-2xs text-editorError-foreground mt-1 flex items-center gap-1"
+            class="text-2xs text-editorError-foreground mt-1 ml-[188px] flex items-center gap-1"
           >
             <span class="codicon codicon-error text-[10px]"></span>
             <span>{{ validationErrors[String(varName)] }}</span>
-          </div>
-
-          <!-- Row 3: default value (compact, below input so it doesn't squash) -->
-          <div
-            class="text-2xs text-editor-fg opacity-60 font-mono mt-1 truncate"
-            :title="`default: ${formatDisplayValue(variable.default)}`"
-          >
-            default: {{ formatDisplayValue(variable.default) }}
           </div>
         </div>
       </template>
@@ -149,6 +152,7 @@ interface Props {
 
 interface Emits {
   (e: "save-overrides", overrides: Record<string, any>, applyOverrides: boolean): void;
+  (e: "close"): void;
 }
 
 const props = defineProps<Props>();
@@ -206,8 +210,14 @@ const saveButtonTooltip = computed(() => {
   return "Apply these overrides";
 });
 
-function placeholderFor(type: string): string {
-  switch (type) {
+function placeholderFor(variable: Variable): string {
+  // Prefer showing the default value as the placeholder so the user always
+  // knows what would run if they don't override. Fall back to a type-shaped
+  // hint when no default is available.
+  if (variable.default !== undefined && variable.default !== null) {
+    return formatVariableValue(variable.default);
+  }
+  switch (variable.type) {
     case "boolean": return "true / false";
     case "integer": return "42";
     case "number": return "3.14";

--- a/webview-ui/src/components/ui/variables-panel/AssetVariablesPanel.vue
+++ b/webview-ui/src/components/ui/variables-panel/AssetVariablesPanel.vue
@@ -169,13 +169,15 @@ const validationErrors = ref<Record<string, string>>({});
 // The last saved state, used to compute `isDirty` and to revert.
 const appliedOverrides = ref<Record<string, any>>({});
 
+// Parent always replaces the prop reference wholesale on save, so a shallow
+// watch is enough — no need to walk the override values on every change.
 watch(
   () => props.initialOverrides,
   (val) => {
     appliedOverrides.value = { ...(val || {}) };
     resetDraftFromApplied();
   },
-  { immediate: true, deep: true },
+  { immediate: true },
 );
 
 function resetDraftFromApplied() {

--- a/webview-ui/src/components/ui/variables-panel/AssetVariablesPanel.vue
+++ b/webview-ui/src/components/ui/variables-panel/AssetVariablesPanel.vue
@@ -1,115 +1,98 @@
 <template>
-  <!-- Backdrop -->
   <div
     v-if="isOpen"
-    class="fixed inset-0 z-[99998] bg-editor-bg opacity-50"
-    @click="$emit('close')"
-  ></div>
-
-  <!-- Asset Variables Panel -->
-  <div
-    v-if="isOpen"
-    class="fixed z-[999999] w-80 max-w-[calc(100vw-2rem)] bg-editorWidget-bg border border-commandCenter-border variables-panel flex flex-col"
-    :style="panelStyle"
-    @mousedown.stop
+    id="asset-variables-panel"
+    class="mt-2 w-full bg-editorWidget-bg border border-commandCenter-border rounded"
   >
     <!-- Header -->
-    <div class="p-2 border-b border-commandCenter-border flex-shrink-0">
-      <div class="flex items-center justify-between">
-        <h4 class="text-xs font-medium text-editor-fg">Variable Overrides</h4>
-        <vscode-button
-          appearance="icon"
-          class="h-5 w-5 p-0 opacity-70 hover:opacity-100"
-          title="Close"
-          @click="$emit('close')"
-        >
-          <span class="codicon codicon-close text-[10px]"></span>
-        </vscode-button>
+    <div class="px-2 py-1.5 border-b border-commandCenter-border flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <h4 class="text-xs font-medium text-editor-fg">Variable overrides</h4>
+        <span class="text-2xs text-editor-fg opacity-60">
+          {{ activeOverrideCount }} / {{ variableCount }} active
+        </span>
       </div>
-      <p class="text-2xs text-editor-fg opacity-70 mt-1">
-        Override pipeline defaults for testing
-      </p>
+      <div class="flex items-center gap-1">
+        <button
+          v-if="activeOverrideCount > 0"
+          type="button"
+          id="clear-all-overrides"
+          class="text-2xs text-editor-fg opacity-70 hover:opacity-100 px-2 py-0.5"
+          title="Clear all overrides"
+          @click="clearAllOverrides"
+        >
+          Clear all
+        </button>
+      </div>
     </div>
 
-    <!-- Scrollable Content -->
-    <div class="flex-1 overflow-y-auto p-2 space-y-2">
-      <!-- Variables List with Override Inputs -->
-      <div v-if="variables && Object.keys(variables).length > 0" class="space-y-2">
+    <!-- Variables List -->
+    <div class="px-2 py-2 max-h-[320px] overflow-y-auto">
+      <div v-if="variableCount > 0" class="space-y-1">
         <div
           v-for="(variable, varName) in variables"
           :key="varName"
-          class="p-2 bg-editor-bg rounded border border-commandCenter-border space-y-2"
+          class="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1.4fr)_auto] items-center gap-2 py-1 border-b border-commandCenter-border last:border-b-0"
         >
-          <!-- Variable Info -->
-          <div>
-            <div class="flex items-center gap-2 mb-1">
-              <span class="text-xs font-mono text-editor-fg font-medium">{{ varName }}</span>
-              <span class="text-2xs px-1.5 py-0.5 bg-button-bg text-button-fg rounded">
-                {{ variable.type }}
-              </span>
-            </div>
-            <div v-if="variable.description" class="text-2xs text-editor-fg opacity-70 mb-1">
-              {{ variable.description }}
-            </div>
-            <div class="text-2xs text-editor-fg opacity-60">
-              Default: <span class="font-mono">{{ formatDisplayValue(variable.default) }}</span>
-            </div>
+          <!-- Name + type -->
+          <div class="flex items-center gap-1 min-w-0">
+            <span
+              class="text-xs font-mono text-editor-fg truncate"
+              :title="variable.description || String(varName)"
+            >{{ varName }}</span>
+            <span class="text-2xs px-1 py-0.5 bg-button-bg text-button-fg rounded shrink-0">
+              {{ variable.type }}
+            </span>
           </div>
 
-          <!-- Override Input -->
-          <div class="pt-2 border-t border-commandCenter-border">
-            <div class="flex gap-1 items-center">
-              <input
-                :value="getOverrideValue(varName)"
-                type="text"
-                placeholder='Override value'
-                class="flex-1 bg-editorWidget-bg text-editor-fg text-2xs border border-commandCenter-border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg h-6"
-                @input="handleOverrideInput(String(varName), variable, ($event.target as HTMLInputElement).value)"
-              />
-              <vscode-button
-                v-if="hasOverride(varName)"
-                appearance="icon"
-                class="h-6 w-6 p-0 opacity-70 hover:opacity-100"
-                title="Clear override"
-                @click="clearOverride(String(varName))"
-              >
-                <span class="codicon codicon-clear-all text-[10px]"></span>
-              </vscode-button>
-            </div>
-            <div v-if="hasOverride(varName)" class="text-2xs text-editor-fg opacity-70 mt-1 flex items-center gap-1">
-              <span class="codicon codicon-info text-[10px]"></span>
-              <span>Using override: <span class="font-mono">{{ formatDisplayValue(getOverrideValue(varName)) }}</span></span>
-            </div>
+          <!-- Default value (compact) -->
+          <div class="text-2xs text-editor-fg opacity-60 font-mono whitespace-nowrap">
+            default: {{ formatDisplayValue(variable.default) }}
           </div>
+
+          <!-- Override input -->
+          <div class="flex items-center gap-1 min-w-0">
+            <input
+              :value="getOverrideValue(String(varName))"
+              type="text"
+              placeholder="Override value"
+              :class="[
+                'flex-1 bg-editorWidget-bg text-editor-fg text-2xs border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg h-6',
+                hasOverride(String(varName))
+                  ? 'border-editorLink-activeFg'
+                  : 'border-commandCenter-border',
+              ]"
+              @input="handleOverrideInput(String(varName), variable, ($event.target as HTMLInputElement).value)"
+            />
+          </div>
+
+          <!-- Clear single -->
+          <button
+            v-if="hasOverride(String(varName))"
+            type="button"
+            class="text-descriptionFg opacity-70 hover:opacity-100 h-5 w-5 inline-flex items-center justify-center"
+            title="Clear override"
+            @click="clearOverride(String(varName))"
+          >
+            <span class="codicon codicon-close text-[10px]"></span>
+          </button>
+          <span v-else aria-hidden="true" class="w-5"></span>
         </div>
       </div>
 
       <!-- No variables state -->
-      <div v-else class="text-center py-4">
-        <div class="text-3xs text-editor-fg opacity-40 mb-2 italic">No pipeline variables found</div>
-        <div class="text-3xs text-editor-fg opacity-60">Add variables to your <span class="font-mono">pipeline.yml</span> to get started</div>
-      </div>
-    </div>
-
-    <!-- Footer with Save Button -->
-    <div class="p-2 border-t border-commandCenter-border flex-shrink-0">
-      <div class="flex justify-end gap-2">
-        <vscode-button
-          appearance="secondary"
-          class="text-2xs h-6 px-3"
-
-          @click="handleSave"
-          :disabled="Object.keys(variableOverrides).length === 0"
-        >
-          Save Overrides
-        </vscode-button>
+      <div v-else class="text-center py-3">
+        <div class="text-2xs text-editor-fg opacity-60 italic">
+          No pipeline variables found. Define variables in
+          <span class="font-mono">pipeline.yml</span> to override them here.
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import { computed, ref, watch } from "vue";
 
 interface Variable {
   type: string;
@@ -120,140 +103,53 @@ interface Variable {
 interface Props {
   isOpen: boolean;
   variables: Record<string, Variable>;
-  triggerElementId: string;
   initialOverrides?: Record<string, any>;
-  initialApplyOverrides?: boolean;
 }
 
 interface Emits {
-  (e: "close"): void;
   (e: "render-with-overrides", overrides: Record<string, any>): void;
-  (e: "save-overrides", overrides: Record<string, any>, applyOverrides: boolean): void;
   (e: "apply-overrides-toggle", applyOverrides: boolean): void;
 }
 
 const props = defineProps<Props>();
 const emit = defineEmits<Emits>();
 
-// Runtime variable overrides
+// Local mirror of overrides, kept in sync with parent via initialOverrides.
 const variableOverrides = ref<Record<string, any>>({});
 
-// Initialize from props
-watch(() => props.initialOverrides, (val) => {
-  if (val) {
-    variableOverrides.value = { ...val };
-  }
-}, { immediate: true });
+watch(
+  () => props.initialOverrides,
+  (val) => {
+    variableOverrides.value = { ...(val || {}) };
+  },
+  { immediate: true },
+);
 
+const variableCount = computed(() => Object.keys(props.variables || {}).length);
 
-// Panel positioning
-const panelStyle = ref<Record<string, string>>({});
-
-function updatePanelPosition() {
-  try {
-    const el = document.getElementById(props.triggerElementId);
-    if (!el) return;
-    
-    const rect = el.getBoundingClientRect();
-    const panelWidth = 320;
-    const margin = 8;
-    const availableHeight = window.innerHeight - margin * 2;
-    const maxPanelHeight = Math.min(600, availableHeight);
-    
-    let top = rect.bottom + margin;
-    let left = rect.left;
-    
-    if (left + panelWidth > window.innerWidth - margin) {
-      left = window.innerWidth - panelWidth - margin;
-    }
-    if (left < margin) {
-      left = margin;
-    }
-    
-    const bottomSpace = window.innerHeight - top;
-    const topSpace = rect.top - margin;
-    if (bottomSpace < maxPanelHeight && topSpace > bottomSpace) {
-      top = Math.max(margin, rect.top - maxPanelHeight - margin);
-    } else {
-      top = Math.min(top, window.innerHeight - maxPanelHeight - margin);
-    }
-    
-    panelStyle.value = {
-      top: `${top}px`,
-      left: `${left}px`,
-      maxHeight: `${maxPanelHeight}px`,
-    };
-  } catch (_) {}
-}
-
-function onWindowResize() {
-  if (props.isOpen) {
-    updatePanelPosition();
-  }
-}
-
-function onWindowClick(e: MouseEvent) {
-  if (props.isOpen) {
-    const triggerButton = document.getElementById(props.triggerElementId);
-    const panel = document.querySelector(".variables-panel");
-    if (triggerButton && !triggerButton.contains(e.target as Node) && 
-        panel && !panel.contains(e.target as Node)) {
-      emit("close");
-    }
-  }
-}
-
-function onWindowBlur() {
-  if (props.isOpen) {
-    emit("close");
-  }
-}
-
-onMounted(() => {
-  window.addEventListener("click", onWindowClick, true);
-  window.addEventListener("resize", onWindowResize);
-  window.addEventListener("blur", onWindowBlur);
-});
-
-onBeforeUnmount(() => {
-  window.removeEventListener("click", onWindowClick, true);
-  window.removeEventListener("resize", onWindowResize);
-  window.removeEventListener("blur", onWindowBlur);
-});
-
-watch(() => props.isOpen, (isOpen) => {
-  if (isOpen) {
-    updatePanelPosition();
-  }
+const activeOverrideCount = computed(() => {
+  const overrides = variableOverrides.value || {};
+  const declared = Object.keys(props.variables || {});
+  return declared.filter((k) => {
+    const v = overrides[k];
+    return v !== undefined && v !== null && v !== "";
+  }).length;
 });
 
 function formatDisplayValue(value: any): string {
-  if (value === null || value === undefined) {
-    return "null";
-  }
-  if (typeof value === "string") {
-    return `"${value}"`;
-  }
-  if (typeof value === "object") {
-    return JSON.stringify(value);
-  }
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "string") return `"${value}"`;
+  if (typeof value === "object") return JSON.stringify(value);
   return String(value);
 }
 
 function formatVariableValue(value: any): string {
-  if (value === null || value === undefined) {
-    return "";
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "object") {
-    return JSON.stringify(value);
-  }
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "object") return JSON.stringify(value);
   return String(value);
 }
 
-// Simplified override functions
 function getOverrideValue(varName: string): string {
   const override = variableOverrides.value[varName];
   if (override === undefined || override === null) return "";
@@ -261,7 +157,8 @@ function getOverrideValue(varName: string): string {
 }
 
 function hasOverride(varName: string): boolean {
-  return variableOverrides.value[varName] !== undefined && variableOverrides.value[varName] !== null;
+  const v = variableOverrides.value[varName];
+  return v !== undefined && v !== null && v !== "";
 }
 
 function parseValueByType(value: string, type: string): any {
@@ -272,12 +169,14 @@ function parseValueByType(value: string, type: string): any {
     switch (type) {
       case "boolean":
         return trimmed.toLowerCase() === "true";
-      case "integer":
+      case "integer": {
         const intVal = parseInt(trimmed);
         return isNaN(intVal) ? null : intVal;
-      case "number":
+      }
+      case "number": {
         const numVal = parseFloat(trimmed);
         return isNaN(numVal) ? null : numVal;
+      }
       case "array":
       case "object":
         return JSON.parse(trimmed);
@@ -297,21 +196,35 @@ function handleOverrideInput(varName: string, variable: Variable, value: string)
 
   const parsedValue = parseValueByType(value, variable.type);
   if (parsedValue === null) {
-    return; // Invalid value, don't update
+    return; // Invalid value, don't update.
   }
 
-  variableOverrides.value[varName] = parsedValue;
+  const wasEmpty = activeOverrideCount.value === 0;
+  variableOverrides.value = { ...variableOverrides.value, [varName]: parsedValue };
   emit("render-with-overrides", { ...variableOverrides.value });
+
+  // First override entered — auto-enable the "apply overrides" toggle so users
+  // don't set a value but forget to apply it on the next run.
+  if (wasEmpty) {
+    emit("apply-overrides-toggle", true);
+  }
 }
 
 function clearOverride(varName: string): void {
-  delete variableOverrides.value[varName];
+  const next = { ...variableOverrides.value };
+  delete next[varName];
+  variableOverrides.value = next;
   emit("render-with-overrides", { ...variableOverrides.value });
+
+  // No overrides left — turn off the apply toggle.
+  if (activeOverrideCount.value === 0) {
+    emit("apply-overrides-toggle", false);
+  }
 }
 
-
-function handleSave() {
-  emit("save-overrides", { ...variableOverrides.value }, true);
-  emit("close");
+function clearAllOverrides(): void {
+  variableOverrides.value = {};
+  emit("render-with-overrides", {});
+  emit("apply-overrides-toggle", false);
 }
 </script>


### PR DESCRIPTION
## Summary

**BRU-4848 — Show run variables and settings on one screen**
Replaces the floating "Variable overrides" modal with an inline panel rendered directly under the run controls.

- All pipeline variables appear at once with name, type, default value, and an override input on the same row.
- The cog icon is gone — the "Variables" label is now a chevron toggle (with count).
- Entering an override **auto-enables** the "Variable overrides" toggle; clearing the last override turns it off automatically. Solves the ticket's "easy to forget that a variable was previously set" complaint.
- A "Clear all" button appears in the panel header when any override is active.
- Live edits persist immediately to webview state — no separate "Save" step.

**Flaky-test fix**
8 failing tests in the `Materialization Tests` describe were throwing `NoSuchElementError: materialization-section` because the `beforeEach` silently swallowed setup errors and each test then ran `driver.findElement(...)` synchronously.

- Adds `ensureMaterializationSectionExpanded()` that re-navigates to Details, locates the section with explicit waits, and expands it via the existing `safeElementInteraction` retry helper.
- All 8 failing tests call the helper at the top, so a flaky `beforeEach` no longer leaves them running against a missing section.
- `safeElementInteraction` now only retries on `StaleElementReferenceError` (was retrying on any error, which masked real failures).
- CI-aware delays: `getPlatformDelay` triples timeouts on Windows **and** CI, matching the pattern used in the Edit-Asset-Name describe.
- The merge-strategy test also explicitly switches to `table` type first, since the strategy select only renders for the table materialization type.

## Test plan
- [ ] Open an asset whose pipeline declares variables. Click "Variables" — inline panel expands.
- [ ] Type a value into one variable's override input. Verify the "Variable overrides" checkbox auto-enables and the count badge updates.
- [ ] Clear that override. Verify the toggle auto-disables.
- [ ] Set two overrides, click "Clear all" — both are removed and the toggle is off.
- [ ] Reload the webview — overrides persist.
- [ ] Run the asset with overrides active — verify `--var key='value'` flags are passed.
- [ ] Run `npm run selenium:run-tests:webview` locally (or on CI) — all Materialization tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)