### PR TITLE
feat: add local backfill with interval chunking

### DIFF
--- a/src/bruin/bruinUtils.ts
+++ b/src/bruin/bruinUtils.ts
@@ -411,6 +411,97 @@ export const runMultipleAssetsInTerminal = async (
   await new Promise((resolve) => setTimeout(resolve, 1000));
 };
 
+export interface BackfillChunk {
+  start: string;
+  end: string;
+}
+
+/**
+ * Builds a single chained shell command that runs `bruin run` once per chunk,
+ * each with its own --start-date/--end-date window.
+ *
+ * Note: backfill deliberately does NOT pass `--full-refresh`. The CLI ignores
+ * the chunk window under full-refresh and reloads from the pipeline's
+ * start_date, which would defeat interval chunking. Correct re-runs of a window
+ * rely on the asset's incremental strategy (merge / delete+insert / time_interval).
+ *
+ * Chunks are joined with `&&` when `stopOnFailure` is set (abort on the first
+ * failed window) or `;` otherwise (run every window regardless). On non-unix
+ * shells we sequence with `;` since legacy PowerShell lacks `&&`.
+ */
+export const buildBackfillCommand = (
+  executable: string,
+  chunks: BackfillChunk[],
+  flags: string,
+  assetPath: string,
+  stopOnFailure: boolean,
+  useUnixFormatting: boolean = true
+): string => {
+  const baseFlags = (flags || "").trim();
+  const separator = !useUnixFormatting ? " ;" : stopOnFailure ? " &&" : " ;";
+  const continuationChar = useUnixFormatting ? " \\" : " `";
+
+  const lines = chunks.map((chunk) => {
+    const parts = [executable, BRUIN_RUN_SQL_COMMAND];
+    if (baseFlags.length > 0) {
+      parts.push(baseFlags);
+    }
+    parts.push(`--start-date ${chunk.start}`);
+    parts.push(`--end-date ${chunk.end}`);
+    parts.push(assetPath);
+    return parts.join(" ");
+  });
+
+  // Join with `<sep> <continuation>\n` between lines for a readable script.
+  return lines
+    .map((line, index) =>
+      index === lines.length - 1 ? line : `${line}${separator}${continuationChar}\n`
+    )
+    .join("");
+};
+
+/**
+ * Runs a local backfill: `bruin run` once per interval chunk, sequentially, in
+ * the integrated terminal. Mirrors how runInIntegratedTerminal sends commands.
+ */
+export const runBackfillInTerminal = async (
+  assetPath: string,
+  chunks: BackfillChunk[],
+  flags: string | undefined,
+  stopOnFailure: boolean,
+  workingDir?: string | undefined,
+  bruinExecutablePath?: string
+): Promise<void> => {
+  if (!assetPath || !chunks || chunks.length === 0) {
+    return;
+  }
+
+  const escapedAssetPath = escapeFilePath(assetPath);
+  const bruinExecutable = bruinExecutablePath ? "bruin" : getBruinExecutablePath();
+  const terminal = await createIntegratedTerminal(workingDir);
+
+  const useUnixFormatting = shouldUseUnixFormatting(terminal);
+  const executable = ((terminal.creationOptions as vscode.TerminalOptions).shellPath?.includes("bash"))
+    ? "bruin"
+    : bruinExecutable;
+
+  const command = buildBackfillCommand(
+    executable,
+    chunks,
+    flags || "",
+    escapedAssetPath,
+    stopOnFailure,
+    useUnixFormatting
+  );
+
+  terminal.show(true);
+  terminal.sendText(" ");
+  setTimeout(() => {
+    terminal.sendText(command);
+  }, 500);
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+};
+
 export const createIntegratedTerminal = async (
   workingDir: string | undefined
 ): Promise<vscode.Terminal> => {

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -15,6 +15,7 @@ import {
   formatInIntegratedTerminal,
   escapeFilePath,
   runMultipleAssetsInTerminal,
+  runBackfillInTerminal,
 } from "../bruin";
 import { BruinFill } from "../bruin/bruinFill";
 import { BruinLockDependencies } from "../bruin/bruinLockDependencies";
@@ -814,6 +815,24 @@ export class BruinPanel {
             }
             // Run multiple assets sequentially in the terminal
             runMultipleAssetsInTerminal(message.payload.assets, message.payload.flags, "bruin");
+            break;
+
+          case "bruin.runBackfill":
+            trackEvent("Command Executed", { command: "runBackfill", source: "extension" });
+            if (!this._lastRenderedDocumentUri) {
+              return;
+            }
+            if (!message.payload?.chunks || message.payload.chunks.length === 0) {
+              return;
+            }
+            runBackfillInTerminal(
+              this._lastRenderedDocumentUri.fsPath,
+              message.payload.chunks,
+              message.payload.flags,
+              message.payload.stopOnFailure !== false,
+              "",
+              "bruin"
+            );
             break;
 
           case "bruin.getAssetDetails":

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -7750,3 +7750,117 @@ suite("Utility Functions Tests", () => {
     });
   });
 });
