### PR TITLE
fix(schedule): use cronstrue for human-readable cron labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [0.81.2] - [2026-06-23]
-- Fixed the schedule CodeLens rendering an invalid time (e.g. "Run every day at NaN:00") for cron step patterns like `0 */6 * * *`. Human-readable schedule labels are now generated with `cronstrue`, matching the Bruin Cloud app. Also aligned the `weekly` keyword to Sunday (`@weekly`) so local backfill windows match how pipelines actually run.
+- Fixed invalid schedule CodeLens labels for cron step patterns (e.g. `0 */6 * * *`) by generating them with `cronstrue`. Also aligned the `weekly` keyword to Sunday (`@weekly`) to match the Bruin Cloud scheduler.
 
 ## [0.81.1] - [2026-06-16]
 - Fixed lineage panel performance: switching files no longer reloads the whole webview or leaks listeners (which made the panel progressively slower over a session), and per-keystroke parsing is now debounced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.81.2] - [2026-06-23]
+- Fixed the schedule CodeLens rendering an invalid time (e.g. "Run every day at NaN:00") for cron step patterns like `0 */6 * * *`. Human-readable schedule labels are now generated with `cronstrue`, matching the Bruin Cloud app. Also aligned the `weekly` keyword to Sunday (`@weekly`) so local backfill windows match how pipelines actually run.
+
 ## [0.81.1] - [2026-06-16]
 - Fixed lineage panel performance: switching files no longer reloads the whole webview or leaks listeners (which made the panel progressively slower over a session), and per-keystroke parsing is now debounced.
 - Retained the lineage webview while hidden so reopening the panel is instant and lands on the current asset instead of briefly showing the previously rendered graph.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.81.2**: Fixed the schedule CodeLens showing an invalid time (e.g. "Run every day at NaN:00") for cron step patterns like `0 */6 * * *`. Schedule labels are now generated with `cronstrue`, matching the Bruin Cloud app, and the `weekly` keyword is aligned to Sunday (`@weekly`).
 - **0.81.1**: Improved lineage panel performance — switching files no longer reloads the whole webview or leaks listeners, the hidden panel is retained so reopening is instant and shows the current asset, and the `+` expand button now zooms out to reveal newly added nodes.
 - **0.81.0**: Added local backfill support with interval chunking — run backfills by splitting a date range into chunks (daily, weekly, monthly, etc.) with stop-on-failure option. Backfill runs are grouped in the Run History panel as expandable rows.
 - **0.80.5**: Flattened the run variables UI — overrides appear inline under the run controls, all variables visible at once, with the "Variable overrides" toggle auto-enabled when an override is entered.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.81.2**: Fixed the schedule CodeLens showing an invalid time (e.g. "Run every day at NaN:00") for cron step patterns like `0 */6 * * *`. Schedule labels are now generated with `cronstrue`, matching the Bruin Cloud app, and the `weekly` keyword is aligned to Sunday (`@weekly`).
+- **0.81.2**: Fixed invalid schedule CodeLens labels for cron step patterns (e.g. `0 */6 * * *`) by generating them with `cronstrue`.
 - **0.81.1**: Improved lineage panel performance — switching files no longer reloads the whole webview or leaks listeners, the hidden panel is retained so reopening is instant and shows the current asset, and the `+` expand button now zooms out to reveal newly added nodes.
 - **0.81.0**: Added local backfill support with interval chunking — run backfills by splitting a date range into chunks (daily, weekly, monthly, etc.) with stop-on-failure option. Backfill runs are grouped in the Run History panel as expandable rows.
 - **0.80.5**: Flattened the run variables UI — overrides appear inline under the run controls, all variables visible at once, with the "Variable overrides" toggle auto-enabled when an override is entered.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "chokidar": "^4.0.3",
         "concurrently": "^10.0.3",
         "cron-parser": "^4.9.0",
+        "cronstrue": "^2.61.0",
         "dotenv": "^16.4.7",
         "elkjs": "^0.9.3",
         "fs-extra": "^11.3.0",
@@ -3428,6 +3429,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cronstrue": {
+      "version": "2.61.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.61.0.tgz",
+      "integrity": "sha512-ootN5bvXbIQI9rW94+QsXN5eROtXWwew6NkdGxIRpS/UFWRggL0G5Al7a9GTBFEsuvVhJ2K3CntIIVt7L2ILhA==",
+      "deprecated": "Non-backwards compatible Breaking changes",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
       }
     },
     "node_modules/cross-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.81.1",
