### PR TITLE
feat(query-preview): multi-column sorting in results table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.81.4] - [2026-06-29]
+- Added multi-column sorting to the query preview results table: click column headers to sort by several columns at once (the most recently clicked column becomes the primary key and previous ones become tie-breakers). A "Sorted by" bar shows the active columns in order with controls to flip a column's direction, remove one, or clear all.
+
 ## [0.81.3] - [2026-06-24]
 - Recognized Tableau assets (`tableau`, `tableau.dashboard`, `tableau.datasource`, `tableau.workbook`, `tableau.worksheet`) and synced the full set of Bruin CLI asset types, fixing "value not accepted" validation errors and missing autocompletion for newer types.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.81.4**: Added multi-column sorting to the query preview results table — click headers to sort by several columns at once (most recently clicked is the primary key), with a "Sorted by" bar to flip direction, remove a column, or clear all.
 - **0.81.3**: Recognized Tableau assets and synced the full set of Bruin CLI asset types, fixing validation errors and missing autocompletion for newer types.
 - **0.81.2**: Fixed invalid schedule CodeLens labels for cron step patterns (e.g. `0 */6 * * *`) by generating them with `cronstrue`.
 - **0.81.1**: Improved lineage panel performance — switching files no longer reloads the whole webview or leaks listeners, the hidden panel is retained so reopening is instant and shows the current asset, and the `+` expand button now zooms out to reveal newly added nodes.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.81.3",
+  "version": "0.81.4",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -780,34 +780,42 @@ const shouldShowCostWarning = (): boolean => {
   return (currentTab.value?.totalRowCount || 0) > COST_WARNING_THRESHOLD;
 };
 
