### PR TITLE
Fix and extend column-level lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [0.81.6] - [2026-07-07]
 - Fixed the lineage panel's "Column Level Lineage" view showing "No column lineage data found" even when columns were annotated. The panel now loads column-level lineage (`-c`) up front so the view renders instead of erroring.
 - Added pipeline-wide column-level lineage: opening "Column Level Lineage" from the pipeline view now renders column edges across every asset in the pipeline, instead of only the currently focused asset.
+- Fixed the lineage panel snapping out of the "Column Level Lineage" (or Pipeline) view whenever lineage data refreshed. The panel now only resets the view when you switch to a different asset/pipeline, and rebuilds the current view in place on data updates.
 
 ## [0.81.5] - [2026-07-07]
 - Regenerated config-schema.json for all connection types from the Bruin CLI, fixing lint errors for profile-based connections in Athena.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [0.81.6] - [2026-07-07]
+## [0.82.0] - [2026-07-08]
 - Fixed the lineage panel's "Column Level Lineage" view showing "No column lineage data found" even when columns were annotated. The panel now loads column-level lineage (`-c`) up front so the view renders instead of erroring.
 - Added pipeline-wide column-level lineage: opening "Column Level Lineage" from the pipeline view now renders column edges across every asset in the pipeline, instead of only the currently focused asset.
 - Fixed the lineage panel snapping out of the "Column Level Lineage" (or Pipeline) view whenever lineage data refreshed. The panel now only resets the view when you switch to a different asset/pipeline, and rebuilds the current view in place on data updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Changelog
 ## [0.82.0] - [2026-07-08]
-- Fixed the lineage panel's "Column Level Lineage" view showing "No column lineage data found" even when columns were annotated. The panel now loads column-level lineage (`-c`) up front so the view renders instead of erroring.
-- Added pipeline-wide column-level lineage: opening "Column Level Lineage" from the pipeline view now renders column edges across every asset in the pipeline, instead of only the currently focused asset.
-- Fixed the lineage panel snapping out of the "Column Level Lineage" (or Pipeline) view whenever lineage data refreshed. The panel now only resets the view when you switch to a different asset/pipeline, and rebuilds the current view in place on data updates.
-- Improved the "Column Level Lineage" view: assets that participate in column lineage now open with their columns expanded so the column-to-column arrows are visible, while unrelated assets stay collapsed (and any node can still be collapsed/expanded via its chevron). Node layout now accounts for expanded height so nodes no longer overlap.
+- Overhauled column-level lineage: fixed the "No column lineage data found" error, added a pipeline-wide column view spanning every asset, and expanded participating assets by default so the column-to-column arrows are visible. Also stopped the view from snapping back when lineage data refreshes.
 
 ## [0.81.5] - [2026-07-07]
 - Regenerated config-schema.json for all connection types from the Bruin CLI, fixing lint errors for profile-based connections in Athena.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.81.6] - [2026-07-07]
 - Fixed the lineage panel's "Column Level Lineage" view showing "No column lineage data found" even when columns were annotated. The panel now loads column-level lineage (`-c`) up front so the view renders instead of erroring.
+- Added pipeline-wide column-level lineage: opening "Column Level Lineage" from the pipeline view now renders column edges across every asset in the pipeline, instead of only the currently focused asset.
 
 ## [0.81.5] - [2026-07-07]
 - Regenerated config-schema.json for all connection types from the Bruin CLI, fixing lint errors for profile-based connections in Athena.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.81.6] - [2026-07-07]
+- Fixed the lineage panel's "Column Level Lineage" view showing "No column lineage data found" even when columns were annotated. The panel now loads column-level lineage (`-c`) up front so the view renders instead of erroring.
+
 ## [0.81.5] - [2026-07-07]
 - Regenerated config-schema.json for all connection types from the Bruin CLI, fixing lint errors for profile-based connections in Athena.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed the lineage panel's "Column Level Lineage" view showing "No column lineage data found" even when columns were annotated. The panel now loads column-level lineage (`-c`) up front so the view renders instead of erroring.
 - Added pipeline-wide column-level lineage: opening "Column Level Lineage" from the pipeline view now renders column edges across every asset in the pipeline, instead of only the currently focused asset.
 - Fixed the lineage panel snapping out of the "Column Level Lineage" (or Pipeline) view whenever lineage data refreshed. The panel now only resets the view when you switch to a different asset/pipeline, and rebuilds the current view in place on data updates.
+- Improved the "Column Level Lineage" view: assets that participate in column lineage now open with their columns expanded so the column-to-column arrows are visible, while unrelated assets stay collapsed (and any node can still be collapsed/expanded via its chevron). Node layout now accounts for expanded height so nodes no longer overlap.
 
 ## [0.81.5] - [2026-07-07]
 - Regenerated config-schema.json for all connection types from the Bruin CLI, fixing lint errors for profile-based connections in Athena.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.82.0**: Overhauled column-level lineage in the lineage panel: fixed the "No column lineage data found" error by loading column lineage up front, added a pipeline-wide column view that spans every asset (not just the focused one), stopped the view from snapping back on data refreshes, and expanded lineage-participating assets by default so the column-to-column arrows are visible.