+  "version": "0.81.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.81.1",
+      "version": "0.81.2",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.81.1",
+  "version": "0.81.2",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/package.json
+++ b/package.json
@@ -502,6 +502,7 @@
     "chokidar": "^4.0.3",
     "concurrently": "^10.0.3",
     "cron-parser": "^4.9.0",
+    "cronstrue": "^2.61.0",
     "dotenv": "^16.4.7",
     "elkjs": "^0.9.3",
     "fs-extra": "^11.3.0",

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -6552,22 +6552,22 @@ suite(" Query export Tests", () => {
 
       test("should handle daily schedule", () => {
         const result = cronToHumanReadable("daily");
-        assert.strictEqual(result, "Every day at midnight");
+        assert.strictEqual(result, "At 12:00 AM");
       });
 
       test("should handle weekly schedule", () => {
         const result = cronToHumanReadable("weekly");
-        assert.strictEqual(result, "Every Monday at midnight");
+        assert.strictEqual(result, "At 12:00 AM, only on Sunday");
       });
 
       test("should handle monthly schedule", () => {
         const result = cronToHumanReadable("monthly");
-        assert.strictEqual(result, "Every 1st of the month at midnight");
+        assert.strictEqual(result, "At 12:00 AM, on day 1 of the month");
       });
 
       test("should handle yearly schedule", () => {
         const result = cronToHumanReadable("yearly");
-        assert.strictEqual(result, "Every January 1st at midnight");
+        assert.strictEqual(result, "At 12:00 AM, on day 1 of the month, only in January");
       });
     });
 