-const isResultTruncated = (): boolean => {
-  // Check if row count equals the limit used when query was executed
-  const executedLimit = currentTab.value?.limit || 0;
-  const rowCount = currentTab.value?.totalRowCount || 0;
+// A tab's results are truncated when its row count hit the executed limit.
+const isTabTruncated = (tabId: string | undefined): boolean => {
+  const tab = tabs.value.find(t => t.id === tabId);
+  const executedLimit = tab?.limit || 0;
+  const rowCount = tab?.totalRowCount || 0;
   return executedLimit > 0 && rowCount >= executedLimit;
 };
+const isResultTruncated = (): boolean => isTabTruncated(activeTab.value);
 
 const formatNumber = (num: number): string => {
   return new Intl.NumberFormat('en-US', { notation: 'compact' }).format(num);
 };
 
-const truncationWarningAcknowledged = ref(false);
+// Truncation acknowledgement and the queued sort are both scoped to a specific
+// tab, so switching tabs can't misdirect a confirmed sort or skip the warning
+// on another truncated tab.
+const acknowledgedTruncationTabs = ref(new Set<string>());
 const pendingSortAction = ref<(() => void) | null>(null);
+const pendingSortTabId = ref<string | null>(null);
 
 const dismissTruncationWarning = (proceed: boolean = false) => {
   showTruncationWarning.value = false;
   if (proceed && pendingSortAction.value) {
-    truncationWarningAcknowledged.value = true;
+    if (pendingSortTabId.value) acknowledgedTruncationTabs.value.add(pendingSortTabId.value);
     pendingSortAction.value();
   }
   pendingSortAction.value = null;
+  pendingSortTabId.value = null;
 };
 
-// Run a sort mutation, first warning the user if the result set is truncated
-// (sorting a truncated set only reorders the rows we already fetched).
-const guardedSort = (action: () => void) => {
-  if (isResultTruncated() && !truncationWarningAcknowledged.value) {
+// Run a sort mutation against `tabId`, first warning the user if that tab's
+// results are truncated (sorting only reorders the rows we already fetched).
+const guardedSort = (tabId: string, action: () => void) => {
+  if (isTabTruncated(tabId) && !acknowledgedTruncationTabs.value.has(tabId)) {
     pendingSortAction.value = action;
+    pendingSortTabId.value = tabId;
     showTruncationWarning.value = true;
     return;
   }
@@ -816,13 +824,13 @@ const guardedSort = (action: () => void) => {
 
 const handleSort = async (column: any, event: MouseEvent) => {
   if (!currentTab.value) return;
-  guardedSort(() => performSort(column, event));
+  const tabId = activeTab.value;
+  guardedSort(tabId, () => performSort(column, tabId));
 };
 
-// Persist a new sort state on the active tab, re-sort, and save.
-const commitSortState = (newSortState: SortState[]) => {
-  newSortState.forEach((s, i) => (s.priority = i));
-  const tabIndex = tabs.value.findIndex(t => t.id === activeTab.value);
+// Persist a new sort state on the given tab, re-sort, and save.
+const commitSortState = (tabId: string, newSortState: SortState[]) => {
+  const tabIndex = tabs.value.findIndex(t => t.id === tabId);
   if (tabIndex !== -1) {
     const newTab = {
       ...tabs.value[tabIndex],
@@ -830,41 +838,51 @@ const commitSortState = (newSortState: SortState[]) => {
     };
     tabs.value.splice(tabIndex, 1, newTab);
     triggerRef(tabs); // Trigger reactivity before applySorting reads the new state
-    applySorting();
+    applySorting(tabId);
     saveState();
   }
 };
 
-const performSort = (column: any, _event: MouseEvent | null) => {
-  if (!currentTab.value) return;
+const performSort = (column: any, tabId: string) => {
+  const tab = tabs.value.find(t => t.id === tabId);
+  if (!tab) return;
   const colName = typeof column === 'string' ? column : column.name;
   // Header click: newest column becomes the primary key, prior columns become
   // tie-breakers — builds a multi-column sort with no modifier key needed.
-  commitSortState(toggleSortColumn(currentTab.value.sortState || [], colName));
+  commitSortState(tabId, toggleSortColumn(tab.sortState || [], colName));
 };
 
 // Flip the direction of one column already in the sort group (sort-bar chip).
 const toggleSortDirection = (colName: string) => {
   if (!currentTab.value) return;
-  guardedSort(() => commitSortState(flipSortDirection(currentTab.value!.sortState || [], colName)));
+  const tabId = activeTab.value;
+  guardedSort(tabId, () => {
+    const tab = tabs.value.find(t => t.id === tabId);
+    if (tab) commitSortState(tabId, flipSortDirection(tab.sortState || [], colName));
+  });
 };
 
 // Remove a single column from the sort group (sort-bar chip).
 const removeFromSort = (colName: string) => {
   if (!currentTab.value) return;
-  guardedSort(() => commitSortState(removeSortColumn(currentTab.value!.sortState || [], colName)));
+  const tabId = activeTab.value;
+  guardedSort(tabId, () => {
+    const tab = tabs.value.find(t => t.id === tabId);
+    if (tab) commitSortState(tabId, removeSortColumn(tab.sortState || [], colName));
+  });
 };
 
-const applySorting = () => {
-  if (!currentTab.value?.parsedOutput?.rows) return;
+const applySorting = (tabId: string = activeTab.value) => {
+  const tab = tabs.value.find(t => t.id === tabId);
+  if (!tab?.parsedOutput?.rows) return;
 
-  const columns = currentTab.value.parsedOutput.columns;
-  const searchTerm = currentTab.value.searchInput?.trim().toLowerCase();
+  const columns = tab.parsedOutput.columns;
+  const searchTerm = tab.searchInput?.trim().toLowerCase();
 
   // Start with original rows, then filter if there's a search term
   let rows: any[];
   if (searchTerm) {
-    rows = currentTab.value.parsedOutput.rows.filter((row: any[]) => {
+    rows = tab.parsedOutput.rows.filter((row: any[]) => {
       for (let i = 0; i < row.length; i++) {
         const cell = row[i];
         if (cell !== null && String(cell).toLowerCase().includes(searchTerm)) {
@@ -874,14 +892,14 @@ const applySorting = () => {
       return false;
     });
   } else {
-    rows = [...currentTab.value.parsedOutput.rows];
+    rows = [...tab.parsedOutput.rows];
   }
 
   // Apply the (multi-)column sort
-  rows = sortRows(rows, columns, currentTab.value.sortState || []);
+  rows = sortRows(rows, columns, tab.sortState || []);
 
   // Update filtered rows count
-  const tabIndex = tabs.value.findIndex(t => t.id === activeTab.value);
+  const tabIndex = tabs.value.findIndex(t => t.id === tabId);
   if (tabIndex !== -1) {
     const newTab = {
       ...tabs.value[tabIndex],
@@ -895,7 +913,7 @@ const applySorting = () => {
 
 const clearSorting = () => {
   if (!currentTab.value) return;
-  commitSortState([]);
+  commitSortState(activeTab.value, []);
 };
 
 const copyQuery = (query: string) => {
@@ -1240,8 +1258,8 @@ window.addEventListener("message", (event) => {
               consoleMessages: [],
               sortState: [],
             };
-            // Reset truncation warning acknowledgment for new query
-            truncationWarningAcknowledged.value = false;
+            // Reset truncation warning acknowledgment for this tab's new query
+            acknowledgedTruncationTabs.value.delete(tabId);
           }
           
           tabs.value.splice(tabIndex, 1, newTab);
@@ -1297,7 +1315,7 @@ window.addEventListener("message", (event) => {
             
             // Apply existing sorting to new data
             nextTick(() => {
-              applySorting();
+              applySorting(tabId);
             });
           }
         } catch (e) {

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -420,6 +420,46 @@
               </div>
             </div>
           </div>
+          <!-- Multi-column sort bar -->
+          <div
+            v-if="currentTab?.parsedOutput && !currentTab?.error && currentTab.sortState && currentTab.sortState.length > 0"
+            class="flex items-center gap-1.5 flex-wrap px-2 py-1 border-b border-commandCenter-border bg-editor-bg text-xs flex-shrink-0"
+          >
+            <span class="codicon codicon-list-ordered opacity-60 text-xs"></span>
+            <span class="opacity-60 mr-0.5">Sorted by</span>
+            <div
+              v-for="(sort, i) in currentTab.sortState"
+              :key="sort.column"
+              class="flex items-center gap-1 bg-input-background border border-commandCenter-border rounded px-1.5 py-0.5"
+            >
+              <span class="opacity-50 text-3xs">{{ i + 1 }}</span>
+              <span class="truncate max-w-[140px]">{{ sort.column }}</span>
+              <button
+                type="button"
+                class="flex items-center hover:text-button-background"
+                :title="sort.direction === 'asc' ? 'Ascending — click for descending' : 'Descending — click for ascending'"
+                @click="toggleSortDirection(sort.column)"
+              >
+                <span class="codicon text-xs" :class="sort.direction === 'asc' ? 'codicon-arrow-up' : 'codicon-arrow-down'"></span>
+              </button>
+              <button
+                type="button"
+                class="flex items-center opacity-60 hover:opacity-100 hover:text-errorForeground"
+                title="Remove from sort"
+                @click="removeFromSort(sort.column)"
+              >
+                <span class="codicon codicon-close text-3xs"></span>
+              </button>
+            </div>
+            <button
+              type="button"
+              class="ml-1 opacity-70 hover:opacity-100 underline-offset-2 hover:underline"
+              title="Clear all sorting"
+              @click="clearSorting"
+            >
+              Clear
+            </button>
+          </div>
           <!-- Results Table -->
           <div
             v-if="currentTab?.parsedOutput && !currentTab?.error"
@@ -439,6 +479,7 @@
                     v-for="(column, colIndex) in currentTab.parsedOutput.columns"
                     :key="typeof column === 'string' ? column : column.name"
                     @click="handleSort(column, $event)"
+                    title="Click to sort. Click additional columns to sort by several at once (newest column first)."
                     class="sticky top-0 p-1 text-left font-semibold text-editor-fg bg-editor-bg border-x border-commandCenter-border before:absolute before:bottom-0 before:left-0 before:w-full before:border-b before:border-commandCenter-border relative cursor-pointer select-none group hover:bg-input-background transition-colors"
                     :class="{
                       'sort-active bg-input-background': getSortDirection(column) !== null,
@@ -448,15 +489,15 @@
                   >
                     <div class="flex items-center w-full overflow-hidden pr-6">
                       <span class="truncate flex-1 min-w-0 block">{{ typeof column === 'string' ? column : (column.name || `Column ${Number(colIndex) + 1}`) }}</span>
-                      
+
                       <!-- Sort Indicators -->
                       <div class="flex items-center gap-1 ml-1 flex-shrink-0">
                         <template v-if="getSortDirection(column)">
-                          <span class="codicon text-xs" 
+                          <span class="codicon text-xs"
                             :class="getSortDirection(column) === 'asc' ? 'codicon-arrow-up' : 'codicon-arrow-down'"
                             :style="{ opacity: 1 - (getSortPriority(column) * 0.2) }"
                           ></span>
-                          <span v-if="currentTab.sortState && currentTab.sortState.length > 1" 
+                          <span v-if="currentTab.sortState && currentTab.sortState.length > 1"
                             class="text-3xs bg-button-background text-button-foreground rounded px-1 min-w-[14px] text-center">
                             {{ getSortPriority(column) + 1 }}
                           </span>
@@ -644,13 +685,13 @@ import type { EditingState, TabData } from "@/types";
 import { useConnectionsStore } from "@/store/bruinStore";
 import { flattenStructColumns } from "@/utilities/structUtils";
 import { formatData, copyToClipboard, FORMAT_LABELS, type ExportFormat } from "@/utilities/dataFormatters";
-
-// Sorting interfaces
-interface SortState {
-  column: string;
-  direction: 'asc' | 'desc';
-  priority: number;
-}
+import {
+  type SortState,
+  toggleSortColumn,
+  flipSortDirection,
+  removeSortColumn,
+  sortRows,
+} from "@/utilities/querySort";
 
 // Constants
 const MAX_CONSOLE_MESSAGES = 1000;
@@ -751,65 +792,36 @@ const formatNumber = (num: number): string => {
 };
 
 const truncationWarningAcknowledged = ref(false);
-const pendingSortColumn = ref<any>(null);
-const pendingSortEvent = ref<MouseEvent | null>(null);
+const pendingSortAction = ref<(() => void) | null>(null);
 
 const dismissTruncationWarning = (proceed: boolean = false) => {
   showTruncationWarning.value = false;
-  if (proceed && pendingSortColumn.value) {
+  if (proceed && pendingSortAction.value) {
     truncationWarningAcknowledged.value = true;
-    performSort(pendingSortColumn.value, pendingSortEvent.value);
+    pendingSortAction.value();
   }
-  pendingSortColumn.value = null;
-  pendingSortEvent.value = null;
+  pendingSortAction.value = null;
+};
+
+// Run a sort mutation, first warning the user if the result set is truncated
+// (sorting a truncated set only reorders the rows we already fetched).
+const guardedSort = (action: () => void) => {
+  if (isResultTruncated() && !truncationWarningAcknowledged.value) {
+    pendingSortAction.value = action;
+    showTruncationWarning.value = true;
+    return;
+  }
+  action();
 };
 
 const handleSort = async (column: any, event: MouseEvent) => {
   if (!currentTab.value) return;
-
-  // Show warning if results are truncated and user hasn't acknowledged yet
-  if (isResultTruncated() && !truncationWarningAcknowledged.value) {
-    pendingSortColumn.value = column;
-    pendingSortEvent.value = event;
-    showTruncationWarning.value = true;
-    return;
-  }
-
-  performSort(column, event);
+  guardedSort(() => performSort(column, event));
 };
 
-const performSort = (column: any, event: MouseEvent | null) => {
-  if (!currentTab.value) return;
-
-  const colName = typeof column === 'string' ? column : column.name;
-  const isMultiSort = event?.ctrlKey || event?.metaKey;
-
-  // Client-side sorting logic
-  let newSortState: SortState[] = [...(currentTab.value.sortState || [])];
-  const existingIndex = newSortState.findIndex((s: SortState) => s.column === colName);
-
-  if (existingIndex === -1) {
-    const newSort: SortState = {
-      column: colName,
-      direction: 'asc',
-      priority: newSortState.length
-    };
-    newSortState = isMultiSort ? [...newSortState, newSort] : [newSort];
-  } else {
-    const current = newSortState[existingIndex];
-    if (current.direction === 'asc') {
-      newSortState[existingIndex] = { ...current, direction: 'desc' };
-    } else {
-      newSortState.splice(existingIndex, 1);
-      newSortState.forEach((s, i) => s.priority = i);
-    }
-
-    if (!isMultiSort && newSortState.length > 1) {
-      newSortState = newSortState.filter((s: SortState) => s.column === colName);
-    }
-  }
-
-  // Update tab with new sort state
+// Persist a new sort state on the active tab, re-sort, and save.
+const commitSortState = (newSortState: SortState[]) => {
+  newSortState.forEach((s, i) => (s.priority = i));
   const tabIndex = tabs.value.findIndex(t => t.id === activeTab.value);
   if (tabIndex !== -1) {
     const newTab = {
@@ -821,6 +833,26 @@ const performSort = (column: any, event: MouseEvent | null) => {
     applySorting();
     saveState();
   }
+};
+
+const performSort = (column: any, _event: MouseEvent | null) => {
+  if (!currentTab.value) return;
+  const colName = typeof column === 'string' ? column : column.name;
+  // Header click: newest column becomes the primary key, prior columns become
+  // tie-breakers — builds a multi-column sort with no modifier key needed.
+  commitSortState(toggleSortColumn(currentTab.value.sortState || [], colName));
+};
+
+// Flip the direction of one column already in the sort group (sort-bar chip).
+const toggleSortDirection = (colName: string) => {
+  if (!currentTab.value) return;
+  guardedSort(() => commitSortState(flipSortDirection(currentTab.value!.sortState || [], colName)));
+};
+
+// Remove a single column from the sort group (sort-bar chip).
+const removeFromSort = (colName: string) => {
+  if (!currentTab.value) return;
+  guardedSort(() => commitSortState(removeSortColumn(currentTab.value!.sortState || [], colName)));
 };
 
 const applySorting = () => {
@@ -845,38 +877,8 @@ const applySorting = () => {
     rows = [...currentTab.value.parsedOutput.rows];
   }
 
-  // Apply sorting if there's a sort state
-  if (currentTab.value.sortState && currentTab.value.sortState.length > 0) {
-    rows.sort((a, b) => {
-      for (const sort of currentTab.value!.sortState!) {
-        const colIndex = columns.findIndex((c: any) =>
-          (typeof c === 'string' ? c : c.name) === sort.column
-        );
-
-        if (colIndex === -1) continue;
-
-        let valA = a[colIndex];
-        let valB = b[colIndex];
-
-        if (valA === null || valA === undefined) valA = -Infinity;
-        if (valB === null || valB === undefined) valB = -Infinity;
-
-        let comparison = 0;
-        if (typeof valA === 'number' && typeof valB === 'number') {
-          comparison = valA - valB;
-        } else if (!isNaN(Date.parse(valA)) && !isNaN(Date.parse(valB))) {
-          comparison = new Date(valA).getTime() - new Date(valB).getTime();
-        } else {
-          comparison = String(valA).localeCompare(String(valB), undefined, { numeric: true });
-        }
-
-        if (comparison !== 0) {
-          return sort.direction === 'asc' ? comparison : -comparison;
-        }
-      }
-      return 0;
-    });
-  }
+  // Apply the (multi-)column sort
+  rows = sortRows(rows, columns, currentTab.value.sortState || []);
 
   // Update filtered rows count
   const tabIndex = tabs.value.findIndex(t => t.id === activeTab.value);
@@ -893,16 +895,7 @@ const applySorting = () => {
 
 const clearSorting = () => {
   if (!currentTab.value) return;
-  const tabIndex = tabs.value.findIndex(t => t.id === activeTab.value);
-  if (tabIndex !== -1) {
-    const newTab = {
-      ...tabs.value[tabIndex],
-      sortState: []
-    };
-    tabs.value.splice(tabIndex, 1, newTab);
-    applySorting();
-    saveState();
-  }
+  commitSortState([]);
 };
 
 const copyQuery = (query: string) => {

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -1260,6 +1260,12 @@ window.addEventListener("message", (event) => {
             };
             // Reset truncation warning acknowledgment for this tab's new query
             acknowledgedTruncationTabs.value.delete(tabId);
+            // Drop any sort queued against this tab's now-replaced results
+            if (pendingSortTabId.value === tabId) {
+              pendingSortAction.value = null;
+              pendingSortTabId.value = null;
+              showTruncationWarning.value = false;
+            }
           }
           
           tabs.value.splice(tabIndex, 1, newTab);

--- a/webview-ui/src/components/query-output/QueryPreview.vue
+++ b/webview-ui/src/components/query-output/QueryPreview.vue
@@ -1048,6 +1048,13 @@ const resetPanel = () => {
   // Clear all tabs except the first one
   tabs.value = [defaultTab];
 
+  // Old tabs are gone — clear truncation acknowledgement and any queued sort
+  // so the recreated tab-1 doesn't inherit a prior tab's acknowledgement.
+  acknowledgedTruncationTabs.value.clear();
+  pendingSortAction.value = null;
+  pendingSortTabId.value = null;
+  showTruncationWarning.value = false;
+
   // Reset tab counter
   tabCounter.value = 2;
 
@@ -1398,6 +1405,15 @@ const closeTab = (tabId: string) => {
 
   if (tabIndex !== -1) {
     tabs.value.splice(tabIndex, 1);
+
+    // Drop the closed tab's truncation acknowledgement / queued sort so a tab
+    // that later reuses this id (e.g. a recreated tab-1) starts fresh.
+    acknowledgedTruncationTabs.value.delete(tabId);
+    if (pendingSortTabId.value === tabId) {
+      pendingSortAction.value = null;
+      pendingSortTabId.value = null;
+      showTruncationWarning.value = false;
+    }
 
     if (tabs.value.length === 0) {
       const newDefaultTab = {

--- a/webview-ui/src/test/querySort.test.ts
+++ b/webview-ui/src/test/querySort.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  type SortState,
+  toggleSortColumn,
+  flipSortDirection,
+  removeSortColumn,
+  sortRows,
+} from "@/utilities/querySort";
+
+const cols = ["country", "city", "revenue"];
+
+describe("toggleSortColumn (header click)", () => {
+  it("adds a column ascending when not present", () => {
+    const next = toggleSortColumn([], "country");
+    expect(next).toEqual([{ column: "country", direction: "asc", priority: 0 }]);
+  });
+
+  it("cycles asc -> desc -> removed on repeat clicks", () => {
+    let s = toggleSortColumn([], "country"); // asc
+    s = toggleSortColumn(s, "country"); // desc
+    expect(s[0].direction).toBe("desc");
+    s = toggleSortColumn(s, "country"); // removed
+    expect(s).toEqual([]);
+  });
+
+  it("accumulates multiple columns with the newest as the primary key", () => {
+    let s = toggleSortColumn([], "country");
+    s = toggleSortColumn(s, "city"); // city should now be primary
+    expect(s.map((x) => x.column)).toEqual(["city", "country"]);
+    expect(s.map((x) => x.priority)).toEqual([0, 1]);
+
+    s = toggleSortColumn(s, "revenue"); // revenue primary, then city, then country
+    expect(s.map((x) => x.column)).toEqual(["revenue", "city", "country"]);
+    expect(s.map((x) => x.priority)).toEqual([0, 1, 2]);
+  });
+
+  it("toggles direction of an existing column without dropping the others", () => {
+    let s = toggleSortColumn([], "country");
+    s = toggleSortColumn(s, "city"); // [city, country]
+    s = toggleSortColumn(s, "country"); // country -> desc, still 2 columns
+    expect(s.map((x) => x.column)).toEqual(["city", "country"]);
+    expect(s.find((x) => x.column === "country")!.direction).toBe("desc");
+  });
+});
+
+describe("removeSortColumn / flipSortDirection", () => {
+  it("removeSortColumn drops one and reindexes priorities", () => {
+    const start: SortState[] = [
+      { column: "country", direction: "asc", priority: 0 },
+      { column: "city", direction: "asc", priority: 1 },
+      { column: "revenue", direction: "asc", priority: 2 },
+    ];
+    const s = removeSortColumn(start, "city");
+    expect(s.map((x) => x.column)).toEqual(["country", "revenue"]);
+    expect(s.map((x) => x.priority)).toEqual([0, 1]);
+  });
+
+  it("flipSortDirection flips only the target column", () => {
+    const start: SortState[] = [
+      { column: "country", direction: "asc", priority: 0 },
+      { column: "city", direction: "asc", priority: 1 },
+    ];
+    const s = flipSortDirection(start, "city");
+    expect(s.find((x) => x.column === "country")!.direction).toBe("asc");
+    expect(s.find((x) => x.column === "city")!.direction).toBe("desc");
+  });
+});
+
+describe("sortRows", () => {
+  // country, city, revenue
+  const rows = [
+    ["US", "NYC", 30],
+    ["US", "LA", 10],
+    ["CA", "Toronto", 20],
+    ["US", "LA", 5],
+  ];
+
+  it("returns rows unchanged when no sort state", () => {
+    expect(sortRows(rows, cols, [])).toEqual(rows);
+  });
+
+  it("sorts by a single numeric column", () => {
+    const sorted = sortRows(rows, cols, [{ column: "revenue", direction: "asc", priority: 0 }]);
+    expect(sorted.map((r) => r[2])).toEqual([5, 10, 20, 30]);
+  });
+
+  it("sorts by two columns together (country asc, then revenue desc)", () => {
+    const sorted = sortRows(rows, cols, [
+      { column: "country", direction: "asc", priority: 0 },
+      { column: "revenue", direction: "desc", priority: 1 },
+    ]);
+    // CA first, then US rows ordered by revenue descending
+    expect(sorted).toEqual([
+      ["CA", "Toronto", 20],
+      ["US", "NYC", 30],
+      ["US", "LA", 10],
+      ["US", "LA", 5],
+    ]);
+  });
+
+  it("uses later columns only as tie-breakers", () => {
+    const sorted = sortRows(rows, cols, [
+      { column: "city", direction: "asc", priority: 0 },
+      { column: "revenue", direction: "asc", priority: 1 },
+    ]);
+    // LA ties broken by revenue ascending (5 before 10)
+    expect(sorted).toEqual([
+      ["US", "LA", 5],
+      ["US", "LA", 10],
+      ["US", "NYC", 30],
+      ["CA", "Toronto", 20],
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [...rows];
+    sortRows(input, cols, [{ column: "revenue", direction: "asc", priority: 0 }]);
+    expect(input).toEqual(rows);
+  });
+
+  it("sorts null values first", () => {
+    const withNulls = [["US", "NYC", 30], ["US", "LA", null], ["CA", "X", 10]];
+    const sorted = sortRows(withNulls, cols, [{ column: "revenue", direction: "asc", priority: 0 }]);
+    expect(sorted[0][2]).toBe(null);
+  });
+});

--- a/webview-ui/src/utilities/querySort.ts
+++ b/webview-ui/src/utilities/querySort.ts
@@ -1,0 +1,88 @@
+// Pure helpers for the query-preview results table sorting.
+// Kept framework-free so the multi-column sort behaviour can be unit-tested
+// without mounting the (large) QueryPreview component.
+
+export interface SortState {
+  column: string;
+  direction: "asc" | "desc";
+  priority: number;
+}
+
+// Normalise the `priority` field to match array order.
+const reindex = (state: SortState[]): SortState[] =>
+  state.map((entry, i) => ({ ...entry, priority: i }));
+
+const columnIndexOf = (columns: any[], name: string): number =>
+  columns.findIndex((c: any) => (typeof c === "string" ? c : c?.name) === name);
+
+/**
+ * Header-click behaviour: the most recently clicked column becomes the PRIMARY
+ * sort key and previously sorted columns are kept as tie-breakers. This means
+ * every click visibly re-orders the table while still accumulating a
+ * multi-column sort (no modifier key required). Re-clicking a column already in
+ * the sort cycles its direction asc -> desc, then removes it.
+ */
+export function toggleSortColumn(sortState: SortState[], colName: string): SortState[] {
+  const existing = sortState.find((s) => s.column === colName);
+  if (!existing) {
+    return reindex([{ column: colName, direction: "asc", priority: 0 }, ...sortState]);
+  }
+  if (existing.direction === "asc") {
+    return reindex(
+      sortState.map((s) => (s.column === colName ? { ...s, direction: "desc" } : s))
+    );
+  }
+  return reindex(sortState.filter((s) => s.column !== colName));
+}
+
+/** Flip a single column's direction (used by the sort-bar chip arrows). */
+export function flipSortDirection(sortState: SortState[], colName: string): SortState[] {
+  return sortState.map((s) =>
+    s.column === colName
+      ? { ...s, direction: s.direction === "asc" ? "desc" : "asc" }
+      : s
+  );
+}
+
+/** Remove a single column from the sort group. */
+export function removeSortColumn(sortState: SortState[], colName: string): SortState[] {
+  return reindex(sortState.filter((s) => s.column !== colName));
+}
+
+/**
+ * Return a new array of rows sorted by every column in `sortState`, in priority
+ * order. Type-aware: numbers compare numerically, parseable dates by time, and
+ * everything else by locale string compare. Nulls sort first (as -Infinity).
+ */
+export function sortRows(rows: any[], columns: any[], sortState: SortState[]): any[] {
+  if (!sortState.length) return rows;
+
+  const sorted = [...rows];
+  sorted.sort((a, b) => {
+    for (const sort of sortState) {
+      const colIndex = columnIndexOf(columns, sort.column);
+      if (colIndex === -1) continue;
+
+      let valA = a[colIndex];
+      let valB = b[colIndex];
+
+      if (valA === null || valA === undefined) valA = -Infinity;
+      if (valB === null || valB === undefined) valB = -Infinity;
+
+      let comparison = 0;
+      if (typeof valA === "number" && typeof valB === "number") {
+        comparison = valA - valB;
+      } else if (!isNaN(Date.parse(valA)) && !isNaN(Date.parse(valB))) {
+        comparison = new Date(valA).getTime() - new Date(valB).getTime();
+      } else {
+        comparison = String(valA).localeCompare(String(valB), undefined, { numeric: true });
+      }
+
+      if (comparison !== 0) {
+        return sort.direction === "asc" ? comparison : -comparison;
+      }
+    }
+    return 0;
+  });
+  return sorted;
+}


### PR DESCRIPTION
Adds multi-column sorting to the query preview results table.

Click column headers to sort by several columns at once — the most recently clicked column becomes the primary key and earlier ones become tie-breakers. Click a header again to cycle asc → desc → off. A "Sorted by" bar above the table shows the active columns in order, with controls to flip direction, remove a column, or clear all.

Still client-side (reorders the fetched rows, truncation warning intact). The sort logic lives in a small pure module (`querySort.ts`) with unit tests.

<img width="954" height="582" alt="sort-multiple-columns" src="https://github.com/user-attachments/assets/c5bae053-7ad3-48ee-8eb7-e6f8b7ca92ef" />

