### PR TITLE
Hide materialization section for ingestr assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [0.82.2] - [2026-07-13]
-- Hid the Materialization section in the asset Details tab for ingestr assets, which don't support materialization.
+- Hid the Materialization section in the asset Details tab for ingestr assets, which don't support materialization, and added a warning when a `materialization` block is added to an ingestr asset.
 
 ## [0.82.1] - [2026-07-08]
 - Fixed "run multiple assets" producing a truncated command with a cut-off path and dangling quote for large selections, which now run via a temporary script file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.82.2] - [2026-07-13]
+- Hid the Materialization section in the asset Details tab for ingestr assets, which don't support materialization.
+
 ## [0.82.1] - [2026-07-08]
 - Fixed "run multiple assets" producing a truncated command with a cut-off path and dangling quote for large selections, which now run via a temporary script file.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.82.2**: Hid the Materialization section in the asset Details tab for ingestr assets, which don't support materialization.
+- **0.82.2**: Hid the Materialization section in the asset Details tab for ingestr assets, which don't support materialization, and added a warning when a `materialization` block is added to an ingestr asset.
 - **0.82.1**: Fixed "run multiple assets" producing a truncated command with a cut-off path and dangling quote for large selections, which now run via a temporary script file.
 - **0.82.0**: Overhauled column-level lineage: fixed the "No column lineage data found" error, added a pipeline-wide column view, and expanded participating assets by default so the arrows are visible.
 - **0.81.5**: Regenerated config-schema.json for all 136 connection types from the Bruin CLI, fixing Athena lint so profile-based connections validate correctly.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.82.2**: Hid the Materialization section in the asset Details tab for ingestr assets, which don't support materialization.
 - **0.82.1**: Fixed "run multiple assets" producing a truncated command with a cut-off path and dangling quote for large selections, which now run via a temporary script file.
 - **0.82.0**: Overhauled column-level lineage: fixed the "No column lineage data found" error, added a pipeline-wide column view, and expanded participating assets by default so the arrows are visible.
 - **0.81.5**: Regenerated config-schema.json for all 136 connection types from the Bruin CLI, fixing Athena lint so profile-based connections validate correctly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.82.1",
+  "version": "0.82.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.82.1",
+      "version": "0.82.2",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.82.1",
+  "version": "0.82.2",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/language-server/providers/materializationValidator.ts
+++ b/src/language-server/providers/materializationValidator.ts
@@ -27,14 +27,42 @@ export class MaterializationValidator {
         }
         
         if (materializationStart !== -1) {
-            // Validate the materialization section
-            this.validateRequiredFields(document, lines, materializationStart, materializationEnd, diagnostics);
+            if (this.getAssetType(lines) === 'ingestr') {
+                // Ingestr assets don't support materialization; the CLI silently ignores
+                // the block. Flag it so it isn't mistaken for a working configuration.
+                const line = lines[materializationStart];
+                const keyEnd = line.indexOf(':');
+                const range = new vscode.Range(materializationStart, 0, materializationStart, keyEnd === -1 ? line.length : keyEnd);
+                diagnostics.push(new vscode.Diagnostic(
+                    range,
+                    'Materialization is not supported for ingestr assets and will be ignored. Configure incremental behavior via "parameters" (e.g. incremental_strategy, incremental_key) instead.',
+                    vscode.DiagnosticSeverity.Warning
+                ));
+            } else {
+                // Validate the materialization section
+                this.validateRequiredFields(document, lines, materializationStart, materializationEnd, diagnostics);
+            }
         }
-        
+
         // Validate interval_modifiers placement based on file type
         this.validateIntervalModifiers(document, lines, diagnostics, isPipelineFile);
-        
+
         return diagnostics;
+    }
+
+    /**
+     * Find the top-level asset type (e.g. "ingestr", "bq.sql"). Only matches a
+     * `type:` key at column 0, so it ignores the indented materialization `type`
+     * and nested asset definitions in pipeline.yml.
+     */
+    private getAssetType(lines: string[]): string | null {
+        for (const line of lines) {
+            const match = line.match(/^type:\s*(\S+)/);
+            if (match) {
+                return match[1];
+            }
+        }
+        return null;
     }
     
     /**

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -770,6 +770,7 @@ const tabs = ref([
       pipelineAssets: pipelineAssets.value,
       currentFilePath: lastRenderedDocument.value,
       secrets: assetDetailsProps.value?.secrets,
+      assetType: assetDetailsProps.value?.type,
     })),
   },
   {

--- a/webview-ui/src/components/asset/materialization/Materialization.vue
+++ b/webview-ui/src/components/asset/materialization/Materialization.vue
@@ -517,8 +517,12 @@
         </div>
       </div>
 
-      <!-- Materialization Section -->
-      <div id="materialization-section" class="collapsible-section">
+      <!-- Materialization Section (not applicable to ingestr assets) -->
+      <div
+        v-if="assetType !== 'ingestr'"
+        id="materialization-section"
+        class="collapsible-section"
+      >
         <div id="materialization-section-header" class="section-header" @click="toggleSection('materialization')">
           <div class="flex items-center justify-between w-full">
             <div class="flex items-center gap-2">
@@ -704,6 +708,10 @@ const props = defineProps({
   secrets: {
     type: Array,
     default: () => [],
+  },
+  assetType: {
+    type: String,
+    default: "",
   },
 });
 


### PR DESCRIPTION
Opening an ingestr asset's **Details** tab showed a Materialization section with table/view radio buttons. Ingestr assets don't support materialization — incremental behavior is configured via `parameters` (`incremental_strategy` / `incremental_key`) — so toggling those radios wrote an invalid `materialization` block into the asset.

This hides the Materialization section entirely for ingestr assets (`assetType === 'ingestr'`), matching the pattern already used in the General and Columns tabs. Other Details sections (owner, tags, dependencies, interval modifiers, secrets) are unaffected.
