### PR TITLE
Release v0.81.0 — Local Backfill Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.81.0] - [2026-06-15]
+- Added local backfill support with interval chunking: run backfills directly from the extension by splitting a date range into chunks (daily, weekly, monthly, etc.) with options to stop on first failure. Backfill runs are grouped in the Run History panel as expandable rows showing per-chunk status and progress.
+
 ## [0.80.5] - [2026-06-04]
 - Flattened the run variables UI: variable overrides now appear in an inline panel under the run controls with all variables, defaults, and override inputs visible at once. The "Variable overrides" toggle auto-enables when an override is entered and turns off when the last one is cleared.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.81.0**: Added local backfill support with interval chunking — run backfills by splitting a date range into chunks (daily, weekly, monthly, etc.) with stop-on-failure option. Backfill runs are grouped in the Run History panel as expandable rows.
 - **0.80.5**: Flattened the run variables UI — overrides appear inline under the run controls, all variables visible at once, with the "Variable overrides" toggle auto-enabled when an override is entered.
 - **0.80.4**: Allowed `options` on MSSQL/Synapse connections in `.bruin.yml`; made connection environments collapsible (collapsed by default) with a connection count per environment.
 - **0.80.3**: Added Fabric as a valid ingestr destination; updated dependencies.
@@ -96,6 +97,5 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 - **0.80.1**: Added warning for `interval_modifiers` typos.
 - **0.80.0**: Added variant selector to the asset panel for pipelines that declare variants. The selected variant is passed to `bruin run` as `--variant <name>`.
 - **0.79.9**: Improved Ingestr asset display with edit/view mode toggle.
-- **0.79.8**: Fixed Bruin panel not updating on file save in latest VS Code versions on Windows due to path comparison issues.
 
 For a full changelog, see Bruin Extension [Changelog](https://github.com/bruin-data/bruin-vscode/blob/main/CHANGELOG.md).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.80.5",
+  "version": "0.81.0",
   "engines": {
     "vscode": "^1.87.0"
   },


### PR DESCRIPTION
## Summary
- Bump version to 0.81.0
- Update CHANGELOG.md with backfill feature release notes
- Update README.md release notes section

## Changes in v0.81.0
Added local backfill support with interval chunking:
- Run backfills directly from the extension by splitting a date range into chunks (daily, weekly, monthly, etc.)
- Stop on first failure option
- Backfill runs are grouped in the Run History panel as expandable rows showing per-chunk status and progress

## Test plan
- [ ] Verify version shows 0.81.0 in package.json
- [ ] Verify CHANGELOG.md has the new entry
- [ ] Verify README.md release notes are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)