+
+suite("buildBackfillCommand", () => {
+  const chunks = [
+    { start: "2024-01-01T00:00:00Z", end: "2024-01-02T00:00:00Z" },
+    { start: "2024-01-02T00:00:00Z", end: "2024-01-03T00:00:00Z" },
+    { start: "2024-01-03T00:00:00Z", end: "2024-01-04T00:00:00Z" },
+  ];
+
+  test("should chain chunks with && when stopOnFailure is true", () => {
+    const result = (bruinUtils as any).buildBackfillCommand(
+      "bruin",
+      chunks,
+      "--environment default",
+      '"/path/to/asset.sql"',
+      true,
+      true
+    );
+
+    const expected = `bruin run --environment default --start-date 2024-01-01T00:00:00Z --end-date 2024-01-02T00:00:00Z "/path/to/asset.sql" && \\
+bruin run --environment default --start-date 2024-01-02T00:00:00Z --end-date 2024-01-03T00:00:00Z "/path/to/asset.sql" && \\
+bruin run --environment default --start-date 2024-01-03T00:00:00Z --end-date 2024-01-04T00:00:00Z "/path/to/asset.sql"`;
+
+    assert.strictEqual(result, expected, "Should chain with && for stop-on-failure");
+  });
+
+  test("should chain chunks with ; when stopOnFailure is false", () => {
+    const result = (bruinUtils as any).buildBackfillCommand(
+      "bruin",
+      chunks,
+      "",
+      '"/path/to/asset.sql"',
+      false,
+      true
+    );
+
+    const expected = `bruin run --start-date 2024-01-01T00:00:00Z --end-date 2024-01-02T00:00:00Z "/path/to/asset.sql" ; \\
+bruin run --start-date 2024-01-02T00:00:00Z --end-date 2024-01-03T00:00:00Z "/path/to/asset.sql" ; \\
+bruin run --start-date 2024-01-03T00:00:00Z --end-date 2024-01-04T00:00:00Z "/path/to/asset.sql"`;
+
+    assert.strictEqual(result, expected, "Should chain with ; for run-all");
+  });
+
+  test("should produce a single command with no separator for one chunk", () => {
+    const result = (bruinUtils as any).buildBackfillCommand(
+      "bruin",
+      [chunks[0]],
+      "--environment default",
+      '"/path/to/asset.sql"',
+      true,
+      true
+    );
+
+    const expected =
+      'bruin run --environment default --start-date 2024-01-01T00:00:00Z --end-date 2024-01-02T00:00:00Z "/path/to/asset.sql"';
+
+    assert.strictEqual(result, expected, "Single chunk should have no separator/continuation");
+  });
+
+  test("should sequence with ; and backtick continuation on non-unix shells even when stopOnFailure is true", () => {
+    const result = (bruinUtils as any).buildBackfillCommand(
+      "bruin",
+      [chunks[0], chunks[1]],
+      "",
+      '"/path/to/asset.sql"',
+      true,
+      false
+    );
+
+    const expected = `bruin run --start-date 2024-01-01T00:00:00Z --end-date 2024-01-02T00:00:00Z "/path/to/asset.sql" ; \`
+bruin run --start-date 2024-01-02T00:00:00Z --end-date 2024-01-03T00:00:00Z "/path/to/asset.sql"`;
+
+    assert.strictEqual(
+      result,
+      expected,
+      "Legacy PowerShell lacks &&, so sequence with ; and backtick continuation"
+    );
+  });
+
+  test("should never inject --full-refresh", () => {
+    const result = (bruinUtils as any).buildBackfillCommand(
+      "bruin",
+      chunks,
+      "--environment default",
+      '"/path/to/asset.sql"',
+      true,
+      true
+    );
+
+    assert.ok(
+      !result.includes("--full-refresh"),
+      "Backfill must not pass --full-refresh (it would ignore the chunk window)"
+    );
+  });
+
+  test("should put each chunk's window, base flags, and asset path on every command", () => {
+    const result = (bruinUtils as any).buildBackfillCommand(
+      "bruin",
+      chunks,
+      "--push-metadata",
+      '"/path/to/asset.sql"',
+      true,
+      true
+    );
+
+    const lines = result.split("\n");
+    assert.strictEqual(lines.length, 3, "One line per chunk");
+    chunks.forEach((chunk: { start: string; end: string }, i: number) => {
+      assert.ok(lines[i].includes(`--start-date ${chunk.start}`), `chunk ${i} has its start-date`);
+      assert.ok(lines[i].includes(`--end-date ${chunk.end}`), `chunk ${i} has its end-date`);
+      assert.ok(lines[i].includes("--push-metadata"), `chunk ${i} keeps base flags`);
+      assert.ok(lines[i].trim().endsWith('"/path/to/asset.sql"'), `chunk ${i} ends with asset path`);
+    });
+  });
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -7860,7 +7860,13 @@ bruin run --start-date 2024-01-02T00:00:00Z --end-date 2024-01-03T00:00:00Z "/pa
       assert.ok(lines[i].includes(`--start-date ${chunk.start}`), `chunk ${i} has its start-date`);
       assert.ok(lines[i].includes(`--end-date ${chunk.end}`), `chunk ${i} has its end-date`);
       assert.ok(lines[i].includes("--push-metadata"), `chunk ${i} keeps base flags`);
-      assert.ok(lines[i].trim().endsWith('"/path/to/asset.sql"'), `chunk ${i} ends with asset path`);
+      // asset path comes after the dates on every line (non-last lines are then
+      // followed by the separator + line-continuation, so use includes, not endsWith).
+      assert.ok(
+        lines[i].indexOf('"/path/to/asset.sql"') > lines[i].indexOf(`--end-date ${chunk.end}`),
+        `chunk ${i} has the asset path after its window`
+      );
     });
