### PR TITLE
Apply sensor-mode setting changes to open panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.82.4] - [2026-07-17]
+- Fixed the "Apply-Sensor-Mode" checkbox using a stale mode: changing the `bruin.run.sensorMode` setting now takes effect immediately in an open asset panel instead of only after reopening it. The checkbox tooltip also shows the active mode and points to the setting.
+
 ## [0.82.3] - [2026-07-13]
 - Restored the Materialization section for ingestr assets (now supported by the Bruin CLI), limited to the options ingestr supports: type "table" only and the create+replace, delete+insert, append, merge, and truncate+insert strategies.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.82.4**: Fixed the "Apply-Sensor-Mode" checkbox using a stale mode: changing the `bruin.run.sensorMode` setting now takes effect immediately in an open asset panel instead of only after reopening it. The checkbox tooltip also shows the active mode and points to the setting.
 - **0.82.3**: Restored the Materialization section for ingestr assets (now supported by the Bruin CLI), limited to the options ingestr supports: type "table" only and the create+replace, delete+insert, append, merge, and truncate+insert strategies.
 - **0.82.2**: Hid the Materialization section in the asset Details tab for ingestr assets, which don't support materialization, and added a warning when a `materialization` block is added to an ingestr asset.
 - **0.82.1**: Fixed "run multiple assets" producing a truncated command with a cut-off path and dangling quote for large selections, which now run via a temporary script file.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.82.3",
+  "version": "0.82.4",
   "engines": {
     "vscode": "^1.87.0"
   },

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -248,6 +248,18 @@ export class BruinPanel {
             }
           }
         }
+      }),
+
+      // Keep the open panel in sync when the sensor-mode setting changes, so the
+      // run command uses the current mode instead of the value read at panel open.
+      workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration("bruin.run.sensorMode")) {
+          this._sensorModeSetting = getSensorModeSetting();
+          this._panel.webview.postMessage({
+            command: "sensorModeSettingChanged",
+            sensorModeSetting: this._sensorModeSetting,
+          });
+        }
       })
     );
 

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -1308,7 +1308,8 @@ const checkboxTooltips = computed(() => {
   }
   tooltips['Apply-Sensor-Mode'] =
     `Runs sensors with --sensor-mode ${sensorModeSetting.value}. ` +
-    `Change the mode in Settings → search "sensor mode" (bruin.run.sensorMode: once / skip / wait).`;
+    `Change the mode in the editor Settings (Cmd/Ctrl+,) — not this panel's Settings tab — ` +
+    `by searching "sensor mode" (bruin.run.sensorMode: once / skip / wait).`;
   return tooltips;
 });
 

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -1306,6 +1306,9 @@ const checkboxTooltips = computed(() => {
   if (intervalModifiersTooltip.value) {
     tooltips['Interval-modifiers'] = intervalModifiersTooltip.value;
   }
+  tooltips['Apply-Sensor-Mode'] =
+    `Runs sensors with --sensor-mode ${sensorModeSetting.value}. ` +
+    `Change the mode in Settings → search "sensor mode" (bruin.run.sensorMode: once / skip / wait).`;
   return tooltips;
 });
 
@@ -2163,6 +2166,16 @@ function receiveMessage(event: { data: any }) {
             checkboxState: envelope.payload,
             sensorModeSetting: sensorModeSetting.value,
           });
+        } catch (_) { }
+      }
+      break;
+
+    case "sensorModeSettingChanged":
+      if (envelope.sensorModeSetting) {
+        sensorModeSetting.value = envelope.sensorModeSetting;
+        try {
+          const prevState = (vscode.getState() as Record<string, any>) || {};
+          vscode.setState({ ...prevState, sensorModeSetting: sensorModeSetting.value });
         } catch (_) { }
       }
       break;

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -1308,7 +1308,7 @@ const checkboxTooltips = computed(() => {
   }
   tooltips['Apply-Sensor-Mode'] =
     `Runs sensors with --sensor-mode ${sensorModeSetting.value}. ` +
-    `Change the mode in the editor Settings (Cmd/Ctrl+,) — not this panel's Settings tab — ` +
+    `Change the mode in the editor Settings (Cmd/Ctrl+,) ` +
     `by searching "sensor mode" (bruin.run.sensorMode: once / skip / wait).`;
   return tooltips;
 });


### PR DESCRIPTION
The "Apply-Sensor-Mode" checkbox appended `--sensor-mode <X>` using the value of `bruin.run.sensorMode` read when the panel was first opened. So changing the setting (e.g. from `skip` to `wait`) had no effect until the panel was closed and reopened, which was confusing — it looked like the mode couldn't be changed at all.

Now the open panel listens for changes to `bruin.run.sensorMode` and updates immediately. Also added a tooltip on the checkbox showing the active mode and where to change it.

Patch release: 0.82.4.