### PR TITLE
Remove debug logs that dump the full pipeline object (freezes the panel)

### DIFF
--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -96,6 +96,9 @@ export class BruinPanel {
   private _currentEndDate: string = "";
   private _currentEnvironment: string = "";
   private _sensorModeSetting: string = "skip";
+  // Assets with an asset-metadata CLI call currently in flight, so duplicate
+  // requests for the same file (fired several times per switch) are coalesced.
+  private _metadataInFlight = new Set<string>();
 
   public static setExtensionContext(context: vscode.ExtensionContext): void {
     BruinPanel._extensionContext = context;
@@ -666,13 +669,8 @@ export class BruinPanel {
               // Render with flags if we have a valid document
               if (this._lastRenderedDocumentUri?.fsPath) {
                 await renderCommandWithFlags(this._flags, this._lastRenderedDocumentUri.fsPath);
-                const assetMetadata = new BruinInternalAssetMetadata(
-                  getBruinExecutablePath(),
-                  vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || ""  
-                );
-                await assetMetadata.getAssetMetadata(
+                await this._fetchAssetMetadata(
                   this._lastRenderedDocumentUri.fsPath,
-                  undefined,
                   this._currentStartDate,
                   this._currentEndDate,
                   this._currentEnvironment
@@ -1532,35 +1530,19 @@ export class BruinPanel {
               await flowLineageCommand(this._lastRenderedDocumentUri, undefined, true);
             }
             break;
-          case "bruin.getAssetMetadata":
+          case "bruin.getAssetMetadata": {
             if (!this._lastRenderedDocumentUri) {
               return;
             }
-            const metadataAssetPath = this._lastRenderedDocumentUri.fsPath;
-            const isAssetForMetadata = await this._isAssetFile(metadataAssetPath);
-            
-            if (isAssetForMetadata) {
-              const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || "";
-              const assetMetadata = new BruinInternalAssetMetadata(
-                getBruinExecutablePath(),
-                workspaceFolder
-              );
-              
-              // Use payload values if provided, otherwise use stored values
-              const { startDate, endDate, environment } = message.payload || {};
-              const finalStartDate = startDate || this._currentStartDate;
-              const finalEndDate = endDate || this._currentEndDate;
-              const finalEnvironment = environment || this._currentEnvironment;
-              
-              await assetMetadata.getAssetMetadata(
-                metadataAssetPath,
-                undefined,
-                finalStartDate,
-                finalEndDate,
-                finalEnvironment
-              );
-            }
+            const meta = message.payload || {};
+            await this._fetchAssetMetadata(
+              this._lastRenderedDocumentUri.fsPath,
+              meta.startDate || this._currentStartDate,
+              meta.endDate || this._currentEndDate,
+              meta.environment || this._currentEnvironment
+            );
             break;
+          }
           case "bruin.parsePipelineForVariables":
             if (!this._lastRenderedDocumentUri) {
               return;
@@ -1817,6 +1799,44 @@ export class BruinPanel {
         console.error("Debounced SQL render failed:", err);
       }
     }, 200);
+  }
+
+  private _isPipelineOrConfigFile(filePath: string): boolean {
+    return (
+      filePath.endsWith("pipeline.yml") ||
+      filePath.endsWith("pipeline.yaml") ||
+      filePath.endsWith(".bruin.yml") ||
+      filePath.endsWith(".bruin.yaml")
+    );
+  }
+
+  // Fetch asset metadata, guarding against the CLI panic on pipeline/config files
+  // and coalescing duplicate concurrent requests for the same asset.
+  private async _fetchAssetMetadata(
+    assetPath: string,
+    startDate?: string,
+    endDate?: string,
+    environment?: string
+  ): Promise<void> {
+    if (this._isPipelineOrConfigFile(assetPath)) {
+      return;
+    }
+    if (this._metadataInFlight.has(assetPath)) {
+      return;
+    }
+    this._metadataInFlight.add(assetPath);
+    try {
+      if (!(await this._isAssetFile(assetPath))) {
+        return;
+      }
+      const assetMetadata = new BruinInternalAssetMetadata(
+        getBruinExecutablePath(),
+        vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || ""
+      );
+      await assetMetadata.getAssetMetadata(assetPath, undefined, startDate, endDate, environment);
+    } finally {
+      this._metadataInFlight.delete(assetPath);
+    }
   }
 
   private async _isAssetFile(filePath: string): Promise<boolean> {

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -374,7 +374,6 @@ const handleMessage = (event: MessageEvent) => {
       }
       case "pipeline-assets":
         pipelineAssetsData.value = updateValue(message, "success");
-        console.log("Pipeline assets:", pipelineAssetsData.value);
         break;
       case "asset-metadata-message":
         const metadataResult = updateValue(message, "success");
@@ -621,7 +620,6 @@ const startDate = computed(() => {
 
   // For pipeline config files (pipeline.yml), get start_date directly
   if (parsedData.type === "pipelineConfig") {
-    console.log("Pipeline config start date:", parsedData.raw);
     return parsedData.raw?.start_date || "";
   }
 
@@ -681,7 +679,6 @@ const columnsProps = computed(() => {
   if (!data.value) return [];
   const details = parseAssetDetails(data.value);
   const columns = details?.columns || [];
-  console.log("Asset columns:", columns);
   return columns;
 });
 
@@ -708,7 +705,6 @@ const transformedDependencies = computed(() => {
 // Computed property to extract pipeline assets from asset details
 const pipelineAssets = computed(() => {
   const assets = pipelineAssetsData.value || [];
-  console.log("Pipeline assets raw data:", assets);
   // Return the full asset objects, not just the name
   return assets;
 });

--- a/webview-ui/src/components/lineage-flow/column-level/useColumnLevel.ts
+++ b/webview-ui/src/components/lineage-flow/column-level/useColumnLevel.ts
@@ -14,7 +14,6 @@ export const getAssetDatasetWithColumns = (
   if (!pipelineData || !pipelineData.assets) {
     return null;
   }
-  console.log("pipelineData for columns", pipelineData);
 
   const findAssetById = (id: string) => {
     if (!id) return null;
@@ -125,7 +124,6 @@ export const getAssetDatasetWithColumns = (
     downstream: downstreams,
   };
 
-  console.log("Column Result", JSON.stringify(result, null, 2));
   return result;
 };
 
@@ -265,11 +263,9 @@ export const processDownstreamAssets = (
   const edges: Edge[] = [];
 
   if (focusAsset.downstreams && focusAsset.downstreams.length > 0) {
-    console.log(`Adding ${focusAsset.downstreams.length} downstream assets for ${focusAsset.name}`);
     focusAsset.downstreams.forEach(downstream => {
       if (downstream.type === 'asset' && downstream.value && assetMap[downstream.value]) {
         const downstreamAsset = assetMap[downstream.value];
-        console.log(`Adding downstream asset: ${downstream.value}`);
         nodes.push(createColumnNode(downstreamAsset, false, columnLineageMap[downstream.value] || []));
         processedAssets.add(downstream.value.toLowerCase());
 
@@ -277,8 +273,6 @@ export const processDownstreamAssets = (
         edges.push(createAssetEdge(focusAsset.name, downstream.value));
       }
     });
-  } else {
-    console.log(`No downstream assets found for ${focusAsset.name}`);
   }
 
   return { nodes, edges };

--- a/webview-ui/src/composables/useLineage.ts
+++ b/webview-ui/src/composables/useLineage.ts
@@ -27,7 +27,6 @@ export function useLineage() {
     const formattedLineage = computed(() => {
         if (lineageSuccess.value) {
             try {
-                console.log("Lineage data:", lineageSuccess.value);
                 return JSON.parse(lineageSuccess.value);
             } catch (e) {
                 console.error("Error parsing lineage data:", e);

--- a/webview-ui/src/utilities/graphGenerator.ts
+++ b/webview-ui/src/utilities/graphGenerator.ts
@@ -330,7 +330,6 @@ export const generateColumnGraph = (
   // First, add the focus asset
   const focusAsset = assetMap[focusAssetName];
   if (focusAsset) {
-    console.log(`Focus asset ${focusAssetName} downstreams:`, focusAsset.downstreams);
     nodes.push(createColumnNode(focusAsset, true, columnLineageMap[focusAssetName] || []));
     processedAssets.add(focusAssetName.toLowerCase());
 


### PR DESCRIPTION
On a large pipeline (1000+ assets), opening the pipeline.yml froze the webview to a black panel. Root cause: several `console.log`s dump the entire parsed pipeline object.

The worst offenders are in **computed properties** in `App.vue` (`parsedData.raw`, all pipeline assets, all columns), so they re-dump multiple MB to the console on every reactive update — enough to hang the webview. Asset switches were fine because that data is small; the whole-pipeline object is megabytes.

Removed:
- `App.vue`: `Pipeline config start date` (`parsedData.raw`), `Asset columns`, `Pipeline assets raw data`, `Pipeline assets`.
- Lineage column path: `useColumnLevel` (`pipelineData for columns`, `Column Result` full JSON.stringify, per-downstream logs), `graphGenerator` (focus-asset downstreams), `useLineage` (`Lineage data`).

No behavior change. 183 webview tests pass.