+- **0.82.0**: Overhauled column-level lineage: fixed the "No column lineage data found" error, added a pipeline-wide column view, and expanded participating assets by default so the arrows are visible.
 - **0.81.5**: Regenerated config-schema.json for all 136 connection types from the Bruin CLI, fixing Athena lint so profile-based connections validate correctly.
 - **0.81.4**: Added multi-column sorting to the query preview results table — click headers to sort by several columns at once (most recently clicked is the primary key), with a "Sorted by" bar to flip direction, remove a column, or clear all.
 - **0.81.3**: Recognized Tableau assets and synced the full set of Bruin CLI asset types, fixing validation errors and missing autocompletion for newer types.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.81.6**: Fixed the lineage panel's "Column Level Lineage" view showing "No column lineage data found" even when columns were annotated — the panel now loads column-level lineage up front.
 - **0.81.5**: Regenerated config-schema.json for all 136 connection types from the Bruin CLI, fixing Athena lint so profile-based connections validate correctly.
 - **0.81.4**: Added multi-column sorting to the query preview results table — click headers to sort by several columns at once (most recently clicked is the primary key), with a "Sorted by" bar to flip direction, remove a column, or clear all.
 - **0.81.3**: Recognized Tableau assets and synced the full set of Bruin CLI asset types, fixing validation errors and missing autocompletion for newer types.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.81.6**: Fixed the lineage panel's "Column Level Lineage" view showing "No column lineage data found" even when columns were annotated — the panel now loads column-level lineage up front.
+- **0.81.6**: Fixed the lineage panel's "Column Level Lineage" view showing "No column lineage data found" even when columns were annotated — the panel now loads column-level lineage up front — and added a pipeline-wide column-level view that renders column edges across every asset instead of only the focused one.
 - **0.81.5**: Regenerated config-schema.json for all 136 connection types from the Bruin CLI, fixing Athena lint so profile-based connections validate correctly.
 - **0.81.4**: Added multi-column sorting to the query preview results table — click headers to sort by several columns at once (most recently clicked is the primary key), with a "Sorted by" bar to flip direction, remove a column, or clear all.
 - **0.81.3**: Recognized Tableau assets and synced the full set of Bruin CLI asset types, fixing validation errors and missing autocompletion for newer types.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.81.6**: Fixed the lineage panel's "Column Level Lineage" view showing "No column lineage data found" even when columns were annotated — the panel now loads column-level lineage up front — and added a pipeline-wide column-level view that renders column edges across every asset instead of only the focused one.
+- **0.82.0**: Overhauled column-level lineage in the lineage panel: fixed the "No column lineage data found" error by loading column lineage up front, added a pipeline-wide column view that spans every asset (not just the focused one), stopped the view from snapping back on data refreshes, and expanded lineage-participating assets by default so the column-to-column arrows are visible.
 - **0.81.5**: Regenerated config-schema.json for all 136 connection types from the Bruin CLI, fixing Athena lint so profile-based connections validate correctly.
 - **0.81.4**: Added multi-column sorting to the query preview results table — click headers to sort by several columns at once (most recently clicked is the primary key), with a "Sorted by" bar to flip direction, remove a column, or clear all.
 - **0.81.3**: Recognized Tableau assets and synced the full set of Bruin CLI asset types, fixing validation errors and missing autocompletion for newer types.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.81.2",