+    assert.ok(lines[2].trim().endsWith('"/path/to/asset.sql"'), "last line ends with asset path");
   });
 });

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -742,6 +742,7 @@ const tabs = ref([
       assetMetadataError: assetMetadataError.value,
       pipelineAssets: pipelineAssets.value,
       filePath: lastRenderedDocument.value,
+      materializationStrategy: materializationProps.value?.strategy,
     })),
     emits: ["update:assetName", "update:description"],
   },

--- a/webview-ui/src/components/asset/AssetDetails.vue
+++ b/webview-ui/src/components/asset/AssetDetails.vue
@@ -95,6 +95,7 @@
         :pipeline="props.pipeline"
         :filePath="props.filePath"
         :startDate="props.startDate"
+        :materializationStrategy="props.materializationStrategy"
       />
     </div>
   </div>
@@ -128,6 +129,7 @@ const props = defineProps<{
   assetMetadataError?: string;
   pipelineAssets?: any[];
   filePath: string;
+  materializationStrategy?: string;
 }>();
 
 const descriptionRef = ref<HTMLElement | null>(null);

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -1740,9 +1740,11 @@ function runAssetOnly() {
 // Remove the global --start-date/--end-date flags; backfill supplies a
 // per-chunk window instead.
 function stripDateFlags(flags: string): string {
+  // \s* (not \s) so the flag is still stripped when it is the first token —
+  // upstream stripFullRefreshFlag trims, so the string can begin with --start-date.
   return flags
-    .replace(/\s--start-date\s+[^\s]+/g, "")
-    .replace(/\s--end-date\s+[^\s]+/g, "")
+    .replace(/\s*--start-date\s+[^\s]+/g, "")
+    .replace(/\s*--end-date\s+[^\s]+/g, "")
     .trim();
 }
 
@@ -1766,7 +1768,7 @@ function handleRunBackfill(payload: { chunks: BackfillChunk[]; stopOnFailure: bo
 
   // Sensors don't make sense replaying historical windows — force skip so a
   // backfill never blocks on a sensor (overrides any Apply-Sensor-Mode choice).
-  baseFlags = `${baseFlags.replace(/\s--sensor-mode\s+\S+/g, "").trim()} --sensor-mode skip`.trim();
+  baseFlags = `${baseFlags.replace(/\s*--sensor-mode\s+\S+/g, "").trim()} --sensor-mode skip`.trim();
 
   vscode.postMessage({
     command: "bruin.runBackfill",

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -369,6 +369,9 @@
         :fullRefreshEnabled="isFullRefreshChecked" @close="showSelectMultipleAssetsDialog = false"
         @run="handleRunMultipleAssets" />
 
+      <BackfillDialog :isOpen="showBackfillDialog" :startDate="startDate" :endDate="endDate"
+        :schedule="props.schedule" @close="showBackfillDialog = false" @run="handleRunBackfill" />
+
       <!-- Selected assets summary (clickable to open panel) -->
       <div v-if="selectedAssetsForRun.length > 0 && !showSelectMultipleAssetsDialog"
         class="mt-2 flex items-center gap-1.5 text-xs min-w-0">
@@ -498,6 +501,8 @@ import ButtonGroup from "@/components/ui/buttons/ButtonGroup.vue";
 import { updateValue, resetStates, determineValidationStatus } from "@/utilities/helper";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 import SelectMultipleAssets from "@/components/ui/asset/SelectMultipleAssets.vue";
+import BackfillDialog from "@/components/ui/asset/BackfillDialog.vue";
+import type { BackfillChunk } from "@/utilities/helper";
 import {
   ChevronDownIcon,
   ChevronUpIcon,
@@ -585,6 +590,7 @@ const runDropdownItems = computed(() => [
   { key: 'run-current-pipeline', label: 'Run the whole pipeline' },
   { key: 'run-with-continue', label: 'Continue from last failure' },
   { key: 'run-multiple-assets', label: 'Run multiple assets' },
+  { key: 'run-backfill', label: 'Backfill…', disabled: isPipelineFile.value },
   { key: 'copy-command', label: 'Copy command' },
 ]);
 
@@ -604,6 +610,9 @@ const selectedAssetsDisplay = computed(() => {
 // Full refresh alert state
 const showFullRefreshAlert = ref(false);
 const pendingRunAction = ref<(() => void) | null>(null);
+
+// Local backfill dialog state
+const showBackfillDialog = ref(false);
 
 // Full refresh alert methods
 const confirmFullRefresh = () => {
@@ -654,6 +663,9 @@ const handleRunDropdown = (key: string) => {
       break;
     case "run-multiple-assets":
       runMultipleAssets();
+      break;
+    case "run-backfill":
+      showBackfillDialog.value = true;
       break;
     case "copy-command":
       copyRunCommand();
@@ -1715,6 +1727,39 @@ function runAssetOnly() {
   vscode.postMessage({
     command: "bruin.runSql",
     payload,
+  });
+}
+
+// Remove the global --start-date/--end-date flags; backfill supplies a
+// per-chunk window instead.
+function stripDateFlags(flags: string): string {
+  return flags
+    .replace(/\s--start-date\s+[^\s]+/g, "")
+    .replace(/\s--end-date\s+[^\s]+/g, "")
+    .trim();
+}
+
+// Kick off a local backfill. We send the per-chunk windows plus the base flags
+// with the global dates and --full-refresh stripped: each chunk supplies its
+// own --start-date/--end-date, and full-refresh is intentionally excluded
+// because the CLI ignores the chunk window under full-refresh (it reloads from
+// the pipeline start_date). Correct window re-runs rely on the asset's
+// incremental strategy.
+function handleRunBackfill(payload: { chunks: BackfillChunk[]; stopOnFailure: boolean }) {
+  showBackfillDialog.value = false;
+  if (!payload.chunks || payload.chunks.length === 0) return;
+
+  const baseFlags = stripDateFlags(
+    stripFullRefreshFlag(stripAllTagFlags(getCheckboxChangePayload()))
+  );
+
+  vscode.postMessage({
+    command: "bruin.runBackfill",
+    payload: {
+      chunks: payload.chunks,
+      flags: baseFlags,
+      stopOnFailure: payload.stopOnFailure,
+    },
   });
 }
 

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -370,7 +370,9 @@
         @run="handleRunMultipleAssets" />
 
       <BackfillDialog :isOpen="showBackfillDialog" :startDate="startDate" :endDate="endDate"
-        :schedule="props.schedule" @close="showBackfillDialog = false" @run="handleRunBackfill" />
+        :schedule="props.schedule" :fullRefreshChecked="isFullRefreshChecked"
+        :sensorModeActive="isSensorModeActive" :materializationStrategy="props.materializationStrategy"
+        @close="showBackfillDialog = false" @run="handleRunBackfill" />
 
       <!-- Selected assets summary (clickable to open panel) -->
       <div v-if="selectedAssetsForRun.length > 0 && !showSelectMultipleAssetsDialog"
@@ -539,6 +541,7 @@ const props = defineProps<{
   assetMetadataError?: string;
   pipeline?: any;
   filePath?: string;
+  materializationStrategy?: string;
 }>();
 
 /**
@@ -1075,6 +1078,10 @@ const activeOverridesSummary = computed(() => {
 });
 const isFullRefreshChecked = computed(() => {
   return checkboxItems.value.find((item) => item.name === "Full-Refresh")?.checked || false;
+});
+
+const isSensorModeActive = computed(() => {
+  return checkboxItems.value.find((item) => item.name === "Apply-Sensor-Mode")?.checked || false;
 });
 
 const activeTagCount = computed(() => includeTags.value.length + excludeTags.value.length);
@@ -1749,9 +1756,17 @@ function handleRunBackfill(payload: { chunks: BackfillChunk[]; stopOnFailure: bo
   showBackfillDialog.value = false;
   if (!payload.chunks || payload.chunks.length === 0) return;
 
-  const baseFlags = stripDateFlags(
-    stripFullRefreshFlag(stripAllTagFlags(getCheckboxChangePayload()))
+  // buildCommandPayload adds --environment/--variant; without it the backfill
+  // would silently run against the default environment. Then strip the global
+  // dates (each chunk supplies its own), --full-refresh (ignored by backfill),
+  // and tag flags (this is an asset-level run).
+  let baseFlags = stripDateFlags(
+    stripFullRefreshFlag(stripAllTagFlags(buildCommandPayload(getCheckboxChangePayload())))
   );
+
+  // Sensors don't make sense replaying historical windows — force skip so a
+  // backfill never blocks on a sensor (overrides any Apply-Sensor-Mode choice).
+  baseFlags = `${baseFlags.replace(/\s--sensor-mode\s+\S+/g, "").trim()} --sensor-mode skip`.trim();
 
   vscode.postMessage({
     command: "bruin.runBackfill",

--- a/webview-ui/src/components/ui/asset/BackfillDialog.vue
+++ b/webview-ui/src/components/ui/asset/BackfillDialog.vue
@@ -47,6 +47,24 @@
           coarser granularity to cover it all.</span>
       </div>
 
+      <!-- create+replace warning: backfill would just overwrite the table -->
+      <div v-if="isOverwriteStrategy"
+        class="text-2xs text-notificationsWarningIcon-fg flex items-start gap-1">
+        <span class="codicon codicon-warning text-2xs mt-0.5"></span>
+        <span>This asset uses <span class="font-mono">create+replace</span> — each chunk overwrites the whole
+          table, so only the last window would survive. Backfill suits incremental strategies
+          (<span class="font-mono">merge</span> / <span class="font-mono">delete+insert</span> /
+          <span class="font-mono">time_interval</span>).</span>
+      </div>
+
+      <!-- Informational notes about flags backfill adjusts -->
+      <ul v-if="notes.length > 0" class="text-2xs text-editor-fg opacity-60 flex flex-col gap-0.5 list-none m-0 p-0">
+        <li v-for="(note, i) in notes" :key="i" class="flex items-start gap-1">
+          <span class="codicon codicon-info text-2xs mt-0.5"></span>
+          <span>{{ note }}</span>
+        </li>
+      </ul>
+
       <!-- Chunk preview -->
       <div v-if="chunks.length > 0"
         class="border border-commandCenter-border rounded bg-editor-bg max-h-36 overflow-y-auto">
@@ -93,6 +111,9 @@ const props = defineProps<{
   startDate: string;
   endDate: string;
   schedule?: string;
+  fullRefreshChecked?: boolean;
+  sensorModeActive?: boolean;
+  materializationStrategy?: string;
 }>();
 
 const emit = defineEmits<{
@@ -129,6 +150,28 @@ const result = computed(() =>
 const chunks = computed(() => result.value.chunks);
 const truncated = computed(() => result.value.truncated);
 const previewChunks = computed(() => chunks.value.slice(0, previewLimit));
+
+const normalizedStrategy = computed(() =>
+  (props.materializationStrategy || "").toLowerCase().replace(/[\s_]/g, "")
+);
+const isOverwriteStrategy = computed(() => normalizedStrategy.value === "create+replace");
+const isAppendStrategy = computed(() => normalizedStrategy.value === "append");
+
+// Notes explaining the flag adjustments backfill makes (full-refresh dropped,
+// sensors skipped, append duplicates on re-run).
+const notes = computed<string[]>(() => {
+  const out: string[] = [];
+  if (props.fullRefreshChecked) {
+    out.push("Full-refresh is ignored for backfill — each chunk runs its own window.");
+  }
+  if (props.sensorModeActive) {
+    out.push("Sensors are skipped for backfill (--sensor-mode skip).");
+  }
+  if (isAppendStrategy.value) {
+    out.push("append accumulates rows — re-running an already-loaded window will duplicate it.");
+  }
+  return out;
+});
 
 const formatBoundary = (iso: string): string => {
   const dt = DateTime.fromISO(iso, { zone: "utc" });

--- a/webview-ui/src/components/ui/asset/BackfillDialog.vue
+++ b/webview-ui/src/components/ui/asset/BackfillDialog.vue
@@ -1,0 +1,142 @@
+<template>
+  <div v-if="isOpen" class="mt-2 flex flex-col">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-2">
+      <div class="flex items-center gap-1.5">
+        <span class="codicon codicon-history text-xs text-editor-fg opacity-70"></span>
+        <span class="text-xs text-editor-fg opacity-70">Backfill</span>
+      </div>
+      <button @click="$emit('close')" class="text-editor-fg opacity-50 hover:opacity-100" title="Close">
+        <span class="codicon codicon-close text-xs"></span>
+      </button>
+    </div>
+
+    <div class="border border-commandCenter-border rounded bg-sideBar-bg p-2 flex flex-col gap-2">
+      <!-- Controls row: granularity + stop-on-failure -->
+      <div class="flex items-center justify-between gap-2 flex-wrap">
+        <div class="flex items-center gap-1.5">
+          <span class="text-2xs text-editor-fg opacity-70">Chunk by</span>
+          <vscode-dropdown v-model="granularity" class="min-w-[90px]">
+            <vscode-option v-for="g in granularities" :key="g" :value="g">{{ g }}</vscode-option>
+          </vscode-dropdown>
+        </div>
+        <vscode-checkbox :checked="stopOnFailure" @change="stopOnFailure = ($event.target as any).checked"
+          class="text-2xs">
+          Stop on first failure
+        </vscode-checkbox>
+      </div>
+
+      <!-- Summary line -->
+      <div class="text-2xs text-editor-fg opacity-70">
+        <template v-if="chunks.length > 0">
+          <span class="font-mono text-editor-fg opacity-100">{{ chunks.length }}</span>
+          run{{ chunks.length === 1 ? "" : "s" }} from
+          <span class="font-mono">{{ formatBoundary(chunks[0].start) }}</span>
+          to
+          <span class="font-mono">{{ formatBoundary(chunks[chunks.length - 1].end) }}</span>
+        </template>
+        <template v-else>
+          <span class="text-errorForeground">No chunks — check that End Date is after Start Date.</span>
+        </template>
+      </div>
+
+      <!-- Truncation warning -->
+      <div v-if="truncated" class="text-2xs text-notificationsWarningIcon-fg flex items-start gap-1">
+        <span class="codicon codicon-warning text-2xs mt-0.5"></span>
+        <span>Range is large — limited to the first {{ chunks.length }} chunks. Narrow the range or use a
+          coarser granularity to cover it all.</span>
+      </div>
+
+      <!-- Chunk preview -->
+      <div v-if="chunks.length > 0"
+        class="border border-commandCenter-border rounded bg-editor-bg max-h-36 overflow-y-auto">
+        <div v-for="(chunk, index) in previewChunks" :key="index"
+          class="flex items-center gap-2 px-2 py-1 text-2xs border-b border-commandCenter-border last:border-b-0">
+          <span class="text-editor-fg opacity-40 w-6 flex-shrink-0 text-right">{{ index + 1 }}</span>
+          <span class="font-mono text-editor-fg">{{ formatBoundary(chunk.start) }}</span>
+          <span class="codicon codicon-arrow-right text-2xs opacity-50"></span>
+          <span class="font-mono text-editor-fg">{{ formatBoundary(chunk.end) }}</span>
+        </div>
+        <div v-if="chunks.length > previewLimit"
+          class="px-2 py-1 text-2xs text-editor-fg opacity-50 italic">
+          +{{ chunks.length - previewLimit }} more
+        </div>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex items-center justify-end gap-2 pt-1">
+        <button @click="$emit('close')"
+          class="text-2xs px-2 py-1 rounded text-editor-fg opacity-70 hover:opacity-100 hover:bg-list-hoverBackground">
+          Cancel
+        </button>
+        <button @click="run" :disabled="chunks.length === 0"
+          class="text-2xs px-2 py-1 rounded bg-editor-button-bg text-editor-button-fg hover:bg-editor-button-hover-bg disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1">
+          <span class="codicon codicon-play text-2xs"></span>
+          Run backfill ({{ chunks.length }})
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { DateTime } from "luxon";
+import {
+  buildBackfillChunks,
+  type BackfillGranularity,
+  type BackfillChunk,
+} from "@/utilities/helper";
+
+const props = defineProps<{
+  isOpen: boolean;
+  startDate: string;
+  endDate: string;
+  schedule?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: "close"): void;
+  (e: "run", payload: { chunks: BackfillChunk[]; stopOnFailure: boolean }): void;
+}>();
+
+const granularities: BackfillGranularity[] = ["hourly", "daily", "weekly", "monthly"];
+const previewLimit = 50;
+
+// Default the granularity to the asset's schedule when it maps cleanly.
+const defaultGranularity = (): BackfillGranularity => {
+  const s = (props.schedule || "").toLowerCase();
+  if (s === "hourly") return "hourly";
+  if (s === "weekly") return "weekly";
+  if (s === "monthly") return "monthly";
+  return "daily";
+};
+
+const granularity = ref<BackfillGranularity>(defaultGranularity());
+const stopOnFailure = ref(true);
+
+// Re-seed granularity whenever the dialog is (re)opened.
+watch(
+  () => props.isOpen,
+  (open) => {
+    if (open) granularity.value = defaultGranularity();
+  }
+);
+
+const result = computed(() =>
+  buildBackfillChunks(props.startDate, props.endDate, granularity.value)
+);
+const chunks = computed(() => result.value.chunks);
+const truncated = computed(() => result.value.truncated);
+const previewChunks = computed(() => chunks.value.slice(0, previewLimit));
+
+const formatBoundary = (iso: string): string => {
+  const dt = DateTime.fromISO(iso, { zone: "utc" });
+  return dt.isValid ? dt.toFormat("yyyy-MM-dd HH:mm") : iso;
+};
+
+const run = () => {
+  if (chunks.value.length === 0) return;
+  emit("run", { chunks: chunks.value, stopOnFailure: stopOnFailure.value });
+};
+</script>

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -8,6 +8,8 @@ import {
   adjustEndDateForExclusive,
   getUpstreams,
   normalizePath,
+  buildBackfillChunks,
+  MAX_BACKFILL_CHUNKS,
 } from "../utilities/helper";
 import {
   getAssetDependencies,
@@ -2666,5 +2668,186 @@ suite('Asset Dependencies - Recursive Fetching', () => {
       const upstreams = fetchAllUpstreams('any_asset', []);
       expect(upstreams).toHaveLength(0);
     });
+  });
+});
+
+suite("buildBackfillChunks", () => {
+  test("splits a daily range into contiguous one-day windows", () => {
+    const { chunks, truncated } = buildBackfillChunks(
+      "2024-01-01T00:00:00",
+      "2024-01-05T00:00:00",
+      "daily"
+    );
+
+    expect(truncated).toBe(false);
+    expect(chunks).toEqual([
+      { start: "2024-01-01T00:00:00Z", end: "2024-01-02T00:00:00Z" },
+      { start: "2024-01-02T00:00:00Z", end: "2024-01-03T00:00:00Z" },
+      { start: "2024-01-03T00:00:00Z", end: "2024-01-04T00:00:00Z" },
+      { start: "2024-01-04T00:00:00Z", end: "2024-01-05T00:00:00Z" },
+    ]);
+  });
+
+  test("splits hourly", () => {
+    const { chunks } = buildBackfillChunks(
+      "2024-01-01T00:00:00",
+      "2024-01-01T03:00:00",
+      "hourly"
+    );
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toEqual({ start: "2024-01-01T00:00:00Z", end: "2024-01-01T01:00:00Z" });
+    expect(chunks[2].end).toBe("2024-01-01T03:00:00Z");
+  });
+
+  test("splits weekly", () => {
+    const { chunks } = buildBackfillChunks(
+      "2024-01-01T00:00:00",
+      "2024-01-15T00:00:00",
+      "weekly"
+    );
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toEqual({ start: "2024-01-01T00:00:00Z", end: "2024-01-08T00:00:00Z" });
+    expect(chunks[1]).toEqual({ start: "2024-01-08T00:00:00Z", end: "2024-01-15T00:00:00Z" });
+  });
+
+  test("clamps the final monthly chunk to the end date", () => {
+    const { chunks } = buildBackfillChunks(
+      "2024-01-15T00:00:00",
+      "2024-03-10T00:00:00",
+      "monthly"
+    );
+    expect(chunks).toEqual([
+      { start: "2024-01-15T00:00:00Z", end: "2024-02-15T00:00:00Z" },
+      { start: "2024-02-15T00:00:00Z", end: "2024-03-10T00:00:00Z" },
+    ]);
+  });
+
+  test("chunks are contiguous (each end equals the next start)", () => {
+    const { chunks } = buildBackfillChunks(
+      "2024-01-01T00:00:00",
+      "2024-01-06T12:00:00",
+      "daily"
+    );
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i].start).toBe(chunks[i - 1].end);
+    }
+    // last chunk reaches the requested end exactly
+    expect(chunks[chunks.length - 1].end).toBe("2024-01-06T12:00:00Z");
+  });
+
+  test("emits ISO boundaries with a trailing Z and no milliseconds", () => {
+    const { chunks } = buildBackfillChunks(
+      "2024-01-01T00:00:00.000",
+      "2024-01-02T00:00:00.000",
+      "daily"
+    );
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].start).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(chunks[0].end).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("returns no chunks when end is before or equal to start", () => {
+    expect(buildBackfillChunks("2024-01-05", "2024-01-01", "daily")).toEqual({
+      chunks: [],
+      truncated: false,
+    });
+    expect(buildBackfillChunks("2024-01-01", "2024-01-01", "daily").chunks).toHaveLength(0);
+  });
+
+  test("returns no chunks for invalid dates", () => {
+    expect(buildBackfillChunks("not-a-date", "2024-01-02", "daily").chunks).toHaveLength(0);
+  });
+
+  test("caps at MAX_BACKFILL_CHUNKS and flags truncation", () => {
+    const { chunks, truncated } = buildBackfillChunks(
+      "2020-01-01T00:00:00",
+      "2024-01-01T00:00:00",
+      "daily"
+    );
+    expect(chunks).toHaveLength(MAX_BACKFILL_CHUNKS);
+    expect(truncated).toBe(true);
+  });
+});
+
+suite("backfill flag pipeline (AssetGeneral.handleRunBackfill)", () => {
+  const mountBackfill = () =>
+    mount(AssetGeneral, {
+      props: {
+        schedule: "daily",
+        environments: ["prod"],
+        selectedEnvironment: "prod",
+        hasIntervalModifiers: false,
+        assetType: "sql",
+        parameters: {},
+        columns: [],
+        startDate: "",
+        endDate: "",
+      },
+      global: {
+        stubs: {
+          "vscode-button": { template: "<button><slot /></button>" },
+          "vscode-checkbox": { template: "<input type=\"checkbox\" />" },
+        },
+      },
+    });
+
+  const chunks = [
+    { start: "2024-01-01T00:00:00Z", end: "2024-01-02T00:00:00Z" },
+    { start: "2024-01-02T00:00:00Z", end: "2024-01-03T00:00:00Z" },
+  ];
+
+  test("posts bruin.runBackfill with the chunks and a stop-on-failure flag", async () => {
+    const { vscode } = await import("@/utilities/vscode");
+    const wrapper = mountBackfill();
+    const vm: any = wrapper.vm as any;
+    await wrapper.vm.$nextTick();
+
+    (vscode.postMessage as any).mockClear();
+    vm.handleRunBackfill({ chunks, stopOnFailure: true });
+
+    const call = (vscode.postMessage as any).mock.calls
+      .map((c: any[]) => c[0])
+      .find((m: any) => m.command === "bruin.runBackfill");
+    expect(call).toBeTruthy();
+    expect(call.payload.chunks).toEqual(chunks);
+    expect(call.payload.stopOnFailure).toBe(true);
+  });
+
+  test("includes --environment, strips dates/full-refresh, forces a single --sensor-mode skip", async () => {
+    const { vscode } = await import("@/utilities/vscode");
+    const wrapper = mountBackfill();
+    const vm: any = wrapper.vm as any;
+
+    // User has full-refresh on and an explicit (non-skip) sensor mode.
+    vm.checkboxItems = [
+      { name: "Full-Refresh", checked: true },
+      { name: "Interval-modifiers", checked: false },
+      { name: "Exclusive-End-Date", checked: true },
+      { name: "Push-Metadata", checked: false },
+      { name: "Apply-Sensor-Mode", checked: true },
+    ];
+    vm.sensorModeSetting = "wait";
+    vm.startDate = "2024-01-01T00:00:00.000Z";
+    vm.endDate = "2024-01-10T00:00:00.000Z";
+    await wrapper.vm.$nextTick();
+
+    (vscode.postMessage as any).mockClear();
+    vm.handleRunBackfill({ chunks, stopOnFailure: true });
+
+    const call = (vscode.postMessage as any).mock.calls
+      .map((c: any[]) => c[0])
+      .find((m: any) => m.command === "bruin.runBackfill");
+    const flags: string = call.payload.flags;
+
+    // environment is carried through (regression: it used to be dropped)
+    expect(flags).toContain("--environment prod");
+    // global dates stripped — each chunk supplies its own window downstream
+    expect(flags).not.toContain("--start-date");
+    expect(flags).not.toContain("--end-date");
+    // full-refresh never sent for backfill
+    expect(flags).not.toContain("--full-refresh");
+    // sensors forced to skip, the user's "wait" dropped, no duplicate flag
+    expect(flags).not.toContain("--sensor-mode wait");
+    expect((flags.match(/--sensor-mode skip/g) || []).length).toBe(1);
   });
 });

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -59,6 +59,76 @@ export const concatCommandFlags = (
   return [startDateFlag, endDateFlag, ...checkboxesFlags, ...intervalModifiersFlags, sensorModeFlag, ...tagFlags].filter(flag => flag).join("");
 };
 
+export type BackfillGranularity = "hourly" | "daily" | "weekly" | "monthly";
+
+export interface BackfillChunk {
+  start: string;
+  end: string;
+}
+
+// Hard cap so a wide range + small granularity can't generate thousands of runs.
+export const MAX_BACKFILL_CHUNKS = 365;
+
+const GRANULARITY_DURATIONS: Record<BackfillGranularity, Record<string, number>> = {
+  hourly: { hours: 1 },
+  daily: { days: 1 },
+  weekly: { weeks: 1 },
+  monthly: { months: 1 },
+};
+
+/**
+ * Splits a date range into contiguous chunk windows for a local backfill.
+ *
+ * Each chunk is `[cursor, min(cursor + granularity, end)]`. Chunks are
+ * contiguous (chunk N's end equals chunk N+1's start), mirroring how the
+ * cloud backfill steps through intervals. Boundaries are emitted as ISO
+ * strings with a trailing `Z` so they match the format the rest of the run
+ * flow sends to the CLI (e.g. `2024-01-01T00:00:00Z`).
+ *
+ * Returns `{ chunks, truncated }` where `truncated` is true when the range
+ * produced more than MAX_BACKFILL_CHUNKS windows and was cut short.
+ */
+export const buildBackfillChunks = (
+  startInput: string,
+  endInput: string,
+  granularity: BackfillGranularity
+): { chunks: BackfillChunk[]; truncated: boolean } => {
+  const start = DateTime.fromISO(startInput, { zone: "utc" });
+  const end = DateTime.fromISO(endInput, { zone: "utc" });
+
+  if (!start.isValid || !end.isValid || end <= start) {
+    return { chunks: [], truncated: false };
+  }
+
+  const step = GRANULARITY_DURATIONS[granularity];
+  const chunks: BackfillChunk[] = [];
+  let cursor = start;
+  let truncated = false;
+
+  while (cursor < end) {
+    let next = cursor.plus(step);
+    if (next > end) {
+      next = end;
+    }
+    chunks.push({
+      start: toBackfillBoundary(cursor),
+      end: toBackfillBoundary(next),
+    });
+    if (chunks.length >= MAX_BACKFILL_CHUNKS && next < end) {
+      truncated = true;
+      break;
+    }
+    cursor = next;
+  }
+
+  return { chunks, truncated };
+};
+
+const toBackfillBoundary = (dt: DateTime): string => {
+  // Match concatCommandFlags: emit ISO with a trailing Z, no fractional seconds.
+  return dt.toUTC().toISO({ suppressMilliseconds: true, includeOffset: false }) + "Z";
+};
+
 export const handleError = (validationError: any | null, renderSQLAssetError: any | null) => {
   if (validationError || renderSQLAssetError) {
     let errorMessage = validationError || renderSQLAssetError || "An error occurred";


### PR DESCRIPTION
## What

Adds a **local backfill** (BRU-4067): split a date range into interval chunks and run `bruin run` once per chunk, sequentially, in the integrated terminal — mirroring the existing run flow.

Accessible via a new **"Backfill…"** entry in the Run dropdown. Opens a dialog with a granularity selector (hourly/daily/weekly/monthly), a stop-on-failure toggle, and a live preview of the chunk windows before running.

## How it works

- **Chunker** (`buildBackfillChunks`, pure Luxon): contiguous windows, capped at 365 chunks with a `truncated` flag surfaced in the dialog.
- **Command builder** (`buildBackfillCommand` / `runBackfillInTerminal`): builds one chained command and sends it to the Bruin terminal — joined with `&&` when stop-on-failure is on, `;` otherwise.
- Granularity defaults from the asset's `schedule` when it maps cleanly.

## Important: backfill omits `--full-refresh`

Verified against the CLI: `bruin run --full-refresh` **ignores** `--start-date` and reloads from the pipeline's `start_date`, which would defeat interval chunking. So backfill deliberately strips full-refresh; correct re-runs of a window rely on the asset's incremental strategy (merge / delete+insert / time_interval).

## Files

- `webview-ui/src/utilities/helper.ts` — `buildBackfillChunks` + types
- `webview-ui/src/components/ui/asset/BackfillDialog.vue` *(new)* — dialog UI
- `webview-ui/src/components/asset/AssetGeneral.vue` — Run-dropdown entry + wiring
- `src/bruin/bruinUtils.ts` — `buildBackfillCommand` + `runBackfillInTerminal`
- `src/panels/BruinPanel.ts` — `bruin.runBackfill` handler

## Testing

Validated end-to-end against the real `bruin` CLI on a duckdb pipeline: the extension-generated chained command runs each window and the target table reflects the exact per-chunk intervals.

## Follow-up (separate PR)

Group the per-chunk runs under a single collapsible "Backfill" entry in the Run History panel, with per-chunk status (the ticket's run summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)