### PR TITLE
fix: cache CLI install status to avoid install-screen flash on open

### DIFF
--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -99,6 +99,29 @@ export class BruinPanel {
   }
 
   /**
+   * Persistent cache of the last known CLI install status so a fresh webview
+   * can boot directly into the main UI when the user has the CLI installed,
+   * instead of flashing the install screen while we await `bruin --version`.
+   */
+  private static readonly CLI_INSTALLED_CACHE_KEY = "bruin.cli.installedCache";
+
+  private static getCachedCliInstalled(): boolean | null {
+    const ctx = BruinPanel._extensionContext;
+    if (!ctx) return null;
+    const cached = ctx.globalState.get<boolean | undefined>(BruinPanel.CLI_INSTALLED_CACHE_KEY);
+    return typeof cached === "boolean" ? cached : null;
+  }
+
+  private static async setCachedCliInstalled(installed: boolean): Promise<void> {
+    const ctx = BruinPanel._extensionContext;
+    if (!ctx) return;
+    if (ctx.globalState.get<boolean | undefined>(BruinPanel.CLI_INSTALLED_CACHE_KEY) === installed) {
+      return; // no-op write avoidance
+    }
+    await ctx.globalState.update(BruinPanel.CLI_INSTALLED_CACHE_KEY, installed);
+  }
+
+  /**
    * The BruinPanel class private constructor (called only from the render method).
    *
    * @param panel A reference to the webview panel
@@ -235,7 +258,15 @@ export class BruinPanel {
   }
 
   private async _initializeWebview(extensionUri: Uri): Promise<void> {
-    this._panel.webview.html = this._getWebviewContent(this._panel.webview, extensionUri, null);
+    // Boot the webview with the last-known CLI install status so users who
+    // already have the CLI don't see the install screen flash while we
+    // re-verify in the background.
+    const cachedCliInstalled = BruinPanel.getCachedCliInstalled();
+    this._panel.webview.html = this._getWebviewContent(
+      this._panel.webview,
+      extensionUri,
+      cachedCliInstalled,
+    );
     this._lastRenderedDocumentUri = window.activeTextEditor?.document.uri;
     this._setWebviewMessageListener(this._panel.webview);
 
@@ -245,11 +276,43 @@ export class BruinPanel {
     try {
       const bruinInstaller = new BruinInstallCLI();
       const detectionTimeoutMs = 2000;
+      let timedOut = false;
       const timeoutPromise = new Promise<{ installed: boolean; isWindows: boolean; gitAvailable: boolean }>((resolve) => {
-        setTimeout(() => resolve({ installed: false, isWindows: process.platform === 'win32', gitAvailable: false }), detectionTimeoutMs);
+        setTimeout(() => {
+          timedOut = true;
+          resolve({ installed: false, isWindows: process.platform === 'win32', gitAvailable: false });
+        }, detectionTimeoutMs);
       });
+
+      // Keep a reference to the real check so we can still react to its result
+      // when the timeout wins the race (slow `bruin --version` on cold shells).
+      const realCheck = bruinInstaller.checkBruinCliInstallation();
+      realCheck
+        .then((real) => {
+          // Cache the real answer regardless of who won the race.
+          void BruinPanel.setCachedCliInstalled(real.installed);
+          // If the timeout already pushed a "not installed" fallback to the
+          // webview, send a corrected status now that the real check has
+          // returned, so the UI flips off the install screen.
+          if (timedOut) {
+            this._cliInstalled = real.installed;
+            this._panel.webview.postMessage({
+              command: "bruinCliInstallationStatus",
+              installed: real.installed,
+              isWindows: real.isWindows,
+              gitAvailable: real.gitAvailable,
+            });
+            if (real.installed && this._lastRenderedDocumentUri) {
+              this._runPostInstallSideEffects(this._lastRenderedDocumentUri).catch(() => {});
+            }
+          }
+        })
+        .catch(() => {
+          // Real check failed — leave existing cache value alone.
+        });
+
       const { installed, isWindows, gitAvailable } = await Promise.race([
-        bruinInstaller.checkBruinCliInstallation(),
+        realCheck,
         timeoutPromise,
       ]);
       this._cliInstalled = installed;
@@ -260,15 +323,7 @@ export class BruinPanel {
         gitAvailable,
       });
       if (installed && this._lastRenderedDocumentUri) {
-        const cliFilePath = this._lastRenderedDocumentUri.fsPath;
-        const isActualAsset = await this._isAssetFile(cliFilePath);
-        
-        if (isActualAsset) {
-          parseAssetCommand(this._lastRenderedDocumentUri);
-        } else {
-          await this._handleAssetDetection(this._lastRenderedDocumentUri);
-        }
-        getEnvListCommand(this._lastRenderedDocumentUri);
+        await this._runPostInstallSideEffects(this._lastRenderedDocumentUri);
       }
     } catch (error) {
       this._cliInstalled = false;
@@ -279,6 +334,22 @@ export class BruinPanel {
         gitAvailable: false,
       });
     }
+  }
+
+  /**
+   * Side effects we run once we know the CLI is installed: parse the asset,
+   * fetch the env list, etc. Extracted so it can run either from the racing
+   * timeout path or from the late real-check follow-up.
+   */
+  private async _runPostInstallSideEffects(uri: Uri): Promise<void> {
+    const filePath = uri.fsPath;
+    const isActualAsset = await this._isAssetFile(filePath);
+    if (isActualAsset) {
+      parseAssetCommand(uri);
+    } else {
+      await this._handleAssetDetection(uri);
+    }
+    getEnvListCommand(uri);
   }
 
 