@@ -6575,113 +6575,123 @@ suite(" Query export Tests", () => {
       suite("daily schedules", () => {
         test("should handle daily at specific time", () => {
           const result = cronToHumanReadable("30 14 * * *");
-          assert.strictEqual(result, "Run every day at 14:30");
+          assert.strictEqual(result, "At 02:30 PM");
         });
 
         test("should handle daily at midnight", () => {
           const result = cronToHumanReadable("0 0 * * *");
-          assert.strictEqual(result, "Run every day at 00:00");
+          assert.strictEqual(result, "At 12:00 AM");
         });
 
         test("should handle daily at different times", () => {
           const result = cronToHumanReadable("15 9 * * *");
-          assert.strictEqual(result, "Run every day at 09:15");
+          assert.strictEqual(result, "At 09:15 AM");
         });
       });
 
       suite("weekly schedules", () => {
         test("should handle single day of week", () => {
           const result = cronToHumanReadable("0 9 * * 1");
-          assert.strictEqual(result, "Run every Monday at 09:00");
+          assert.strictEqual(result, "At 09:00 AM, only on Monday");
         });
 
         test("should handle multiple days of week", () => {
           const result = cronToHumanReadable("0 9 * * 1,3,5");
-          assert.strictEqual(result, "Run every Monday, Wednesday, Friday at 09:00");
+          assert.strictEqual(result, "At 09:00 AM, only on Monday, Wednesday, and Friday");
         });
 
         test("should handle weekend schedule", () => {
           const result = cronToHumanReadable("0 10 * * 0,6");
-          assert.strictEqual(result, "Run every Sunday, Saturday at 10:00");
+          assert.strictEqual(result, "At 10:00 AM, only on Sunday and Saturday");
         });
       });
 
       suite("monthly schedules", () => {
         test("should handle 1st of month", () => {
           const result = cronToHumanReadable("0 0 1 * *");
-          assert.strictEqual(result, "Run on the 1st of every month at 00:00");
+          assert.strictEqual(result, "At 12:00 AM, on day 1 of the month");
         });
 
         test("should handle 2nd of month", () => {
           const result = cronToHumanReadable("0 12 2 * *");
-          assert.strictEqual(result, "Run on the 2nd of every month at 12:00");
+          assert.strictEqual(result, "At 12:00 PM, on day 2 of the month");
         });
 
         test("should handle 3rd of month", () => {
           const result = cronToHumanReadable("30 15 3 * *");
-          assert.strictEqual(result, "Run on the 3rd of every month at 15:30");
+          assert.strictEqual(result, "At 03:30 PM, on day 3 of the month");
         });
 
         test("should handle other days of month", () => {
           const result = cronToHumanReadable("0 8 15 * *");
-          assert.strictEqual(result, "Run on the 15th of every month at 08:00");
+          assert.strictEqual(result, "At 08:00 AM, on day 15 of the month");
         });
       });
 
       suite("hourly schedules", () => {
         test("should handle every hour on the hour", () => {
           const result = cronToHumanReadable("0 * * * *");
-          assert.strictEqual(result, "Run every day every hour");
+          assert.strictEqual(result, "Every hour");
         });
 
         test("should handle every hour at specific minute", () => {
           const result = cronToHumanReadable("30 * * * *");
-          assert.strictEqual(result, "Run every day at 30 minutes past every hour");
+          assert.strictEqual(result, "At 30 minutes past the hour");
         });
 
         test("should handle every hour at 15 minutes past", () => {
           const result = cronToHumanReadable("15 * * * *");
-          assert.strictEqual(result, "Run every day at 15 minutes past every hour");
+          assert.strictEqual(result, "At 15 minutes past the hour");
+        });
+
+        test("should handle every n hours (step pattern)", () => {
+          const result = cronToHumanReadable("0 */6 * * *");
+          assert.strictEqual(result, "At 0 minutes past the hour, every 6 hours");
         });
       });
 
       suite("edge cases", () => {
         test("should handle every minute", () => {
           const result = cronToHumanReadable("* * * * *");
-          assert.strictEqual(result, "Run every day every minute");
+          assert.strictEqual(result, "Every minute");
         });
 
         test("should handle complex schedule", () => {
           const result = cronToHumanReadable("0 0 * * 0");
-          assert.strictEqual(result, "Run every Sunday at 00:00");
+          assert.strictEqual(result, "At 12:00 AM, only on Sunday");
         });
       });
     });
 
     suite("invalid expressions", () => {
+      // cronstrue is configured with throwExceptionOnParseError: false (matching
+      // the cloud app), so invalid input returns cronstrue's standard message.
+      const PARSE_ERROR =
+        "An error occurred when generating the expression description. Check the cron expression syntax.";
+
       test("should handle invalid cron expression with wrong field count", () => {
         const result = cronToHumanReadable("0 0 0");
-        assert.strictEqual(result, "Invalid cron expression: 0 0 0");
+        assert.strictEqual(result, PARSE_ERROR);
       });
 
       test("should handle invalid cron expression with too many fields", () => {
         const result = cronToHumanReadable("0 0 0 0 0 0");
-        assert.strictEqual(result, "Invalid cron expression: 0 0 0 0 0 0");
+        assert.strictEqual(result, PARSE_ERROR);
       });
 
       test("should handle malformed cron expression", () => {
         const result = cronToHumanReadable("invalid");
-        assert.strictEqual(result, "Invalid cron expression: invalid");
+        assert.strictEqual(result, PARSE_ERROR);
       });
 
       test("should handle empty string", () => {
         const result = cronToHumanReadable("");
-        assert.strictEqual(result, "Invalid cron expression: ");
+        assert.strictEqual(result, PARSE_ERROR);
       });
 
       test("should handle invalid field values", () => {
         const result = cronToHumanReadable("60 25 32 13 8");
-        assert.strictEqual(result, "Invalid cron expression: 60 25 32 13 8");
+        assert.strictEqual(result, PARSE_ERROR);
       });
     });
   });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -6728,7 +6728,7 @@ suite(" Query export Tests", () => {
 
         const result = provider.provideCodeLenses(mockDocument, mockToken);
         assert.strictEqual(result.length, 1);
-        assert.strictEqual(result[0].command?.title, "Run every Monday at 09:00");
+        assert.strictEqual(result[0].command?.title, "At 09:00 AM, only on Monday");
         assert.strictEqual(result[0].command?.command, "");
       });
 
@@ -6740,7 +6740,7 @@ suite(" Query export Tests", () => {
 
         const result = provider.provideCodeLenses(mockDocument, mockToken);
         assert.strictEqual(result.length, 1);
-        assert.strictEqual(result[0].command?.title, "Run every day at 00:00");
+        assert.strictEqual(result[0].command?.title, "At 12:00 AM");
         assert.strictEqual(result[0].command?.command, "");
       });
 
@@ -6759,9 +6759,9 @@ schedule: '30 14 * * *'
         const result = provider.provideCodeLenses(mockDocument, mockToken);
         assert.strictEqual(result.length, 3);
         
