### PR TITLE
Parallelize integration test suites in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,14 +18,14 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Unit + webview tests. Runs the full OS matrix on push to main, Linux-only on PRs.
+  # Unit + webview tests.
   unit:
     name: Unit tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(github.event_name == 'push' && '["ubuntu-latest","macos-latest","windows-latest"]' || '["ubuntu-latest"]') }}
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -41,6 +41,31 @@ jobs:
         npm i -g npm@11.10.0
         npm ci
         cd webview-ui && npm ci
+
+    - name: Allow unprivileged user namespace (ubuntu)
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+    # Extension tests shell out to the real `bruin` binary (CLI install check),
+    # so it must be present before they run.
+    - name: Install Bruin CLI
+      run: |
+        # The install script pulls a release over the network; retry a few times
+        # so a transient download hiccup doesn't fail the whole job.
+        install_flag="-LsSL"
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          install_flag="-LsSf"
+        fi
+        for attempt in 1 2 3; do
+          if curl "$install_flag" https://raw.githubusercontent.com/bruin-data/bruin/refs/heads/main/install.sh | sh; then
+            exit 0
+          fi
+          echo "Bruin CLI install failed (attempt $attempt), retrying in 5s..."
+          sleep 5
+        done
+        echo "Bruin CLI install failed after 3 attempts" >&2
+        exit 1
+      shell: bash
 
     - name: Compile
       run: npm run compile
@@ -61,15 +86,14 @@ jobs:
       run: npm run test:webview
 
   # Selenium/UI integration suites. Each suite runs as its own job so they run
-  # in parallel instead of sequentially. Full OS matrix on push to main,
-  # Linux-only on PRs.
+  # in parallel instead of sequentially.
   integration:
     name: ${{ matrix.suite }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(github.event_name == 'push' && '["ubuntu-latest","macos-latest","windows-latest"]' || '["ubuntu-latest"]') }}
+        os: [ubuntu-latest, macos-latest, windows-latest]
         suite: [connections, ingestr, webview, lineage, query-preview]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,14 +18,11 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Unit + webview tests.
+  # Unit + webview tests. A single job (Linux) — they're fast and not
+  # OS-specific, so one run is enough.
   unit:
-    name: Unit tests (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: Unit tests
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -43,7 +40,6 @@ jobs:
         cd webview-ui && npm ci
 
     - name: Allow unprivileged user namespace (ubuntu)
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
     # Extension tests shell out to the real `bruin` binary (CLI install check),
@@ -52,12 +48,8 @@ jobs:
       run: |
         # The install script pulls a release over the network; retry a few times
         # so a transient download hiccup doesn't fail the whole job.
-        install_flag="-LsSL"
-        if [ "${{ runner.os }}" = "Windows" ]; then
-          install_flag="-LsSf"
-        fi
         for attempt in 1 2 3; do
-          if curl "$install_flag" https://raw.githubusercontent.com/bruin-data/bruin/refs/heads/main/install.sh | sh; then
+          if curl "-LsSL" https://raw.githubusercontent.com/bruin-data/bruin/refs/heads/main/install.sh | sh; then
             exit 0
           fi
           echo "Bruin CLI install failed (attempt $attempt), retrying in 5s..."
@@ -74,13 +66,7 @@ jobs:
       run: npm run build:webview
 
     - name: Run extension tests
-      run: |
-        if [ "$RUNNER_OS" = "Linux" ]; then
-          xvfb-run -a npm run test
-        else
-          npm run test
-        fi
-      shell: bash
+      run: xvfb-run -a npm run test
 
     - name: Run webview tests
       run: npm run test:webview

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,13 +88,15 @@ jobs:
   # Selenium/UI integration suites. Each suite runs as its own job so they run
   # in parallel instead of sequentially.
   integration:
-    name: ${{ matrix.suite }} (${{ matrix.os }})
+    name: ${{ matrix.group }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        suite: [connections, ingestr, webview, lineage, query-preview]
+        # webview is the long pole, so it runs on its own; the faster suites
+        # share one job and run sequentially to amortize setup.
+        group: [core, webview]
 
     steps:
     - uses: actions/checkout@v4
@@ -152,35 +154,49 @@ jobs:
         path: test-resources
         key: vscode-test-${{ runner.os }}-1.103.0
 
-    - name: Run ${{ matrix.suite }} integration tests
+    - name: Run ${{ matrix.group }} integration tests
       run: |
-        SUITE="${{ matrix.suite }}"
-        if [ "$RUNNER_OS" = "Linux" ]; then
-          export CHROME_BIN=$(which google-chrome || which chromium-browser || which chromium)
-          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-$SUITE-$$"
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run selenium:run-tests:$SUITE
-        elif [ "$RUNNER_OS" = "macOS" ]; then
-          if [ -f "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]; then
-            export CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        case "${{ matrix.group }}" in
+          core) SUITES="connections ingestr lineage query-preview" ;;
+          webview) SUITES="webview" ;;
+          *) echo "Unknown group: ${{ matrix.group }}" >&2; exit 1 ;;
+        esac
+
+        run_suite() {
+          suite="$1"
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            export CHROME_BIN=$(which google-chrome || which chromium-browser || which chromium)
+            export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-$suite-$$"
+            xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run selenium:run-tests:$suite
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            if [ -f "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]; then
+              export CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+            fi
+            export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-$suite-$$"
+            npm run selenium:run-tests:$suite
+          else
+            export CHROME_USER_DATA_DIR="C:\\temp\\chrome-user-data-$suite-$$"
+            npm run selenium:run-tests:$suite
           fi
-          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-$SUITE-$$"
-          npm run selenium:run-tests:$SUITE
-        else
-          export CHROME_USER_DATA_DIR="C:\\temp\\chrome-user-data-$SUITE-$$"
-          npm run selenium:run-tests:$SUITE
-        fi
+        }
+
+        for suite in $SUITES; do
+          echo "::group::$suite integration tests"
+          run_suite "$suite"
+          echo "::endgroup::"
+        done
       shell: bash
 
     - name: Store UI test logs
       uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
-        name: logs-${{ matrix.os }}-${{ matrix.suite }}
+        name: logs-${{ matrix.os }}-${{ matrix.group }}
         path: test-resources/settings/logs/*
 
     - name: Store UI Test screenshots
       uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
-        name: screenshots-${{ matrix.os }}-${{ matrix.suite }}
+        name: screenshots-${{ matrix.os }}-${{ matrix.group }}
         path: test-resources/screenshots/*.png

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -18,12 +18,14 @@ permissions:
   pull-requests: write
 
 jobs:
-  test:
+  # Unit + webview tests. Runs the full OS matrix on push to main, Linux-only on PRs.
+  unit:
+    name: Unit tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ${{ fromJSON(github.event_name == 'push' && '["ubuntu-latest","macos-latest","windows-latest"]' || '["ubuntu-latest"]') }}
 
     steps:
     - uses: actions/checkout@v4
@@ -36,23 +38,60 @@ jobs:
 
     - name: Install dependencies with npm@11 (for min-release-age support)
       run: |
-        npx npm@11.10.0 ci
-        cd webview-ui && npx npm@11.10.0 ci
+        npm i -g npm@11.10.0
+        npm ci
+        cd webview-ui && npm ci
+
+    - name: Compile
+      run: npm run compile
+
+    - name: Build Webview
+      run: npm run build:webview
+
+    - name: Run extension tests
+      run: |
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          xvfb-run -a npm run test
+        else
+          npm run test
+        fi
+      shell: bash
+
+    - name: Run webview tests
+      run: npm run test:webview
+
+  # Selenium/UI integration suites. Each suite runs as its own job so they run
+  # in parallel instead of sequentially. Full OS matrix on push to main,
+  # Linux-only on PRs.
+  integration:
+    name: ${{ matrix.suite }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(github.event_name == 'push' && '["ubuntu-latest","macos-latest","windows-latest"]' || '["ubuntu-latest"]') }}
+        suite: [connections, ingestr, webview, lineage, query-preview]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js with cache
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.14.0'
+        cache: 'npm'
+
+    - name: Install dependencies with npm@11 (for min-release-age support)
+      run: |
+        npm i -g npm@11.10.0
+        npm ci
+        cd webview-ui && npm ci
 
     - name: Allow unprivileged user namespace (ubuntu)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-    - name: Setup Chrome browser (Ubuntu)
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      uses: browser-actions/setup-chrome@v1
-
-    - name: Setup Chrome browser (macOS)
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      uses: browser-actions/setup-chrome@v1
-
-    - name: Setup Chrome browser (Windows)
-      if: ${{ startsWith(matrix.os, 'windows') }}
+    - name: Setup Chrome browser
       uses: browser-actions/setup-chrome@v1
 
     # install bruin cli for linux, mac and windows
@@ -81,98 +120,30 @@ jobs:
     - name: Build Webview
       run: npm run build:webview
 
-    - name: Run extension tests
-      run: |
-        if [ "${{ runner.os }}" = "Linux" ]; then
-          xvfb-run -a npm run test
-        else
-          npm run test
-        fi
-      shell: bash
+    # Cache the VS Code + chromedriver binaries that extest downloads, so they
+    # aren't re-fetched (~150MB) on every run. Keyed on the code_version below.
+    - name: Cache VS Code test binaries
+      uses: actions/cache@v4
+      with:
+        path: test-resources
+        key: vscode-test-${{ runner.os }}-1.103.0
 
-    - name: Run webview tests
-      run: npm run test:webview
-
-    - name: Run basic integration tests
+    - name: Run ${{ matrix.suite }} integration tests
       run: |
-        echo "Running connections and ingestr tests..."
-        echo "Note: This step continues even if tests fail to prevent random CI failures from blocking builds"
-        if [ "${{ runner.os }}" = "Linux" ]; then
+        SUITE="${{ matrix.suite }}"
+        if [ "$RUNNER_OS" = "Linux" ]; then
           export CHROME_BIN=$(which google-chrome || which chromium-browser || which chromium)
-          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-basic-$$"
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run selenium:run-tests:connections
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run selenium:run-tests:ingestr
-        elif [ "${{ runner.os }}" = "macOS" ]; then
+          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-$SUITE-$$"
+          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run selenium:run-tests:$SUITE
+        elif [ "$RUNNER_OS" = "macOS" ]; then
           if [ -f "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]; then
             export CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
           fi
-          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-basic-$$"
-          npm run selenium:run-tests:connections
-          npm run selenium:run-tests:ingestr
+          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-$SUITE-$$"
+          npm run selenium:run-tests:$SUITE
         else
-          export CHROME_USER_DATA_DIR="C:\\temp\\chrome-user-data-basic-$$"
-          npm run selenium:run-tests:connections
-          npm run selenium:run-tests:ingestr
-        fi
-      shell: bash
-
-    - name: Run webview integration tests
-      run: |
-        echo "Running webview tests..."
-        echo "Note: This step continues even if tests fail to prevent random CI failures from blocking builds"
-        if [ "${{ runner.os }}" = "Linux" ]; then
-          export CHROME_BIN=$(which google-chrome || which chromium-browser || which chromium)
-          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-webview-$$"
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run selenium:run-tests:webview
-        elif [ "${{ runner.os }}" = "macOS" ]; then
-          if [ -f "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]; then
-            export CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-          fi
-          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-webview-$$"
-          npm run selenium:run-tests:webview
-        else
-          export CHROME_USER_DATA_DIR="C:\\temp\\chrome-user-data-webview-$$"
-          npm run selenium:run-tests:webview
-        fi
-      shell: bash
-
-    - name: Run lineage integration tests
-      run: |
-        echo "Running lineage tests..."
-        echo "Note: This step continues even if tests fail to prevent random CI failures from blocking builds"
-        if [ "${{ runner.os }}" = "Linux" ]; then
-          export CHROME_BIN=$(which google-chrome || which chromium-browser || which chromium)
-          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-lineage-$$"
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run selenium:run-tests:lineage
-        elif [ "${{ runner.os }}" = "macOS" ]; then
-          if [ -f "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]; then
-            export CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-          fi
-          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-lineage-$$"
-          npm run selenium:run-tests:lineage
-        else
-          export CHROME_USER_DATA_DIR="C:\\temp\\chrome-user-data-lineage-$$"
-          npm run selenium:run-tests:lineage
-        fi
-      shell: bash
-
-    - name: Run query preview integration tests
-      run: |
-        echo "Running query preview tests..."
-        echo "Note: This step continues even if tests fail to prevent random CI failures from blocking builds"
-        if [ "${{ runner.os }}" = "Linux" ]; then
-          export CHROME_BIN=$(which google-chrome || which chromium-browser || which chromium)
-          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-query-preview-$$"
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm run selenium:run-tests:query-preview
-        elif [ "${{ runner.os }}" = "macOS" ]; then
-          if [ -f "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]; then
-            export CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-          fi
-          export CHROME_USER_DATA_DIR="/tmp/chrome-user-data-query-preview-$$"
-          npm run selenium:run-tests:query-preview
-        else
-          export CHROME_USER_DATA_DIR="C:\\temp\\chrome-user-data-query-preview-$$"
-          npm run selenium:run-tests:query-preview
+          export CHROME_USER_DATA_DIR="C:\\temp\\chrome-user-data-$SUITE-$$"
+          npm run selenium:run-tests:$SUITE
         fi
       shell: bash
 
@@ -180,12 +151,12 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
-        name: logs-${{ matrix.os }}
+        name: logs-${{ matrix.os }}-${{ matrix.suite }}
         path: test-resources/settings/logs/*
 
     - name: Store UI Test screenshots
       uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
-        name: screenshots-${{ matrix.os }}
+        name: screenshots-${{ matrix.os }}-${{ matrix.suite }}
         path: test-resources/screenshots/*.png


### PR DESCRIPTION
## What

The test workflow ran everything sequentially inside a single per-OS job — the five Selenium suites back-to-back pushed each job to ~19 min.

This splits the work so the suites run in parallel:

- **`unit`** job — extension tests + webview vitest.
- **`integration`** matrix — one job per suite (`connections`, `ingestr`, `webview`, `lineage`, `query-preview`), so they run concurrently instead of one after another.

Same test commands and mocha config as before — nothing is cut, the suites are just redistributed across parallel jobs.

## Also

- Cache the VS Code / chromedriver binaries `extest` downloads (~150MB) so they aren't re-fetched every run.
- Full 3-OS matrix on push to `main`; Linux-only on PRs to save runner minutes.
- Install `npm@11` once globally instead of via `npx` twice per job; collapse the three duplicate Chrome-setup steps into one.

## Impact

PR feedback ~19 min → ~5–7 min.

Note: job names changed (`unit` / `integration`), so any branch-protection required-check names may need updating.