### PR TITLE
Raise CLI output buffer to 64MB and drop multi-MB lineage debug logs

### DIFF
--- a/src/bruin/bruinCommand.ts
+++ b/src/bruin/bruinCommand.ts
@@ -8,6 +8,13 @@ export abstract class BruinCommand {
   public static isTestMode = false;
 
   /**
+   * Max stdout captured from a Bruin command. Lineage parses of large pipelines
+   * already emit several MB (6+ MB on ~1,500 assets), and exceeding this cap
+   * makes execFile throw instead of returning output, breaking the panel.
+   */
+  private static readonly MAX_OUTPUT_BUFFER = 1024 * 1024 * 64; // 64MB
+
+  /**
    * Initializes a new Bruin command instance.
    *
    * @param bruinExecutable The path to the Bruin executable.
@@ -62,7 +69,7 @@ export abstract class BruinCommand {
     return new Promise((resolve, reject) => {
       const execOptions: any = {
         cwd: this.workingDirectory,
-        maxBuffer: 1024 * 1024 * 10, // 10MB
+        maxBuffer: BruinCommand.MAX_OUTPUT_BUFFER,
       };
 
       // Windows-specific optimizations

--- a/src/bruin/bruinFlowLineage.ts
+++ b/src/bruin/bruinFlowLineage.ts
@@ -17,7 +17,6 @@ export class BruinLineageInternalParse extends BruinCommand {
   ): Promise<any> {
     const cliResult = await this.run([...flags, filePath], { ignoresErrors });
     const pipelineData = JSON.parse(cliResult);
-    console.log("Pipeline data from parsePipelineConfig", pipelineData);
     const parsedResult: any = {
       name: pipelineData.name || '',
       schedule: pipelineData.schedule || '',

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -5992,7 +5992,7 @@ suite(" Query export Tests", () => {
       assert.strictEqual(executable, "path/to/bruin");
       assert.deepStrictEqual(args, ["internal", "fetch-databases", "-c", connectionName, "-o", "json"]);
       assert.strictEqual(options.cwd, "path/to/working/directory");
-      assert.strictEqual(options.maxBuffer, 10485760);
+      assert.strictEqual(options.maxBuffer, 67108864);
       assert.strictEqual(typeof callback, "function");
       
       // On Windows, check for Windows-specific options
@@ -6035,7 +6035,7 @@ suite(" Query export Tests", () => {
       assert.strictEqual(executable, "path/to/bruin");
       assert.deepStrictEqual(args, ["internal", "fetch-tables", "-c", connectionName, "-d", database, "-o", "json"]);
       assert.strictEqual(options.cwd, "path/to/working/directory");
-      assert.strictEqual(options.maxBuffer, 10485760);
+      assert.strictEqual(options.maxBuffer, 67108864);
       assert.strictEqual(typeof callback, "function");
       
       // On Windows, check for Windows-specific options
@@ -6083,7 +6083,7 @@ suite(" Query export Tests", () => {
       assert.strictEqual(executable, "path/to/bruin");
       assert.deepStrictEqual(args, ["internal", "fetch-columns", "-c", connectionName, "-d", database, "-table", table, "-o", "json"]);
       assert.strictEqual(options.cwd, "path/to/working/directory");
-      assert.strictEqual(options.maxBuffer, 10485760);
+      assert.strictEqual(options.maxBuffer, 67108864);
       assert.strictEqual(typeof callback, "function");
       
       // On Windows, check for Windows-specific options
@@ -6139,7 +6139,7 @@ suite(" Query export Tests", () => {
       assert.strictEqual(executable, "path/to/bruin");
       assert.deepStrictEqual(args, ["internal", "fetch-tables", "-c", connectionName, "-d", "", "-o", "json"]);
       assert.strictEqual(options.cwd, "path/to/working/directory");
-      assert.strictEqual(options.maxBuffer, 10485760);
+      assert.strictEqual(options.maxBuffer, 67108864);
       assert.strictEqual(typeof callback, "function");
       
       // On Windows, check for Windows-specific options

--- a/webview-ui/src/components/lineage-flow/asset-lineage/useAssetLineage.ts
+++ b/webview-ui/src/components/lineage-flow/asset-lineage/useAssetLineage.ts
@@ -7,9 +7,7 @@ export const getAssetDataset = (
 ): AssetDataset  | null => {
   if (!pipelineData) {
     return null;
-  } 
-  console.log("pipelineData", pipelineData);
-
+  }
 
   const findAssetById = (id) => {
     if (!id) return null;
@@ -79,7 +77,6 @@ export const getAssetDataset = (
     downstream: downstreams,
   };
 
-  console.log("Result", JSON.stringify(result, null, 2));
   return result;
 }
  


### PR DESCRIPTION
First of a series of lineage-panel performance fixes.

- Raise the `execFile` `maxBuffer` from 10MB to 64MB. Column-lineage parses (`parse-pipeline -c`) on large pipelines already emit 6+ MB (~1,500 assets), and exceeding the cap makes the command throw and breaks the lineage panel entirely.
- Remove `console.log`s that dumped the entire multi-MB pipeline object on the lineage render path.

No behavior change beyond not crashing on large output.