-        assert.strictEqual(result[0].command?.title, "Run every Monday at 09:00");
-        assert.strictEqual(result[1].command?.title, "Every day at midnight");
-        assert.strictEqual(result[2].command?.title, "Run every day at 14:30");
+        assert.strictEqual(result[0].command?.title, "At 09:00 AM, only on Monday");
+        assert.strictEqual(result[1].command?.title, "At 12:00 AM");
+        assert.strictEqual(result[2].command?.title, "At 02:30 PM");
       });
 
       test("should handle schedule with double quotes", () => {
@@ -6772,7 +6772,7 @@ schedule: '30 14 * * *'
 
         const result = provider.provideCodeLenses(mockDocument, mockToken);
         assert.strictEqual(result.length, 1);
-        assert.strictEqual(result[0].command?.title, "Run every Friday at 12:00");
+        assert.strictEqual(result[0].command?.title, "At 12:00 PM, only on Friday");
       });
 
       test("should handle schedule with single quotes", () => {
@@ -6783,7 +6783,7 @@ schedule: '30 14 * * *'
 
         const result = provider.provideCodeLenses(mockDocument, mockToken);
         assert.strictEqual(result.length, 1);
-        assert.strictEqual(result[0].command?.title, "Run on the 1st of every month at 08:00");
+        assert.strictEqual(result[0].command?.title, "At 08:00 AM, on day 1 of the month");
       });
 
       test("should handle schedule without quotes", () => {
@@ -6808,8 +6808,8 @@ schedule: '30 14 * * *'
 
         const result = provider.provideCodeLenses(mockDocument, mockToken);
         assert.strictEqual(result.length, 2);
-        assert.strictEqual(result[0].command?.title, "Run every day at 06:00");
-        assert.strictEqual(result[1].command?.title, "Run every day at 18:00");
+        assert.strictEqual(result[0].command?.title, "At 06:00 AM");
+        assert.strictEqual(result[1].command?.title, "At 06:00 PM");
       });
 
       test("should handle invalid cron expressions", () => {
@@ -6820,7 +6820,10 @@ schedule: '30 14 * * *'
 
         const result = provider.provideCodeLenses(mockDocument, mockToken);
         assert.strictEqual(result.length, 1);
-        assert.strictEqual(result[0].command?.title, "Invalid cron expression: invalid-cron");
+        assert.strictEqual(
+          result[0].command?.title,
+          "An error occurred when generating the expression description. Check the cron expression syntax."
+        );
       });
 
       test("should create correct range for schedule line", () => {
@@ -6893,7 +6896,7 @@ schedule: '0 12 * * *'
 
         const result = provider.provideCodeLenses(mockDocument, mockToken);
         assert.strictEqual(result.length, 1);
-        assert.strictEqual(result[0].command?.title, "Run every day at 12:00");
+        assert.strictEqual(result[0].command?.title, "At 12:00 PM");
       });
 
       test("should handle schedule field with extra whitespace", () => {
@@ -6904,7 +6907,7 @@ schedule: '0 12 * * *'
 
         const result = provider.provideCodeLenses(mockDocument, mockToken);
         assert.strictEqual(result.length, 1);
-        assert.strictEqual(result[0].command?.title, "Run every Tuesday at 15:00");
+        assert.strictEqual(result[0].command?.title, "At 03:00 PM, only on Tuesday");
       });
 
       test("should handle predefined schedule types", () => {
@@ -6922,10 +6925,10 @@ schedule: yearly
         const result = provider.provideCodeLenses(mockDocument, mockToken);
         assert.strictEqual(result.length, 5);
         assert.strictEqual(result[0].command?.title, "Every hour");
-        assert.strictEqual(result[1].command?.title, "Every day at midnight");
-        assert.strictEqual(result[2].command?.title, "Every Monday at midnight");
-        assert.strictEqual(result[3].command?.title, "Every 1st of the month at midnight");
-        assert.strictEqual(result[4].command?.title, "Every January 1st at midnight");
+        assert.strictEqual(result[1].command?.title, "At 12:00 AM");
+        assert.strictEqual(result[2].command?.title, "At 12:00 AM, only on Sunday");
+        assert.strictEqual(result[3].command?.title, "At 12:00 AM, on day 1 of the month");
+        assert.strictEqual(result[4].command?.title, "At 12:00 AM, on day 1 of the month, only in January");
       });
     });
   });

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import path = require("path");
 export const isEditorActive = (): boolean => !!vscode.window.activeTextEditor;