+  "version": "0.82.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.81.2",
+      "version": "0.82.0",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.81.5",
+  "version": "0.82.0",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -1514,7 +1514,10 @@ export class BruinPanel {
             break;
           case "bruin.showPipelineLineage":
             if (this._lastRenderedDocumentUri) {
-              await flowLineageCommand(this._lastRenderedDocumentUri);
+              // Include column-level lineage (-c) so the lineage panel's
+              // "Column Level Lineage" view has the column data it needs;
+              // without it the view reports "No column lineage data found".
+              await flowLineageCommand(this._lastRenderedDocumentUri, undefined, true);
             }
             break;
           case "bruin.getAssetMetadata":

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -1369,7 +1369,10 @@ export class BruinPanel {
             break;
           case "bruin.getPipelineAssets":
             console.log("Getting pipeline assets");
-            flowLineageCommand(this._lastRenderedDocumentUri, "BruinPanel");
+            // Include column data (-c): this also feeds the lineage panel via
+            // updateLineageData, so fetching without it would clobber the
+            // panel's column-level lineage with a column-less payload.
+            flowLineageCommand(this._lastRenderedDocumentUri, "BruinPanel", true);
             break;
           case "bruin.createEnvironment":
             trackEvent("Command Executed", { command: "createEnvironment", source: "extension" });

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -1369,9 +1369,8 @@ export class BruinPanel {
             break;
           case "bruin.getPipelineAssets":
             console.log("Getting pipeline assets");
-            // Include column data (-c): this also feeds the lineage panel via
-            // updateLineageData, so fetching without it would clobber the
-            // panel's column-level lineage with a column-less payload.
+            // -c: also feeds the lineage panel, so a column-less fetch would
+            // clobber its column-level lineage.
             flowLineageCommand(this._lastRenderedDocumentUri, "BruinPanel", true);
             break;
           case "bruin.createEnvironment":
@@ -1517,9 +1516,7 @@ export class BruinPanel {
             break;
           case "bruin.showPipelineLineage":
             if (this._lastRenderedDocumentUri) {
-              // Include column-level lineage (-c) so the lineage panel's
-              // "Column Level Lineage" view has the column data it needs;
-              // without it the view reports "No column lineage data found".
+              // -c so the panel's Column Level Lineage view has column data.
               await flowLineageCommand(this._lastRenderedDocumentUri, undefined, true);
             }
             break;

--- a/src/panels/LineagePanel.ts
+++ b/src/panels/LineagePanel.ts
@@ -131,11 +131,8 @@ export abstract class BaseLineagePanel implements vscode.WebviewViewProvider, vs
   protected loadLineageData = async () => {
     if (this._lastRenderedDocumentUri) {
       try {
-        // Request column-level lineage (-c) up front: the panel loads data once
-        // and the webview toggles between asset- and column-level views without a
-        // round-trip, so the "Column Level Lineage" view needs the column data to
-        // already be present. Without includeColumns the view shows "No column
-        // lineage data found".
+        // -c up front: the webview toggles to the column view without a
+        // round-trip, so the column data must already be present.
         await flowLineageCommand(this._lastRenderedDocumentUri, undefined, true);
       } catch (error) {
         console.error("❌ [LineagePanel] Error loading lineage data:", error);

--- a/src/panels/LineagePanel.ts
+++ b/src/panels/LineagePanel.ts
@@ -131,7 +131,12 @@ export abstract class BaseLineagePanel implements vscode.WebviewViewProvider, vs
   protected loadLineageData = async () => {
     if (this._lastRenderedDocumentUri) {
       try {
-        await flowLineageCommand(this._lastRenderedDocumentUri);
+        // Request column-level lineage (-c) up front: the panel loads data once
+        // and the webview toggles between asset- and column-level views without a
+        // round-trip, so the "Column Level Lineage" view needs the column data to
+        // already be present. Without includeColumns the view shows "No column
+        // lineage data found".
+        await flowLineageCommand(this._lastRenderedDocumentUri, undefined, true);
       } catch (error) {
         console.error("❌ [LineagePanel] Error loading lineage data:", error);
       }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -4537,9 +4537,11 @@ suite(" Query export Tests", () => {
         flowLineageCommandStub.resolves();
         
         await baseLineagePanel.loadLineageData();
-        
+
         sinon.assert.calledOnce(flowLineageCommandStub);
-        sinon.assert.calledWith(flowLineageCommandStub, testUri);
+        // Must request column-level lineage (-c) so the panel's "Column Level
+        // Lineage" view has the column data it needs.
+        sinon.assert.calledWith(flowLineageCommandStub, testUri, undefined, true);
       });
 
       test("should not load lineage data when no URI", async () => {

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -697,11 +697,8 @@ const handleColumnLevelLineage = async () => {
   await buildColumnElements();
 };
 
-// Stable identity of the lineage target currently shown. It changes when the
-// user opens a different asset/pipeline, but stays the same across the repeated
-// data refreshes the extension pushes for the same target (visibility changes,
-// document edits, multiple loader paths). We use it to decide whether a data
-// update should reset the view or just rebuild the current one.
+// Identity of the current lineage target; stays stable across the repeated data
+// refreshes for the same asset/pipeline so we can tell a switch from a refresh.
 const computeTargetKey = () => {
   const ds = props.assetDataset as any;
   if (!ds) return "";
@@ -709,9 +706,7 @@ const computeTargetKey = () => {
 };
 let lastViewKey = "";
 
-// Pick the default view for whichever target is currently loaded: pipeline view
-// for a pipeline, asset view for an asset. Used on first load and whenever the
-// user switches to a different target.
+// Default view for the current target: pipeline view for a pipeline, else asset.
 const selectDefaultViewForTarget = () => {
   const isPipeline = Boolean((props.assetDataset as any)?.isPipelineView);
   showColumnView.value = false;
@@ -724,11 +719,7 @@ const selectDefaultViewForTarget = () => {
 };
 
 onMounted(() => {
-  console.log('🚀 [Lineage] Lineage component mounted');
-
-  // Enable auto-fit for first load
   shouldAutoFit.value = true;
-
   lastViewKey = computeTargetKey();
   selectDefaultViewForTarget();
 });
@@ -750,15 +741,13 @@ watch(
 
     const key = computeTargetKey();
     if (key !== lastViewKey) {
-      // Switched to a different asset/pipeline: reset to its default view.
+      // Switched target: reset to its default view.
       lastViewKey = key;
       selectDefaultViewForTarget();
       return;
     }
 
-    // Same target, data just refreshed: rebuild whichever view the user is in
-    // rather than forcing them back to the pipeline/asset view. This is what
-    // keeps the "Column Level Lineage" view from snapping away on every update.
+    // Same target refreshed: rebuild the current view instead of snapping away.
     if (showColumnView.value) {
       buildColumnElements();
     } else if (showPipelineView.value) {

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -697,19 +697,40 @@ const handleColumnLevelLineage = async () => {
   await buildColumnElements();
 };
 
+// Stable identity of the lineage target currently shown. It changes when the
+// user opens a different asset/pipeline, but stays the same across the repeated
+// data refreshes the extension pushes for the same target (visibility changes,
+// document edits, multiple loader paths). We use it to decide whether a data
+// update should reset the view or just rebuild the current one.
+const computeTargetKey = () => {
+  const ds = props.assetDataset as any;
+  if (!ds) return "";
+  return ds.isPipelineView ? `pipeline:${ds.name ?? ""}` : `asset:${ds.id ?? ds.name ?? ""}`;
+};
+let lastViewKey = "";
+
+// Pick the default view for whichever target is currently loaded: pipeline view
+// for a pipeline, asset view for an asset. Used on first load and whenever the
+// user switches to a different target.
+const selectDefaultViewForTarget = () => {
+  const isPipeline = Boolean((props.assetDataset as any)?.isPipelineView);
+  showColumnView.value = false;
+  showPipelineView.value = isPipeline;
+  if (isPipeline) {
+    buildPipelineElements();
+  } else if (props.assetDataset && props.pipelineData) {
+    processProperties();
+  }
+};
+
 onMounted(() => {
   console.log('🚀 [Lineage] Lineage component mounted');
-  console.log('🚀 [Lineage] Props:', { 
-    hasAssetDataset: !!props.assetDataset, 
-    hasPipelineData: !!props.pipelineData, 
-    isLoading: props.isLoading,
-    LineageError: props.LineageError 
-  });
-  
+
   // Enable auto-fit for first load
   shouldAutoFit.value = true;
-  
-  processProperties();
+
+  lastViewKey = computeTargetKey();
+  selectDefaultViewForTarget();
 });
 
 watch(
@@ -724,13 +745,25 @@ watch(
 
 watch(
   () => [props.assetDataset, props.pipelineData],
-  ([newAssetDataset, newPipelineData]) => {
-    // Check if this is a pipeline view and auto-switch
-    if (newAssetDataset && (newAssetDataset as any).isPipelineView) {
-      showPipelineView.value = true;
-      showColumnView.value = false;
+  () => {
+    if (!props.assetDataset) return;
+
+    const key = computeTargetKey();
+    if (key !== lastViewKey) {
+      // Switched to a different asset/pipeline: reset to its default view.
+      lastViewKey = key;
+      selectDefaultViewForTarget();
+      return;
+    }
+
+    // Same target, data just refreshed: rebuild whichever view the user is in
+    // rather than forcing them back to the pipeline/asset view. This is what
+    // keeps the "Column Level Lineage" view from snapping away on every update.
+    if (showColumnView.value) {
+      buildColumnElements();
+    } else if (showPipelineView.value) {
       buildPipelineElements();
-    } else if (newAssetDataset && newPipelineData && !showPipelineView.value && !showColumnView.value) {
+    } else {
       processProperties();
     }
   },

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -205,7 +205,8 @@ import {
   generateGraphFromJSON,
   generateGraphForDownstream,
   generateGraphForUpstream,
-  generateColumnGraph
+  generateColumnGraph,
+  generateColumnGraphForPipeline
 } from "@/utilities/graphGenerator";
 import { fetchAllDownstreams, fetchAllUpstreams } from "@/utilities/assetDependencies";
 import { buildPipelineLineage, applyLayout as applyPipelineLayout } from "@/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder";
@@ -989,10 +990,12 @@ const buildColumnElements = async () => {
   }
   error.value = null;
   const lineageData = buildColumnLineage(newPipelineData);
-  const { nodes: initialNodes, edges: initialEdges } = generateColumnGraph(
-    lineageData,
-    props.assetDataset?.name || ""
-  );
+  // In pipeline view there is no single focus asset, so render column lineage
+  // across every asset in the pipeline instead of centering on one.
+  const isPipelineView = Boolean((props.assetDataset as any)?.isPipelineView);
+  const { nodes: initialNodes, edges: initialEdges } = isPipelineView
+    ? generateColumnGraphForPipeline(lineageData)
+    : generateColumnGraph(lineageData, props.assetDataset?.name || "");
   const { nodes: layoutNodes, edges: layoutEdges } = await applyPipelineLayout(initialNodes, initialEdges);
 
   // Save original positions for recalculation

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodesWithColumn.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodesWithColumn.vue
@@ -206,8 +206,11 @@ const showColumns = ref(false);
 const showAllColumns = ref(false);
 const maxVisibleColumns = 5;
 
-// Auto-expand columns for focus assets
-if (props.data?.asset?.isFocusAsset) {
+// Auto-expand columns for the focus asset and for any asset that participates
+// in column lineage — collapsed nodes hide the column handles, making the
+// column-to-column edges invisible. Users can still collapse a node via the
+// chevron to reduce clutter.
+if (props.data?.asset?.isFocusAsset || props.data?.expandColumns || props.data?.asset?.expandColumns) {
   showColumns.value = true;
 }
 

--- a/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodesWithColumn.vue
+++ b/webview-ui/src/components/lineage-flow/custom-nodes/CustomNodesWithColumn.vue
@@ -174,7 +174,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, defineEmits } from "vue";
+import { computed, ref, watch, defineEmits } from "vue";
 import { Handle, Position } from "@vue-flow/core";
 import { PlusIcon, ChevronDownIcon } from "@heroicons/vue/24/outline";
 import type { BruinNodeProps, ColumnInfo } from "@/types";
@@ -206,13 +206,15 @@ const showColumns = ref(false);
 const showAllColumns = ref(false);
 const maxVisibleColumns = 5;
 
-// Auto-expand columns for the focus asset and for any asset that participates
-// in column lineage — collapsed nodes hide the column handles, making the
-// column-to-column edges invisible. Users can still collapse a node via the
-// chevron to reduce clutter.
-if (props.data?.asset?.isFocusAsset || props.data?.expandColumns || props.data?.asset?.expandColumns) {
-  showColumns.value = true;
-}
+// Auto-expand columns for the focus asset and any lineage-participating asset so
+// its column edges are visible. A watcher (not a one-time check) keeps this
+// correct when a reused node is re-flagged on a data refresh.
+const shouldAutoExpandColumns = computed(() =>
+  Boolean(props.data?.asset?.isFocusAsset || props.data?.expandColumns || props.data?.asset?.expandColumns)
+);
+watch(shouldAutoExpandColumns, (expand) => {
+  if (expand) showColumns.value = true;
+}, { immediate: true });
 
 // Computed properties
 const columns = computed(() => {

--- a/webview-ui/src/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder.ts
+++ b/webview-ui/src/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder.ts
@@ -138,6 +138,22 @@ function updateNodePositions(layout: any, nodes: Node[]) {
   });
   return updatedNodes;
 };
+// Estimate the rendered height of a node so ELK can lay out expanded
+// column-lineage nodes without overlap. Collapsed / asset-only nodes keep the
+// original ~80px; nodes rendered with their columns expanded grow by roughly
+// one row per column.
+function estimateNodeHeight(node: Node): number {
+  const data: any = node.data || {};
+  const expanded = data.asset?.isFocusAsset || data.expandColumns || data.asset?.expandColumns;
+  const columns = data.columns || data.asset?.columns || [];
+  if (expanded && columns.length) {
+    const HEADER_HEIGHT = 90;
+    const COLUMN_ROW_HEIGHT = 14;
+    return HEADER_HEIGHT + columns.length * COLUMN_ROW_HEIGHT;
+  }
+  return 80;
+}
+
 // Function to apply ELK layout
 async function applyLayout(nodes: Node[], edges: Edge[]) : Promise<{ nodes: Node[], edges: Edge[] }> {
   const elk = new ELK();
@@ -152,7 +168,9 @@ async function applyLayout(nodes: Node[], edges: Edge[]) : Promise<{ nodes: Node
       "elk.algorithm": "layered",
       "elk.direction": "RIGHT",
       "elk.layered.spacing.nodeNodeBetweenLayers": "100",
-      "elk.spacing.nodeNode": "0.0",
+      // Vertical gap between nodes in the same layer. Kept small but non-zero so
+      // expanded column nodes don't butt up against (or overlap) each other.
+      "elk.spacing.nodeNode": "24",
       "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
       "elk.layered.nodePlacement.bk.fixedAlignment": "BALANCED",
       "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
@@ -165,7 +183,7 @@ async function applyLayout(nodes: Node[], edges: Edge[]) : Promise<{ nodes: Node
     children: nodes.map((node) => ({
       id: node.id,
       width: 224, // Same as node-content width
-      height: 80, // Approximate height
+      height: estimateNodeHeight(node),
     })),
     edges: edges.map((edge) => ({
       id: edge.id,

--- a/webview-ui/src/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder.ts
+++ b/webview-ui/src/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder.ts
@@ -139,8 +139,10 @@ function updateNodePositions(layout: any, nodes: Node[]) {
   return updatedNodes;
 };
 // Estimate rendered node height so ELK lays out expanded column nodes without
-// overlap: expanded nodes grow ~one row per column, others stay ~80px.
+// overlap: expanded nodes grow ~one row per column. Only column-view nodes
+// ('customWithColumn') render columns; everything else stays ~80px.
 function estimateNodeHeight(node: Node): number {
+  if (node.type !== 'customWithColumn') return 80;
   const data: any = node.data || {};
   const expanded = data.asset?.isFocusAsset || data.expandColumns || data.asset?.expandColumns;
   const columns = data.columns || data.asset?.columns || [];
@@ -161,7 +163,7 @@ async function applyLayout(nodes: Node[], edges: Edge[]) : Promise<{ nodes: Node
       "elk.algorithm": "layered",
       "elk.direction": "RIGHT",
       "elk.layered.spacing.nodeNodeBetweenLayers": "100",
-      "elk.spacing.nodeNode": "24",
+      "elk.spacing.nodeNode": "0.0",
       "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
       "elk.layered.nodePlacement.bk.fixedAlignment": "BALANCED",
       "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",

--- a/webview-ui/src/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder.ts
+++ b/webview-ui/src/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder.ts
@@ -138,20 +138,13 @@ function updateNodePositions(layout: any, nodes: Node[]) {
   });
   return updatedNodes;
 };
-// Estimate the rendered height of a node so ELK can lay out expanded
-// column-lineage nodes without overlap. Collapsed / asset-only nodes keep the
-// original ~80px; nodes rendered with their columns expanded grow by roughly
-// one row per column.
+// Estimate rendered node height so ELK lays out expanded column nodes without
+// overlap: expanded nodes grow ~one row per column, others stay ~80px.
 function estimateNodeHeight(node: Node): number {
   const data: any = node.data || {};
   const expanded = data.asset?.isFocusAsset || data.expandColumns || data.asset?.expandColumns;
   const columns = data.columns || data.asset?.columns || [];
-  if (expanded && columns.length) {
-    const HEADER_HEIGHT = 90;
-    const COLUMN_ROW_HEIGHT = 14;
-    return HEADER_HEIGHT + columns.length * COLUMN_ROW_HEIGHT;
-  }
-  return 80;
+  return expanded && columns.length ? 90 + columns.length * 14 : 80;
 }
 
 // Function to apply ELK layout
@@ -168,8 +161,6 @@ async function applyLayout(nodes: Node[], edges: Edge[]) : Promise<{ nodes: Node
       "elk.algorithm": "layered",
       "elk.direction": "RIGHT",
       "elk.layered.spacing.nodeNodeBetweenLayers": "100",
-      // Vertical gap between nodes in the same layer. Kept small but non-zero so
-      // expanded column nodes don't butt up against (or overlap) each other.
       "elk.spacing.nodeNode": "24",
       "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
       "elk.layered.nodePlacement.bk.fixedAlignment": "BALANCED",

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -25,7 +25,7 @@ import FilterTab from "@/components/lineage-flow/filterTab/filterTab.vue";
 import "./mocks/vueFlow"; // Import the mocks
 import { buildPipelineLineage, generateGraph } from "@/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder";
 import { buildColumnLineage, getAssetDatasetWithColumns } from "@/components/lineage-flow/column-level/useColumnLevel";
-import { generateColumnGraph, createColumnLevelEdges, generateGraphFromJSON, generateGraphForUpstream, generateGraphForDownstream } from "@/utilities/graphGenerator";
+import { generateColumnGraph, generateColumnGraphForPipeline, createColumnLevelEdges, generateGraphFromJSON, generateGraphForUpstream, generateGraphForDownstream } from "@/utilities/graphGenerator";
 import { 
   findDownstreamAssets, 
   getDownstreamAssetNames,
@@ -1346,6 +1346,52 @@ suite('createColumnLevelEdges', () => {
     expect(focusToDownstreamEdge?.data.targetAsset).toBe('downstream_asset');
     expect(focusToDownstreamEdge?.data.sourceColumn).toBe('focus_col');
     expect(focusToDownstreamEdge?.data.targetColumn).toBe('downstream_col');
+  });
+});
+
+suite('generateColumnGraphForPipeline', () => {
+  // a -> b -> c is a chain with column lineage; d is an isolated asset.
+  const assetMap = {
+    a: { name: 'a', columns: [{ name: 'a_col' }], upstreams: [], downstreams: [] },
+    b: {
+      name: 'b',
+      columns: [{ name: 'b_col' }],
+      upstreams: [{ type: 'asset', value: 'a' }],
+      downstreams: []
+    },
+    c: {
+      name: 'c',
+      columns: [{ name: 'c_col' }],
+      upstreams: [{ type: 'asset', value: 'b' }],
+      downstreams: []
+    },
+    d: { name: 'd', columns: [{ name: 'd_col' }], upstreams: [], downstreams: [] }
+  };
+  const columnLineageMap = {
+    b: [{ column: 'b_col', source_columns: [{ asset: 'a', column: 'a_col' }] }],
+    c: [{ column: 'c_col', source_columns: [{ asset: 'b', column: 'b_col' }] }]
+  };
+  const lineageData = { assets: Object.values(assetMap), columnLineageMap, assetMap };
+
+  test('renders a node for every asset in the pipeline, including isolated ones', () => {
+    const { nodes } = generateColumnGraphForPipeline(lineageData);
+    expect(nodes.map(n => n.id).sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  test('draws asset-level edges for every in-pipeline dependency', () => {
+    const { edges } = generateColumnGraphForPipeline(lineageData);
+    const assetEdges = edges.filter(e => e.data?.type === 'asset-lineage');
+    expect(assetEdges).toHaveLength(2);
+    expect(assetEdges.some(e => e.source === 'a' && e.target === 'b')).toBe(true);
+    expect(assetEdges.some(e => e.source === 'b' && e.target === 'c')).toBe(true);
+  });
+
+  test('draws column-level edges across the whole chain', () => {
+    const { edges } = generateColumnGraphForPipeline(lineageData);
+    const columnEdges = edges.filter(e => e.data?.type === 'column-lineage');
+    expect(columnEdges).toHaveLength(2);
+    expect(columnEdges.some(e => e.id === 'column-a.a_col-to-b.b_col')).toBe(true);
+    expect(columnEdges.some(e => e.id === 'column-b.b_col-to-c.c_col')).toBe(true);
   });
 });
 

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -1393,6 +1393,17 @@ suite('generateColumnGraphForPipeline', () => {
     expect(columnEdges.some(e => e.id === 'column-a.a_col-to-b.b_col')).toBe(true);
     expect(columnEdges.some(e => e.id === 'column-b.b_col-to-c.c_col')).toBe(true);
   });
+
+  test('expands columns by default only for lineage-participating assets', () => {
+    const { nodes } = generateColumnGraphForPipeline(lineageData);
+    const byId = Object.fromEntries(nodes.map(n => [n.id, n]));
+    // a (source), b (source+target), c (target) participate → expanded.
+    expect(byId.a.data.expandColumns).toBe(true);
+    expect(byId.b.data.expandColumns).toBe(true);
+    expect(byId.c.data.expandColumns).toBe(true);
+    // d has no column lineage → left collapsed to reduce clutter.
+    expect(byId.d.data.expandColumns).toBeFalsy();
+  });
 });
 
 suite('ConnectionsForm updateUseApplicationDefaultCredentials', () => {

--- a/webview-ui/src/utilities/graphGenerator.ts
+++ b/webview-ui/src/utilities/graphGenerator.ts
@@ -256,6 +256,42 @@ export const createColumnLevelEdges = (
 };
 
 /**
+ * Names of assets (lowercased) that participate in column-level lineage —
+ * either they own lineage entries (targets) or they feed another asset's
+ * column (sources). These are the nodes worth expanding by default in the
+ * column view so their column-to-column edges are actually visible.
+ */
+export const getColumnLineageParticipants = (
+  columnLineageMap: Record<string, ColumnLineage[]>
+): Set<string> => {
+  const participants = new Set<string>();
+  Object.entries(columnLineageMap).forEach(([assetName, lineage]) => {
+    if (!lineage || lineage.length === 0) return;
+    participants.add(assetName.toLowerCase());
+    lineage.forEach(entry => {
+      entry.source_columns.forEach(sc => participants.add(sc.asset.toLowerCase()));
+    });
+  });
+  return participants;
+};
+
+/**
+ * Flag the nodes that participate in column lineage so the node component
+ * expands their columns by default. Collapsed nodes stack all their column
+ * handles on the header, which makes the column edges invisible.
+ */
+const markExpandedColumnNodes = (nodes: Node[], participants: Set<string>): void => {
+  nodes.forEach(node => {
+    if (participants.has(String(node.id).toLowerCase())) {
+      (node.data as any).expandColumns = true;
+      if ((node.data as any).asset) {
+        (node.data as any).asset.expandColumns = true;
+      }
+    }
+  });
+};
+
+/**
  * Create column node
  */
 export const createColumnNode = (asset: any, isFocusAsset: boolean = false, columnLineage: ColumnLineage[] = []): Node => {
@@ -319,6 +355,10 @@ export const generateColumnGraph = (
     // Add column-level edges based on column lineage information
     const columnEdges = createColumnLevelEdges(processedAssets, columnLineageMap, assetMap);
     edges.push(...columnEdges);
+
+    // Expand columns for lineage-participating neighbours so their column
+    // edges are visible (the focus asset is already expanded).
+    markExpandedColumnNodes(nodes, getColumnLineageParticipants(columnLineageMap));
   }
 
   return { nodes, edges };
@@ -366,6 +406,10 @@ export const generateColumnGraphForPipeline = (
 
   // Column-level edges across all assets in the pipeline.
   edges.push(...createColumnLevelEdges(processedAssets, columnLineageMap, assetMap));
+
+  // Expand columns for assets that participate in column lineage so their
+  // column edges are visible; leave metadata-only assets collapsed.
+  markExpandedColumnNodes(nodes, getColumnLineageParticipants(columnLineageMap));
 
   return { nodes, edges };
 };

--- a/webview-ui/src/utilities/graphGenerator.ts
+++ b/webview-ui/src/utilities/graphGenerator.ts
@@ -255,12 +255,7 @@ export const createColumnLevelEdges = (
   return edges;
 };
 
-/**
- * Names of assets (lowercased) that participate in column-level lineage —
- * either they own lineage entries (targets) or they feed another asset's
- * column (sources). These are the nodes worth expanding by default in the
- * column view so their column-to-column edges are actually visible.
- */
+/** Assets (lowercased) that are a source or target of column-level lineage. */
 export const getColumnLineageParticipants = (
   columnLineageMap: Record<string, ColumnLineage[]>
 ): Set<string> => {
@@ -275,11 +270,8 @@ export const getColumnLineageParticipants = (
   return participants;
 };
 
-/**
- * Flag the nodes that participate in column lineage so the node component
- * expands their columns by default. Collapsed nodes stack all their column
- * handles on the header, which makes the column edges invisible.
- */
+// Expand columns by default for participating nodes; collapsed nodes hide the
+// column handles, which makes the column edges invisible.
 const markExpandedColumnNodes = (nodes: Node[], participants: Set<string>): void => {
   nodes.forEach(node => {
     if (participants.has(String(node.id).toLowerCase())) {
@@ -356,8 +348,6 @@ export const generateColumnGraph = (
     const columnEdges = createColumnLevelEdges(processedAssets, columnLineageMap, assetMap);
     edges.push(...columnEdges);
 
-    // Expand columns for lineage-participating neighbours so their column
-    // edges are visible (the focus asset is already expanded).
     markExpandedColumnNodes(nodes, getColumnLineageParticipants(columnLineageMap));
   }
 
@@ -365,12 +355,9 @@ export const generateColumnGraph = (
 };
 
 /**
- * Generate nodes and edges for a pipeline-wide column-level lineage view.
- *
- * Unlike generateColumnGraph, this is not anchored to a single focus asset:
- * every asset in the pipeline becomes a column node and all asset- and
- * column-level edges between in-pipeline assets are drawn. Used for the
- * pipeline view, where there is no single focus asset to center on.
+ * Pipeline-wide column-level lineage: every asset becomes a column node and all
+ * asset- and column-level edges are drawn. Used in pipeline view, where there
+ * is no single focus asset to center on.
  */
 export const generateColumnGraphForPipeline = (
   lineageData: {
@@ -384,13 +371,12 @@ export const generateColumnGraphForPipeline = (
   const edges: Edge[] = [];
   const processedAssets = new Set<string>();
 
-  // Add every asset in the pipeline as a column node.
   Object.values(assetMap).forEach((asset: any) => {
     nodes.push(createColumnNode(asset, false, columnLineageMap[asset.name] || []));
     processedAssets.add(asset.name.toLowerCase());
   });
 
-  // Draw asset-level edges for every in-pipeline dependency.
+  // Asset-level edges for every in-pipeline dependency.
   const assetEdgeSet = new Set<string>();
   Object.values(assetMap).forEach((asset: any) => {
     (asset.upstreams || []).forEach((upstream: any) => {
@@ -404,11 +390,7 @@ export const generateColumnGraphForPipeline = (
     });
   });
 
-  // Column-level edges across all assets in the pipeline.
   edges.push(...createColumnLevelEdges(processedAssets, columnLineageMap, assetMap));
-
-  // Expand columns for assets that participate in column lineage so their
-  // column edges are visible; leave metadata-only assets collapsed.
   markExpandedColumnNodes(nodes, getColumnLineageParticipants(columnLineageMap));
 
   return { nodes, edges };

--- a/webview-ui/src/utilities/graphGenerator.ts
+++ b/webview-ui/src/utilities/graphGenerator.ts
@@ -323,3 +323,49 @@ export const generateColumnGraph = (
 
   return { nodes, edges };
 };
+
+/**
+ * Generate nodes and edges for a pipeline-wide column-level lineage view.
+ *
+ * Unlike generateColumnGraph, this is not anchored to a single focus asset:
+ * every asset in the pipeline becomes a column node and all asset- and
+ * column-level edges between in-pipeline assets are drawn. Used for the
+ * pipeline view, where there is no single focus asset to center on.
+ */
+export const generateColumnGraphForPipeline = (
+  lineageData: {
+    assets: any[],
+    columnLineageMap: Record<string, ColumnLineage[]>,
+    assetMap: { [key: string]: any }
+  }
+): { nodes: Node[], edges: Edge[] } => {
+  const { assetMap, columnLineageMap } = lineageData;
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  const processedAssets = new Set<string>();
+
+  // Add every asset in the pipeline as a column node.
+  Object.values(assetMap).forEach((asset: any) => {
+    nodes.push(createColumnNode(asset, false, columnLineageMap[asset.name] || []));
+    processedAssets.add(asset.name.toLowerCase());
+  });
+
+  // Draw asset-level edges for every in-pipeline dependency.
+  const assetEdgeSet = new Set<string>();
+  Object.values(assetMap).forEach((asset: any) => {
+    (asset.upstreams || []).forEach((upstream: any) => {
+      if (upstream.type === 'asset' && upstream.value && assetMap[upstream.value]) {
+        const key = `${upstream.value}->${asset.name}`;
+        if (!assetEdgeSet.has(key)) {
+          assetEdgeSet.add(key);
+          edges.push(createAssetEdge(upstream.value, asset.name));
+        }
+      }
+    });
+  });
+
+  // Column-level edges across all assets in the pipeline.
+  edges.push(...createColumnLevelEdges(processedAssets, columnLineageMap, assetMap));
+
+  return { nodes, edges };
+};


### PR DESCRIPTION
Fixes #781.

Column-level lineage was broken: the panel loaded pipeline data without the `-c` flag, so "Column Level Lineage" always showed "No column lineage data found" even with annotated columns. While fixing that, cleaned up the rest of the column-lineage UX.

### Changes
- **Load column lineage up front** — the lineage panel and `showPipelineLineage`/`getPipelineAssets` now request `parse-pipeline -c`, so the column view has the data it needs (was the root cause of #781).
- **Pipeline-wide column view** — opening "Column Level Lineage" from the pipeline view now renders column edges across every asset, instead of only the focused asset (previously produced an empty graph since there's no focus asset).
- **Stop the view resetting on refresh** — the panel re-received data on every visibility/document change and snapped back to pipeline view, so the column view "only worked once". It now only resets when you switch to a different asset/pipeline and rebuilds the current view in place otherwise.
- **Expand participating nodes by default** — assets that take part in column lineage open with columns expanded so the arrows are visible; unrelated assets stay collapsed and any node can still be toggled via its chevron. ELK layout now estimates expanded node height + adds vertical spacing so nodes don't overlap.

### Testing
- Extension `tsc` compiles; webview builds.
- Added webview unit tests for the pipeline-wide graph builder and the expand-by-default logic.
- Manually: `bruin-pipeline` renders column arrows in both pipeline and asset column views; chess (no column lineage in its SQL) correctly shows the empty state.