@@ -1515,6 +1586,8 @@ export class BruinPanel {
   private async checkAndUpdateBruinCliStatus() {
     const bruinInstaller = new BruinInstallCLI();
     const { installed, isWindows, gitAvailable } = await bruinInstaller.checkBruinCliInstallation();
+    this._cliInstalled = installed;
+    void BruinPanel.setCachedCliInstalled(installed);
     this._panel.webview.postMessage({
       command: "bruinCliInstallationStatus",
       installed,

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -308,7 +308,12 @@ export class BruinPanel {
           }
         })
         .catch(() => {
-          // Real check failed — leave existing cache value alone.
+          // Real check threw — treat as "not installed" so we don't keep
+          // showing the main UI on cold opens only to flip back to the
+          // install screen each time. The webview message itself is sent
+          // by the outer catch (or by the timed-out path, which already
+          // pushed `installed: false`).
+          void BruinPanel.setCachedCliInstalled(false);
         });
 
       const { installed, isWindows, gitAvailable } = await Promise.race([
@@ -327,6 +332,14 @@ export class BruinPanel {
       }
     } catch (error) {
       this._cliInstalled = false;
+      // Persist so the next cold open doesn't flash the cached "installed"
+      // main UI before flipping back to the install screen. The `realCheck`
+      // catch handler also writes this, but doing it here as well covers the
+      // case where the synchronous spawn failed before realCheck was even
+      // created (defensive — `bruinInstaller.checkBruinCliInstallation()`
+      // shouldn't throw synchronously today, but we don't want to depend
+      // on that).
+      void BruinPanel.setCachedCliInstalled(false);
       this._panel.webview.postMessage({
         command: "bruinCliInstallationStatus",
         installed: false,


### PR DESCRIPTION
## Summary

Fixes the long-standing bug where opening the extension flashes the install screen — even on machines where the CLI is clearly installed — and only resolves itself once the user clicks on a file.

## Root cause

- \`BruinPanel._initializeWebview\` builds the webview HTML with \`initialCliStatus = null\` (hardcoded since the caching logic was removed in [\`5a56403e\`](https://github.com/bruin-data/bruin-vscode/commit/5a56403e), Aug 2025). So \`window.initialBruinCliStatus\` is always \`null\` on a cold open.
- \`_checkCliStatus\` races the CLI detection against a **2 s** timeout. If \`bruin --version\` takes longer (cold shell, antivirus, slow PATH lookup), the timeout pushes \`installed: false\` to the webview.
- App.vue has a parallel 2.5 s fallback that flips to install UI if it doesn't hear back.
- Clicking a file gives the real check enough wall-clock time to finish, at which point a follow-up CLI check eventually arrives and the UI corrects itself.

## Fix

Persist the last-known \`installed\` value to \`context.globalState\` under \`bruin.cli.installedCache\`:

- \`_initializeWebview\` reads the cached value and passes it to \`_getWebviewContent\`, so returning users boot straight into the main UI.
- \`_checkCliStatus\` keeps a reference to the real CLI check and writes its result to the cache **regardless of who won the race**. If the timeout already fired with a fallback "not installed", the late real-check result is sent to the webview so the UI flips back, and post-install side effects (asset parse, env list) are run.
- \`checkAndUpdateBruinCliStatus\` (the on-demand path) also updates the cache.
- Post-install side effects extracted into \`_runPostInstallSideEffects(uri)\` so both the racing-timeout path and the late real-check path share the same logic.
- No-op writes are skipped to avoid churning globalState on every open.

The cache is only used as the **initial hint** — the backend still verifies in the background, so an uninstalled CLI is detected on the next check and the UI updates accordingly.

## Test plan
- [ ] Fresh extension install (no cached value): first open still shows install screen until the CLI check returns. After a successful check, the cache is populated.
- [ ] Subsequent opens with the CLI installed: webview boots straight into the main UI with no install-screen flash.
- [ ] Slow CLI check (simulate by adding a sleep to \`bruin --version\` or running on a cold shell): timeout fires, fallback "not installed" is sent, then the late real-check pushes the correct status and the install screen disappears.
- [ ] CLI uninstalled after a successful previous open: cache says \`true\`, but the next \`_checkCliStatus\` returns \`installed: false\`, the install screen shows, and the cache is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)