-import * as cronParser from "cron-parser";
+import { toString as cronstrueToString } from "cronstrue";
 
 export interface Environment {
   name: string;
@@ -360,84 +360,23 @@ export const extractNonNullConnections = (json: any): Connection[] => {
 };
 
 export const cronToHumanReadable = (cronExpression: string): string => {
-  // Handle predefined schedules
-  const predefinedSchedules = {
-    hourly: "Every hour",
-    daily: "Every day at midnight",
-    weekly: "Every Monday at midnight", 
-    monthly: "Every 1st of the month at midnight",
-    yearly: "Every January 1st at midnight"
-  };
-
-  if (cronExpression in predefinedSchedules) {
-    return predefinedSchedules[cronExpression as keyof typeof predefinedSchedules];
-  }
-
-  // Handle cron expressions
   try {
-    const parsed = cronParser.parseExpression(cronExpression);
-    const fields = cronExpression.split(' ');
-    
-    if (fields.length !== 5) {
-      return `Invalid cron expression: ${cronExpression}`;
+    // Bruin's named schedule keywords aren't valid cron — convert them to cron's
+    // @-aliases so cronstrue can describe them. Mirrors the cloud app (both its
+    // ScheduleDisplay component and the backend scheduler, which use @weekly),
+    // so the extension's labels match how pipelines actually run in production
+    // (e.g. weekly = Sunday midnight).
+    let expression = cronExpression;
+    if (["daily", "weekly", "monthly", "yearly", "hourly"].includes(expression)) {
+      expression = "@" + expression;
     }
 
-    const [minute, hour, dayOfMonth, month, dayOfWeek] = fields;
-    
-    // Build human readable description
-    let description = "Run";
-    
-    // Handle frequency
-    if (dayOfWeek !== '*' && dayOfMonth === '*') {
-      // Weekly schedule
-      const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-      const dayNumbers = dayOfWeek.split(',').map(d => parseInt(d));
-      const dayNames = dayNumbers.map(d => days[d]).join(', ');
-      description += ` every ${dayNames}`;
-    } else if (dayOfMonth !== '*' && dayOfWeek === '*') {
-      // Monthly schedule
-      if (dayOfMonth === '1') {
-        description += " on the 1st of every month";
-      } else if (dayOfMonth === '2') {
-        description += " on the 2nd of every month";
-      } else if (dayOfMonth === '3') {
-        description += " on the 3rd of every month";
-      } else {
-        description += ` on the ${dayOfMonth}th of every month`;
-      }
-    } else if (dayOfMonth === '*' && dayOfWeek === '*') {
-      // Daily schedule
-      description += " every day";
-    } else {
-      description += " on schedule";
-    }
-    
-    // Handle time
-    if (hour === '*' && minute === '*') {
-      description += " every minute";
-    } else if (hour === '*') {
-      // Handle minute patterns
-      if (minute === '0') {
-        description += " every hour";
-      } else if (minute.startsWith('*/')) {
-        const interval = minute.substring(2);
-        description += ` every ${interval} minutes`;
-      } else if (minute.includes(',')) {
-        const minutes = minute.split(',').map(m => m.trim());
-        description += ` at ${minutes.join(', ')} minutes past every hour`;
-      } else {
-        description += ` at ${minute} minutes past every hour`;
-      }
-    } else {
-      const hourNum = parseInt(hour);
-      const minuteNum = parseInt(minute);
-      const time = `${hourNum.toString().padStart(2, '0')}:${minuteNum.toString().padStart(2, '0')}`;
-      description += ` at ${time}`;
-    }
-    
-    return description;
-  } catch (error) {
-    return `Invalid cron expression: ${cronExpression}`;
+    return cronstrueToString(expression, {
+      throwExceptionOnParseError: false,
+      verbose: false,
+    });
+  } catch {
+    return "Invalid cron expression";
   }
 };
 

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -272,8 +272,9 @@ suite("testing webview", () => {
   test('test get previous run for "weekly" schedule', () => {
     schedule = "weekly";
     const { startTime, endTime } = getPreviousRun(schedule, today);
-    assert.strictEqual(startTime, new Date("2024-07-01T00:00:00.000Z").getTime());
-    assert.strictEqual(endTime, new Date("2024-07-08T00:00:00.000Z").getTime());
+    // weekly => @weekly => Sunday midnight (matches the cloud scheduler)
+    assert.strictEqual(startTime, new Date("2024-06-30T00:00:00.000Z").getTime());
+    assert.strictEqual(endTime, new Date("2024-07-07T00:00:00.000Z").getTime());
   });
   /**
    * Test suite for getPreviousRun function with "monthly" schedule.
@@ -361,11 +362,12 @@ suite("testing webview", () => {
   test('test reset Start End Date for "weekly" schedule', () => {
     schedule = "weekly";
     resetStartEndDate(schedule, today, startDate, endDate);
-    assert.strictEqual(startDate.value, "2024-07-01T00:00:00.000Z");
-    assert.strictEqual(endDate.value, "2024-07-08T00:00:00.000Z");
+    // weekly => @weekly => Sunday midnight (matches the cloud scheduler)
+    assert.strictEqual(startDate.value, "2024-06-30T00:00:00.000Z");
+    assert.strictEqual(endDate.value, "2024-07-07T00:00:00.000Z");
 
     const endDateExclusive = adjustEndDateForExclusive(endDate.value);
-    assert.strictEqual(endDateExclusive, "2024-07-07T23:59:59.999999999Z");
+    assert.strictEqual(endDateExclusive, "2024-07-06T23:59:59.999999999Z");
   });
 
   test('test reset Start End Date for "monthly" schedule', () => {

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -155,7 +155,7 @@ suite("testing webview", () => {
   test("test scheduleToCron", () => {
     const hourly = "0 * * * *";
     const daily = "0 0 * * *";
-    const weekly = "0 0 * * 1";
+    const weekly = "0 0 * * 0";
     const monthly = "0 0 1 * *";
 
     const cronHourly = scheduleToCron("hourly");

--- a/webview-ui/src/utilities/helper.ts
+++ b/webview-ui/src/utilities/helper.ts
@@ -273,10 +273,13 @@ export const scheduleToCron = (schedule: string) => {
     return { cronSchedule: schedule, error: null };
   }
 
+  // Match the cloud scheduler's interpretation of these keywords (it uses cron's
+  // @-aliases), so local backfill windows line up with how pipelines actually run.
+  // Notably @weekly is Sunday midnight, not Monday.
   const cronSchedules = {
     hourly: "0 * * * *",
     daily: "0 0 * * *",
-    weekly: "0 0 * * 1",
+    weekly: "0 0 * * 0",
     monthly: "0 0 1 * *",
   };
 


### PR DESCRIPTION
## Problem

The schedule CodeLens rendered `"0 */6 * * *"` as **"Run every day at NaN:00"**.

The hand-rolled `cronToHumanReadable` (`src/utilities/helperUtils.ts`) only handled step patterns (`*/n`) for the minute field, not the hour field. For `"0 */6 * * *"` it ran `parseInt("*/6")` → `NaN`, producing `NaN:00`.

## Fix

Replace the ~70-line hand-rolled parser with [`cronstrue`](https://github.com/bradymholt/cRonstrue), matching the **cloud app's** `ScheduleDisplay.vue` behavior so both surfaces render schedules identically:

- Named keywords (`daily`/`weekly`/…) → cron `@`-aliases, then described by cronstrue.
- Options `{ throwExceptionOnParseError: false, verbose: false }` (12-hour AM/PM).
- Pinned **`cronstrue@^2.61.0`** to match cloud's version (v3 phrases step patterns differently).

`"0 */6 * * *"` now renders **"At 0 minutes past the hour, every 6 hours"**.

## Weekly = Sunday alignment

Investigated the `weekly` day discrepancy:
- **Cloud scheduler** (`AssetsController.php` `getCronLastTwoDate`) uses `@weekly` = **Sunday** midnight — confirmed by cloud's own test fixture. This is when pipelines actually run.
- The webview's `scheduleToCron` was the outlier, mapping `weekly` → `0 0 * * 1` (**Monday**).

Aligned `scheduleToCron` `weekly` → `0 0 * * 0` (Sunday / `@weekly`) so local backfill windows line up with production runs.

## Tests

- `src/test/extension.test.ts` — updated all `cronToHumanReadable` assertions to cronstrue output (12-hour, weekly = Sunday, invalid → cronstrue's standard message); added a `0 */6 * * *` regression test.
- `webview-ui/src/test/webview.test.ts` — `weekly` expectation → `0 0 * * 0`.

## Verification

- `tsc -p ./ --noEmit` → clean.
- `vitest -t "test scheduleToCron"` → passing.
- All 26 label cases checked directly against installed cronstrue 2.61.0 → all match.

Note: user-facing CodeLens wording changes (e.g. "Run every day at 14:30" → "At 02:30 PM"), now identical to cloud's schedule display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)