### PR TITLE
Speed up the asset lineage panel

### DIFF
--- a/src/bruin/bruinFlowLineage.ts
+++ b/src/bruin/bruinFlowLineage.ts
@@ -96,8 +96,7 @@ export class BruinLineageInternalParse extends BruinCommand {
       // assets of the same pipeline reuses it instead of re-running the CLI.
       const cache = getPipelineLineageCache();
       const cacheKey = isPipelineFile ? path.dirname(filePath) : pipelinePath;
-      // TEMP: cache read disabled to check whether it causes the lineage weirdness.
-      let result: string | undefined = undefined;
+      let result = cache.get(cacheKey, includeColumns);
       if (result === undefined) {
         result = await this.run([...enhancedFlags, pipelinePath], { ignoresErrors });
         // Never cache empty output (e.g. ignoresErrors swallowed a failure).

--- a/src/bruin/bruinFlowLineage.ts
+++ b/src/bruin/bruinFlowLineage.ts
@@ -96,7 +96,8 @@ export class BruinLineageInternalParse extends BruinCommand {
       // assets of the same pipeline reuses it instead of re-running the CLI.
       const cache = getPipelineLineageCache();
       const cacheKey = isPipelineFile ? path.dirname(filePath) : pipelinePath;
-      let result = cache.get(cacheKey, includeColumns);
+      // TEMP: cache read disabled to check whether it causes the lineage weirdness.
+      let result: string | undefined = undefined;
       if (result === undefined) {
         result = await this.run([...enhancedFlags, pipelinePath], { ignoresErrors });
         // Never cache empty output (e.g. ignoresErrors swallowed a failure).

--- a/src/bruin/bruinFlowLineage.ts
+++ b/src/bruin/bruinFlowLineage.ts
@@ -3,8 +3,10 @@ import { BruinCommand } from "./bruinCommand";
 import { updateLineageData } from "../panels/LineagePanel";
 import { getCurrentPipelinePath } from "./bruinUtils";
 import * as vscode from "vscode";
+import * as path from "path";
 import { isConfigFile } from "../utilities/helperUtils";
 import { BruinPanel } from "../panels/BruinPanel";
+import { getPipelineLineageCache } from "../providers/PipelineLineageCacheService";
 
 export class BruinLineageInternalParse extends BruinCommand {
   
@@ -89,7 +91,19 @@ export class BruinLineageInternalParse extends BruinCommand {
         : flags;
       
       const pipelinePath = isPipelineFile ? filePath : await getCurrentPipelinePath(filePath) as string;
-      const result = await this.run([...enhancedFlags, pipelinePath], { ignoresErrors });
+
+      // Cache raw parse output per pipeline directory so switching between
+      // assets of the same pipeline reuses it instead of re-running the CLI.
+      const cache = getPipelineLineageCache();
+      const cacheKey = isPipelineFile ? path.dirname(filePath) : pipelinePath;
+      let result = cache.get(cacheKey, includeColumns);
+      if (result === undefined) {
+        result = await this.run([...enhancedFlags, pipelinePath], { ignoresErrors });
+        // Never cache empty output (e.g. ignoresErrors swallowed a failure).
+        if (result) {
+          cache.set(cacheKey, result, includeColumns);
+        }
+      }
       const pipelineData = JSON.parse(result);
       
       if(panel === "BruinPanel"){

--- a/src/panels/LineagePanel.ts
+++ b/src/panels/LineagePanel.ts
@@ -3,6 +3,8 @@ import { getNonce } from "../utilities/getNonce";
 import { getUri } from "../utilities/getUri";
 import { flowLineageCommand } from "../extension/commands/FlowLineageCommand";
 import { trackEvent } from "../extension/extension";
+import { getCurrentPipelinePath } from "../bruin/bruinUtils";
+import { getPipelineLineageCache } from "../providers/PipelineLineageCacheService";
 
 export class LineagePanel implements vscode.WebviewViewProvider, vscode.Disposable {
   private static instance: LineagePanel;
@@ -122,11 +124,23 @@ export abstract class BaseLineagePanel implements vscode.WebviewViewProvider, vs
     if (this._docChangeDebounceTimer) {
       clearTimeout(this._docChangeDebounceTimer);
     }
-    this._docChangeDebounceTimer = setTimeout(() => {
+    this._docChangeDebounceTimer = setTimeout(async () => {
       this._docChangeDebounceTimer = undefined;
+      // The document changed, so any cached parse for its pipeline is stale.
+      await this.invalidateCacheForCurrentDoc();
       this.loadLineageData();
     }, BaseLineagePanel.docChangeDebounceMs);
   }
+
+  private invalidateCacheForCurrentDoc = async () => {
+    if (!this._lastRenderedDocumentUri) {
+      return;
+    }
+    const pipelineDir = await getCurrentPipelinePath(this._lastRenderedDocumentUri.fsPath);
+    if (pipelineDir) {
+      getPipelineLineageCache().invalidate(pipelineDir);
+    }
+  };
 
   protected loadLineageData = async () => {
     if (this._lastRenderedDocumentUri) {

--- a/src/panels/LineagePanel.ts
+++ b/src/panels/LineagePanel.ts
@@ -145,9 +145,10 @@ export abstract class BaseLineagePanel implements vscode.WebviewViewProvider, vs
   protected loadLineageData = async () => {
     if (this._lastRenderedDocumentUri) {
       try {
-        // -c up front: the webview toggles to the column view without a
-        // round-trip, so the column data must already be present.
-        await flowLineageCommand(this._lastRenderedDocumentUri, undefined, true);
+        // Plain parse only (no -c): the fast path. Column-level lineage is
+        // fetched on demand via bruin.fetchColumnLineage when the column view
+        // is opened, since -c is far slower than the plain parse.
+        await flowLineageCommand(this._lastRenderedDocumentUri, undefined, false);
       } catch (error) {
         console.error("❌ [LineagePanel] Error loading lineage data:", error);
       }

--- a/src/panels/LineagePanel.ts
+++ b/src/panels/LineagePanel.ts
@@ -332,6 +332,16 @@ export abstract class BaseLineagePanel implements vscode.WebviewViewProvider, vs
           }
           this.refresh(vscode.window.activeTextEditor!!);
           break;
+        case "bruin.fetchColumnLineage":
+          // On-demand column-level lineage (-c): only fetched when the user
+          // opens the Column view, since -c is far slower than the plain parse.
+          trackEvent("Command Executed", { command: "fetchColumnLineage", source: "extension" });
+          if (this._lastRenderedDocumentUri) {
+            flowLineageCommand(this._lastRenderedDocumentUri, undefined, true).catch((err) =>
+              console.error("[LineagePanel] on-demand column fetch failed", err)
+            );
+          }
+          break;
       }
     })
     );

--- a/src/panels/LineagePanel.ts
+++ b/src/panels/LineagePanel.ts
@@ -85,7 +85,13 @@ export abstract class BaseLineagePanel implements vscode.WebviewViewProvider, vs
     this.disposables.push(
       vscode.window.onDidChangeActiveTextEditor((event: vscode.TextEditor | undefined) => {
         if (event && event.document.uri.scheme !== "vscodebruin:panel") {
+          const changedFile = this._lastRenderedDocumentUri?.fsPath !== event.document.uri.fsPath;
           this._lastRenderedDocumentUri = event?.document.uri;
+          // On a real file switch, tell the panel a parse is coming so it shows
+          // loading instead of leaving the previous graph on screen.
+          if (changedFile) {
+            this.postLoading();
+          }
           this.loadLineageData();
           this.initPanel(event);
         }
@@ -175,6 +181,17 @@ export abstract class BaseLineagePanel implements vscode.WebviewViewProvider, vs
     }
     await this.resolveWebviewView(this._view, this.context!, this.token!);
   };
+
+  // Tell the webview a new parse is in flight so it shows loading instead of
+  // the previous graph.
+  private postLoading() {
+    if (this._view) {
+      this._view.webview.postMessage({
+        command: "flow-lineage-loading",
+        panelType: this.panelType,
+      });
+    }
+  }
 
   protected onDataUpdated(data: any) {
     // Post even when the view is hidden: with retainContextWhenHidden the

--- a/src/providers/PipelineLineageCacheService.ts
+++ b/src/providers/PipelineLineageCacheService.ts
@@ -1,0 +1,70 @@
+import * as vscode from "vscode";
+import * as path from "path";
+
+interface CacheEntry {
+  raw: string;
+  hasColumns: boolean;
+}
+
+/**
+ * Caches raw `bruin internal parse-pipeline` output per pipeline so switching
+ * assets of the same pipeline reuses it instead of re-running the CLI. A
+ * with-columns (`-c`) entry can serve a no-column request, but not vice versa.
+ */
+export class PipelineLineageCacheService {
+  private static instance: PipelineLineageCacheService;
+  private cache = new Map<string, CacheEntry>();
+
+  private constructor() {
+    // A different Bruin binary can produce different output.
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("bruin.executable")) {
+        this.invalidateAll();
+      }
+    });
+  }
+
+  public static getInstance(): PipelineLineageCacheService {
+    if (!PipelineLineageCacheService.instance) {
+      PipelineLineageCacheService.instance = new PipelineLineageCacheService();
+    }
+    return PipelineLineageCacheService.instance;
+  }
+
+  public get(pipelinePath: string, needColumns: boolean): string | undefined {
+    const entry = this.cache.get(pipelinePath);
+    if (!entry) {
+      return undefined;
+    }
+    if (needColumns && !entry.hasColumns) {
+      return undefined;
+    }
+    return entry.raw;
+  }
+
+  public set(pipelinePath: string, raw: string, hasColumns: boolean): void {
+    const existing = this.cache.get(pipelinePath);
+    // Never downgrade a with-columns entry to a no-column one.
+    if (existing?.hasColumns && !hasColumns) {
+      return;
+    }
+    this.cache.set(pipelinePath, { raw, hasColumns });
+  }
+
+  /** Drop cached entries for the pipeline rooted at `pipelineDir`. */
+  public invalidate(pipelineDir: string): void {
+    for (const key of this.cache.keys()) {
+      if (key === pipelineDir || key.startsWith(pipelineDir + path.sep) || key.startsWith(pipelineDir + "/")) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  public invalidateAll(): void {
+    this.cache.clear();
+  }
+}
+
+export function getPipelineLineageCache(): PipelineLineageCacheService {
+  return PipelineLineageCacheService.getInstance();
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -52,6 +52,7 @@ import {
 } from "../bruin/bruinConnections";
 import { BruinPanel } from "../panels/BruinPanel";
 import { LineagePanel } from "../panels/LineagePanel";
+import { getPipelineLineageCache } from "../providers/PipelineLineageCacheService";
 import { BruinLineage, BruinRender, BruinValidate } from "../bruin";
 import { renderCommand, renderCommandWithFlags } from "../extension/commands/renderCommand";
 import {
@@ -4132,6 +4133,9 @@ suite(" Query export Tests", () => {
       
       const lineagePanelModule = await import("../panels/LineagePanel");
       sinon.replace(lineagePanelModule, "updateLineageData", updateLineageDataStub);
+
+      // The parse cache is a singleton; clear it so each test triggers a real run.
+      getPipelineLineageCache().invalidateAll();
     });
 
     teardown(() => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -4543,9 +4543,9 @@ suite(" Query export Tests", () => {
         await baseLineagePanel.loadLineageData();
 
         sinon.assert.calledOnce(flowLineageCommandStub);
-        // Must request column-level lineage (-c) so the panel's "Column Level
-        // Lineage" view has the column data it needs.
-        sinon.assert.calledWith(flowLineageCommandStub, testUri, undefined, true);
+        // Plain parse only (no -c); column lineage is fetched on demand when the
+        // column view is opened.
+        sinon.assert.calledWith(flowLineageCommandStub, testUri, undefined, false);
       });
 
       test("should not load lineage data when no URI", async () => {

--- a/src/ui-test/lineage-integration.test.ts
+++ b/src/ui-test/lineage-integration.test.ts
@@ -592,10 +592,11 @@ describe("Lineage Panel Integration Tests", function () {
         const ariaHiddenElements = await driver.findElements(By.css("[aria-hidden='true']"));
         console.log(`✓ Found ${ariaHiddenElements.length} aria-hidden elements`);
         
-        // Check for accessibility descriptions
-        const nodeDesc = await driver.findElements(By.css("#vue-flow__node-desc-vue-flow-0"));
-        const edgeDesc = await driver.findElements(By.css("#vue-flow__edge-desc-vue-flow-0"));
-        const ariaLive = await driver.findElements(By.css("#vue-flow__aria-live-vue-flow-0"));
+        // Check for accessibility descriptions (each view has its own Vue Flow
+        // instance id; the asset view uses "asset-lineage-flow").
+        const nodeDesc = await driver.findElements(By.css("#vue-flow__node-desc-asset-lineage-flow"));
+        const edgeDesc = await driver.findElements(By.css("#vue-flow__edge-desc-asset-lineage-flow"));
+        const ariaLive = await driver.findElements(By.css("#vue-flow__aria-live-asset-lineage-flow"));
         
         assert(nodeDesc.length > 0, "Should have node description for accessibility");
         assert(edgeDesc.length > 0, "Should have edge description for accessibility");

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -439,13 +439,9 @@ const handleMessage = (event: MessageEvent) => {
               activeTab.value = settingsIndex;
             }
           }
-          
-          // Auto-trigger lineage for pipeline.yml files
-          const isPipelineConfigFile = filePath.endsWith("pipeline.yml") || filePath.endsWith("pipeline.yaml");
-          if (isPipelineConfigFile) {
-            // Trigger lineage panel and show pipeline view
-            vscode.postMessage({ command: "bruin.showPipelineLineage" });
-          }
+          // Note: the lineage panel loads the pipeline view itself on file
+          // switch, so no separate showPipelineLineage trigger is needed here
+          // (it would cause a redundant second parse + rebuild).
         } catch (_) {}
         // Ask backend for status and details; relevant files will update via parse-message
         vscode.postMessage({ command: "checkBruinCliInstallation" });

--- a/webview-ui/src/AssetLineage.vue
+++ b/webview-ui/src/AssetLineage.vue
@@ -41,7 +41,6 @@ const handleMessage = (event) => {
     case "flow-lineage-loading":
       // A new parse started (file switch / edit): show loading instead of the
       // previous graph so stale content isn't left on screen.
-      console.log(`[LT] recv loading t=${Math.round(performance.now())}`);
       isReloading.value = true;
       lineageError.value = undefined;
       return;
@@ -49,7 +48,6 @@ const handleMessage = (event) => {
       isReloading.value = false;
       const newData = updateValue(message, "success");
       const newError = updateValue(message, "error");
-      console.log(`[LT] recv message isPipelineView=${!!newData?.isPipelineView} id=${newData?.id ?? "-"} name=${newData?.name ?? "-"} err=${!!newError} t=${Math.round(performance.now())}`);
       
       // Create a detailed hash to detect truly identical messages
       const messageId = JSON.stringify({ 
@@ -62,7 +60,6 @@ const handleMessage = (event) => {
       
       // Skip if this is the exact same message we just processed
       if (messageId === lastMessageId && messageId !== 'null') {
-        console.log(`[LT] skip duplicate message t=${Math.round(performance.now())}`);
         return;
       }
       lastMessageId = messageId;

--- a/webview-ui/src/AssetLineage.vue
+++ b/webview-ui/src/AssetLineage.vue
@@ -24,6 +24,7 @@ import { getAssetDataset } from "@/components/lineage-flow/asset-lineage/useAsse
 const lineageData = ref(); // Holds the lineage data received from the extension
 const lineageError = ref(); // Holds any errors related to lineage data
 const hasTimedOut = ref(false); // Tracks if initial load has timed out
+const isReloading = ref(false); // A new parse is in flight (file switch / edit)
 
 let lastMessageId: string | null = null;
 
@@ -37,7 +38,14 @@ const handleMessage = (event) => {
   if (message.panelType !== "AssetLineage") return;
   
   switch (message.command) {
+    case "flow-lineage-loading":
+      // A new parse started (file switch / edit): show loading instead of the
+      // previous graph so stale content isn't left on screen.
+      isReloading.value = true;
+      lineageError.value = undefined;
+      return;
     case "flow-lineage-message":
+      isReloading.value = false;
       const newData = updateValue(message, "success");
       const newError = updateValue(message, "error");
       
@@ -103,7 +111,7 @@ const assetDataset = computed(() => {
 });
 
 const pipelineData = computed(() => pipeline.value);
-const isLoading = computed(() => !lineageData.value && !lineageError.value && !hasTimedOut.value);
+const isLoading = computed(() => !hasTimedOut.value && (isReloading.value || (!lineageData.value && !lineageError.value)));
 
 onMounted(() => {
   console.log('🚀 [AssetLineage] Component mounted');

--- a/webview-ui/src/AssetLineage.vue
+++ b/webview-ui/src/AssetLineage.vue
@@ -41,6 +41,7 @@ const handleMessage = (event) => {
     case "flow-lineage-loading":
       // A new parse started (file switch / edit): show loading instead of the
       // previous graph so stale content isn't left on screen.
+      console.log(`[LT] recv loading t=${Math.round(performance.now())}`);
       isReloading.value = true;
       lineageError.value = undefined;
       return;
@@ -48,6 +49,7 @@ const handleMessage = (event) => {
       isReloading.value = false;
       const newData = updateValue(message, "success");
       const newError = updateValue(message, "error");
+      console.log(`[LT] recv message isPipelineView=${!!newData?.isPipelineView} id=${newData?.id ?? "-"} name=${newData?.name ?? "-"} err=${!!newError} t=${Math.round(performance.now())}`);
       
       // Create a detailed hash to detect truly identical messages
       const messageId = JSON.stringify({ 
@@ -60,7 +62,7 @@ const handleMessage = (event) => {
       
       // Skip if this is the exact same message we just processed
       if (messageId === lastMessageId && messageId !== 'null') {
-        console.log('⚡ [AssetLineage] Skipping duplicate message');
+        console.log(`[LT] skip duplicate message t=${Math.round(performance.now())}`);
         return;
       }
       lastMessageId = messageId;

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -864,14 +864,22 @@ const buildPipelineElements = async () => {
     pipelineElements.value = { nodes: [], edges: [] };
     return;
   }
-  const lineageData = buildPipelineLineage(props.pipelineData);
-  const { nodes: initialNodes, edges: initialEdges } = (await import("@/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder")).generateGraph(
-    lineageData,
-    props.assetDataset?.name || ""
-  );
-  const { nodes: layoutNodes, edges: layoutEdges } = await applyPipelineLayout(initialNodes, initialEdges);
-  pipelineElements.value = { nodes: layoutNodes, edges: layoutEdges };
-  console.log(`[LT] buildPipeline DONE nodes=${layoutNodes.length} edges=${layoutEdges.length} t=${Math.round(performance.now())}`);
+  // Clear the previous pipeline's graph and show loading so the stale graph
+  // isn't left on screen while this (possibly slow) build runs.
+  pipelineElements.value = { nodes: [], edges: [] };
+  isLayouting.value = true;
+  try {
+    const lineageData = buildPipelineLineage(props.pipelineData);
+    const { nodes: initialNodes, edges: initialEdges } = (await import("@/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder")).generateGraph(
+      lineageData,
+      props.assetDataset?.name || ""
+    );
+    const { nodes: layoutNodes, edges: layoutEdges } = await applyPipelineLayout(initialNodes, initialEdges);
+    pipelineElements.value = { nodes: layoutNodes, edges: layoutEdges };
+    console.log(`[LT] buildPipeline DONE nodes=${layoutNodes.length} edges=${layoutEdges.length} t=${Math.round(performance.now())}`);
+  } finally {
+    isLayouting.value = false;
+  }
 };
 
 const onPipelineNodesInitialized = async () => {
@@ -1062,25 +1070,33 @@ const buildColumnElements = async () => {
   }
   columnFetchPending.value = false;
   error.value = null;
-  const lineageData = buildColumnLineage(newPipelineData);
-  // In pipeline view there is no single focus asset, so render column lineage
-  // across every asset in the pipeline instead of centering on one.
-  const isPipelineView = Boolean((props.assetDataset as any)?.isPipelineView);
-  const { nodes: initialNodes, edges: initialEdges } = isPipelineView
-    ? generateColumnGraphForPipeline(lineageData)
-    : generateColumnGraph(lineageData, props.assetDataset?.name || "");
-  const { nodes: layoutNodes, edges: layoutEdges } = await applyPipelineLayout(initialNodes, initialEdges);
+  // Clear the previous graph and show loading so a stale column graph isn't
+  // left on screen while this build runs.
+  columnElements.value = { nodes: [], edges: [] };
+  isLayouting.value = true;
+  try {
+    const lineageData = buildColumnLineage(newPipelineData);
+    // In pipeline view there is no single focus asset, so render column lineage
+    // across every asset in the pipeline instead of centering on one.
+    const isPipelineView = Boolean((props.assetDataset as any)?.isPipelineView);
+    const { nodes: initialNodes, edges: initialEdges } = isPipelineView
+      ? generateColumnGraphForPipeline(lineageData)
+      : generateColumnGraph(lineageData, props.assetDataset?.name || "");
+    const { nodes: layoutNodes, edges: layoutEdges } = await applyPipelineLayout(initialNodes, initialEdges);
 
-  // Save original positions for recalculation
-  originalColumnNodePositions.value = {};
-  layoutNodes.forEach(node => {
-    originalColumnNodePositions.value[node.id] = {
-      x: node.position.x,
-      y: node.position.y
-    };
-  });
+    // Save original positions for recalculation
+    originalColumnNodePositions.value = {};
+    layoutNodes.forEach(node => {
+      originalColumnNodePositions.value[node.id] = {
+        x: node.position.x,
+        y: node.position.y
+      };
+    });
 
-  columnElements.value = { nodes: layoutNodes, edges: layoutEdges };
+    columnElements.value = { nodes: layoutNodes, edges: layoutEdges };
+  } finally {
+    isLayouting.value = false;
+  }
 };
 
 const onColumnNodesInitialized = async () => {

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -594,6 +594,10 @@ const processProperties = async () => {
   
   // Don't set loading states here - let _updateGraph handle it
   error.value = null;
+  // updateGraph is debounced, so clear the previous asset's graph now to avoid
+  // showing it for the debounce window before the new one is built.
+  setNodes([]);
+  setEdges([]);
   console.log('🔄 [Lineage] Starting graph update');
   try {
     await updateGraph();

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -498,7 +498,6 @@ const onNodesDragged = (draggedNodes: NodeDragEvent[]) => {
 // Fit view helper - now with smart auto-fit logic
 const fitViewSmooth = async (forceAutoFit = false, useAnimation = false) => {
   await nextTick();
-  console.log(`[LT] fitViewSmooth force=${forceAutoFit} shouldAutoFit=${shouldAutoFit.value} view=${showColumnView.value ? "column" : showPipelineView.value ? "pipeline" : "asset"} t=${Math.round(performance.now())}`);
 
   // Only auto-fit if explicitly requested or first load
   if (!forceAutoFit && !shouldAutoFit.value) {
@@ -523,7 +522,6 @@ const fitViewSmooth = async (forceAutoFit = false, useAnimation = false) => {
 };
 
 const _updateGraph = async () => {
-  console.log(`[LT] _updateGraph START asset=${props.assetDataset?.name ?? "?"} t=${Math.round(performance.now())}`);
   if (!showPipelineView.value && !showColumnView.value) {
     isLoadingLocal.value = true;
     isLayouting.value = true;
@@ -770,7 +768,6 @@ let lastViewKey = "";
 // Default view for the current target: pipeline view for a pipeline, else asset.
 const selectDefaultViewForTarget = () => {
   const isPipeline = Boolean((props.assetDataset as any)?.isPipelineView);
-  console.log(`[LT] selectDefaultView isPipeline=${isPipeline} hasPipelineData=${!!props.pipelineData} t=${Math.round(performance.now())}`);
   showColumnView.value = false;
   showPipelineView.value = isPipeline;
   if (isPipeline) {
@@ -800,7 +797,6 @@ watch(
   () => [props.assetDataset, props.pipelineData],
   () => {
     const key = computeTargetKey();
-    console.log(`[LT] dataWatch key=${key} lastViewKey=${lastViewKey} changed=${key !== lastViewKey} hasAsset=${!!props.assetDataset} showPipeline=${showPipelineView.value} showColumn=${showColumnView.value} t=${Math.round(performance.now())}`);
     if (!props.assetDataset) return;
 
     if (key !== lastViewKey) {
@@ -812,13 +808,10 @@ watch(
 
     // Same target refreshed: rebuild the current view instead of snapping away.
     if (showColumnView.value) {
-      console.log("[LT] dataWatch -> refresh column");
       buildColumnElements();
     } else if (showPipelineView.value) {
-      console.log("[LT] dataWatch -> refresh pipeline");
       buildPipelineElements();
     } else {
-      console.log("[LT] dataWatch -> refresh asset");
       processProperties();
     }
   },
@@ -877,7 +870,6 @@ const onPipelineNodeClick = (nodeId: string) => {
 };
 
 const buildPipelineElements = async () => {
-  console.log(`[LT] buildPipeline START assets=${(props.pipelineData as any)?.assets?.length ?? "NONE"} t=${Math.round(performance.now())}`);
   if (!props.pipelineData) {
     pipelineElements.value = { nodes: [], edges: [] };
     return;
@@ -894,7 +886,6 @@ const buildPipelineElements = async () => {
     );
     const { nodes: layoutNodes, edges: layoutEdges } = await applyPipelineLayout(initialNodes, initialEdges);
     pipelineElements.value = { nodes: layoutNodes, edges: layoutEdges };
-    console.log(`[LT] buildPipeline DONE nodes=${layoutNodes.length} edges=${layoutEdges.length} t=${Math.round(performance.now())}`);
   } finally {
     isBuildingView.value = false;
   }
@@ -1070,7 +1061,6 @@ const onColumnNodeClick = (nodeId: string) => {
 
 const buildColumnElements = async () => {
   const newPipelineData = props.pipelineData;
-  console.log(`[LT] buildColumn START hasColumns=${hasColumnLineageData(newPipelineData)} pending=${columnFetchPending.value} t=${Math.round(performance.now())}`);
   if (!newPipelineData) {
     columnElements.value = { nodes: [], edges: [] };
     return;

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -8,6 +8,7 @@
     <!-- Asset View -->
     <VueFlow
       v-if="shouldShowAssetView"
+      :id="ASSET_FLOW_ID"
       v-model:elements="elements"
       :fit-view-on-init="false"
       class="basic-flow"
@@ -66,6 +67,7 @@
     <!-- Pipeline View (no special filter controls; use Asset behavior) -->
     <VueFlow
       v-if="showPipelineView"
+      :id="PIPELINE_FLOW_ID"
       :nodes="pipelineElements.nodes"
       :edges="pipelineElements.edges"
       @nodesInitialized="onPipelineNodesInitialized"
@@ -116,6 +118,7 @@
     <!-- Column Level View -->
     <VueFlow
       v-if="showColumnView"
+      :id="COLUMN_FLOW_ID"
       :nodes="columnElements.nodes"
       :edges="columnElements.edges"
       @nodesInitialized="onColumnNodesInitialized"
@@ -261,9 +264,17 @@ const shouldShowAssetView = computed(() => {
   return !showPipelineView.value && !showColumnView.value && !shouldShowLoading.value;
 });
 
+// Each view gets its own Vue Flow instance id so their viewports don't leak
+// into each other (e.g. the pipeline zoom carrying into the asset view).
+const ASSET_FLOW_ID = "asset-lineage-flow";
+const PIPELINE_FLOW_ID = "pipeline-lineage-flow";
+const COLUMN_FLOW_ID = "column-lineage-flow";
+
 // ===== Asset View State =====
 const flowRef = ref(null);
-const { nodes, edges, addNodes, addEdges, setNodes, setEdges, fitView, onNodeMouseEnter, onNodeMouseLeave, getNodes, getEdges } = useVueFlow();
+const { nodes, edges, addNodes, addEdges, setNodes, setEdges, fitView, onNodeMouseEnter, onNodeMouseLeave, getNodes, getEdges } = useVueFlow(ASSET_FLOW_ID);
+const { fitView: fitPipelineView } = useVueFlow(PIPELINE_FLOW_ID);
+const { fitView: fitColumnView } = useVueFlow(COLUMN_FLOW_ID);
 const elements = computed(() => [...nodes.value, ...edges.value]);
 const selectedNodeId = ref<string | null>(null);
 const isLoadingLocal = ref(true);
@@ -483,13 +494,18 @@ const fitViewSmooth = async (forceAutoFit = false, useAnimation = false) => {
   }
   
   const duration = useAnimation ? 300 : 0;
-  
+  const fit = showColumnView.value
+    ? fitColumnView
+    : showPipelineView.value
+      ? fitPipelineView
+      : fitView;
+
   try {
-    fitView({ padding: 0.2, duration });
+    fit({ padding: 0.2, duration });
     shouldAutoFit.value = false; // Disable auto-fit after first use
   } catch (e) {
     await nextTick();
-    fitView({ padding: 0.2, duration });
+    fit({ padding: 0.2, duration });
     shouldAutoFit.value = false;
   }
 };

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -487,7 +487,8 @@ const onNodesDragged = (draggedNodes: NodeDragEvent[]) => {
 // Fit view helper - now with smart auto-fit logic
 const fitViewSmooth = async (forceAutoFit = false, useAnimation = false) => {
   await nextTick();
-  
+  console.log(`[LT] fitViewSmooth force=${forceAutoFit} shouldAutoFit=${shouldAutoFit.value} view=${showColumnView.value ? "column" : showPipelineView.value ? "pipeline" : "asset"} t=${Math.round(performance.now())}`);
+
   // Only auto-fit if explicitly requested or first load
   if (!forceAutoFit && !shouldAutoFit.value) {
     return;
@@ -511,10 +512,11 @@ const fitViewSmooth = async (forceAutoFit = false, useAnimation = false) => {
 };
 
 const _updateGraph = async () => {
+  console.log(`[LT] _updateGraph START asset=${props.assetDataset?.name ?? "?"} t=${Math.round(performance.now())}`);
   if (!showPipelineView.value && !showColumnView.value) {
     isLoadingLocal.value = true;
     isLayouting.value = true;
-    
+
     try {
       const graphData = currentGraphData.value;
       if (graphData.nodes.length > 0) {
@@ -750,6 +752,7 @@ let lastViewKey = "";
 // Default view for the current target: pipeline view for a pipeline, else asset.
 const selectDefaultViewForTarget = () => {
   const isPipeline = Boolean((props.assetDataset as any)?.isPipelineView);
+  console.log(`[LT] selectDefaultView isPipeline=${isPipeline} hasPipelineData=${!!props.pipelineData} t=${Math.round(performance.now())}`);
   showColumnView.value = false;
   showPipelineView.value = isPipeline;
   if (isPipeline) {
@@ -778,9 +781,10 @@ watch(
 watch(
   () => [props.assetDataset, props.pipelineData],
   () => {
+    const key = computeTargetKey();
+    console.log(`[LT] dataWatch key=${key} lastViewKey=${lastViewKey} changed=${key !== lastViewKey} hasAsset=${!!props.assetDataset} showPipeline=${showPipelineView.value} showColumn=${showColumnView.value} t=${Math.round(performance.now())}`);
     if (!props.assetDataset) return;
 
-    const key = computeTargetKey();
     if (key !== lastViewKey) {
       // Switched target: reset to its default view.
       lastViewKey = key;
@@ -790,10 +794,13 @@ watch(
 
     // Same target refreshed: rebuild the current view instead of snapping away.
     if (showColumnView.value) {
+      console.log("[LT] dataWatch -> refresh column");
       buildColumnElements();
     } else if (showPipelineView.value) {
+      console.log("[LT] dataWatch -> refresh pipeline");
       buildPipelineElements();
     } else {
+      console.log("[LT] dataWatch -> refresh asset");
       processProperties();
     }
   },
@@ -852,6 +859,7 @@ const onPipelineNodeClick = (nodeId: string) => {
 };
 
 const buildPipelineElements = async () => {
+  console.log(`[LT] buildPipeline START assets=${(props.pipelineData as any)?.assets?.length ?? "NONE"} t=${Math.round(performance.now())}`);
   if (!props.pipelineData) {
     pipelineElements.value = { nodes: [], edges: [] };
     return;
@@ -863,6 +871,7 @@ const buildPipelineElements = async () => {
   );
   const { nodes: layoutNodes, edges: layoutEdges } = await applyPipelineLayout(initialNodes, initialEdges);
   pipelineElements.value = { nodes: layoutNodes, edges: layoutEdges };
+  console.log(`[LT] buildPipeline DONE nodes=${layoutNodes.length} edges=${layoutEdges.length} t=${Math.round(performance.now())}`);
 };
 
 const onPipelineNodesInitialized = async () => {
@@ -1035,6 +1044,7 @@ const onColumnNodeClick = (nodeId: string) => {
 
 const buildColumnElements = async () => {
   const newPipelineData = props.pipelineData;
+  console.log(`[LT] buildColumn START hasColumns=${hasColumnLineageData(newPipelineData)} pending=${columnFetchPending.value} t=${Math.round(performance.now())}`);
   if (!newPipelineData) {
     columnElements.value = { nodes: [], edges: [] };
     return;

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -232,6 +232,9 @@ const columnFetchPending = ref(false);
 // True while a pipeline/column graph is being (re)built. Drives an immediate
 // loading overlay for those slower builds, instead of a bare dark canvas.
 const isBuildingView = ref(false);
+// Bumped whenever a (re)build starts; an async build only applies its result
+// if it's still the latest, so a slow older build can't overwrite a newer one.
+let buildGeneration = 0;
 const showLoadingIndicator = ref(false);
 let loadingTimer: NodeJS.Timeout | null = null;
 const shouldAutoFit = ref(true);
@@ -529,6 +532,7 @@ const _updateGraph = async () => {
     setNodes([]);
     setEdges([]);
 
+    const gen = ++buildGeneration;
     try {
       const graphData = currentGraphData.value;
       if (graphData.nodes.length > 0) {
@@ -538,12 +542,16 @@ const _updateGraph = async () => {
           layoutedGraphData = await applyLayout(graphData.nodes, graphData.edges);
           layoutCache.value.set(key, layoutedGraphData);
         }
+        // A newer build started while we were laying out; discard this result.
+        if (gen !== buildGeneration) {
+          return;
+        }
         setNodes(layoutedGraphData.nodes);
         setEdges(layoutedGraphData.edges);
         isLayouting.value = false;
         isLoadingLocal.value = false;
         await nextTick();
-        
+
         await fitViewSmooth(true, false);
       } else {
         setNodes([]);
@@ -818,6 +826,19 @@ watch(
   { immediate: false }
 );
 
+// A parse error (e.g. an on-demand column fetch that failed) must clear any
+// pending/building state so the spinner can't hang, and surface the error.
+watch(
+  () => props.LineageError,
+  (newError) => {
+    if (newError) {
+      columnFetchPending.value = false;
+      isBuildingView.value = false;
+      error.value = newError;
+    }
+  }
+);
+
 onNodeMouseEnter((event: NodeMouseEvent) => {
   if (showPipelineView.value || showColumnView.value) return;
   const hoveredNode = event.node;
@@ -878,6 +899,7 @@ const buildPipelineElements = async () => {
   // isn't left on screen while this (possibly slow) build runs.
   pipelineElements.value = { nodes: [], edges: [] };
   isBuildingView.value = true;
+  const gen = ++buildGeneration;
   try {
     const lineageData = buildPipelineLineage(props.pipelineData);
     const { nodes: initialNodes, edges: initialEdges } = (await import("@/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder")).generateGraph(
@@ -885,9 +907,15 @@ const buildPipelineElements = async () => {
       props.assetDataset?.name || ""
     );
     const { nodes: layoutNodes, edges: layoutEdges } = await applyPipelineLayout(initialNodes, initialEdges);
+    // A newer build started while we were laying out; discard this stale result.
+    if (gen !== buildGeneration) {
+      return;
+    }
     pipelineElements.value = { nodes: layoutNodes, edges: layoutEdges };
   } finally {
-    isBuildingView.value = false;
+    if (gen === buildGeneration) {
+      isBuildingView.value = false;
+    }
   }
 };
 
@@ -1061,27 +1089,24 @@ const onColumnNodeClick = (nodeId: string) => {
 
 const buildColumnElements = async () => {
   const newPipelineData = props.pipelineData;
+  // We only reach here once data is available, so any pending on-demand fetch
+  // has resolved — clear it so the spinner can't hang if columns are absent.
+  columnFetchPending.value = false;
   if (!newPipelineData) {
     columnElements.value = { nodes: [], edges: [] };
     return;
   }
   if (!hasColumnLineageData(newPipelineData)) {
-    // Still waiting on the on-demand `-c` fetch: keep the spinner, no error yet.
-    if (columnFetchPending.value) {
-      columnElements.value = { nodes: [], edges: [] };
-      return;
-    }
-    console.warn("No column lineage data available. The data may have been parsed without the -c flag.");
     columnElements.value = { nodes: [], edges: [] };
     error.value = "No column lineage data found. To view column-level lineage, ensure the pipeline data includes column information";
     return;
   }
-  columnFetchPending.value = false;
   error.value = null;
   // Clear the previous graph and show loading so a stale column graph isn't
   // left on screen while this build runs.
   columnElements.value = { nodes: [], edges: [] };
   isBuildingView.value = true;
+  const gen = ++buildGeneration;
   try {
     const lineageData = buildColumnLineage(newPipelineData);
     // In pipeline view there is no single focus asset, so render column lineage
@@ -1091,6 +1116,10 @@ const buildColumnElements = async () => {
       ? generateColumnGraphForPipeline(lineageData)
       : generateColumnGraph(lineageData, props.assetDataset?.name || "");
     const { nodes: layoutNodes, edges: layoutEdges } = await applyPipelineLayout(initialNodes, initialEdges);
+    // A newer build started while we were laying out; discard this stale result.
+    if (gen !== buildGeneration) {
+      return;
+    }
 
     // Save original positions for recalculation
     originalColumnNodePositions.value = {};
@@ -1103,7 +1132,9 @@ const buildColumnElements = async () => {
 
     columnElements.value = { nodes: layoutNodes, edges: layoutEdges };
   } finally {
-    isBuildingView.value = false;
+    if (gen === buildGeneration) {
+      isBuildingView.value = false;
+    }
   }
 };
 

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="flow">
-    <div v-if="shouldShowLoading" class="loading-overlay">
+    <div v-if="shouldShowLoading || isBuildingView" class="loading-overlay">
       <vscode-progress-ring></vscode-progress-ring>
-      <span class="ml-2 text-editor-fg">Loading lineage data...</span>
+      <span class="ml-2 text-editor-fg">{{ loadingMessage }}</span>
     </div>
     
     <!-- Asset View -->
@@ -229,9 +229,20 @@ const error = ref<string | null>(props.LineageError);
 const showPipelineView = ref(false);
 const showColumnView = ref(false);
 const columnFetchPending = ref(false);
+// True while a pipeline/column graph is being (re)built. Drives an immediate
+// loading overlay for those slower builds, instead of a bare dark canvas.
+const isBuildingView = ref(false);
 const showLoadingIndicator = ref(false);
 let loadingTimer: NodeJS.Timeout | null = null;
-const shouldAutoFit = ref(true); 
+const shouldAutoFit = ref(true);
+
+const loadingMessage = computed(() =>
+  showPipelineView.value
+    ? "Building pipeline lineage…"
+    : showColumnView.value
+      ? "Building column lineage…"
+      : "Loading lineage…"
+);
 
 // Debug computed properties
 const shouldShowLoading = computed(() => {
@@ -516,6 +527,9 @@ const _updateGraph = async () => {
   if (!showPipelineView.value && !showColumnView.value) {
     isLoadingLocal.value = true;
     isLayouting.value = true;
+    // Clear the previous asset's graph so it isn't shown while this builds.
+    setNodes([]);
+    setEdges([]);
 
     try {
       const graphData = currentGraphData.value;
@@ -525,7 +539,7 @@ const _updateGraph = async () => {
         if (!layoutedGraphData) {
           layoutedGraphData = await applyLayout(graphData.nodes, graphData.edges);
           layoutCache.value.set(key, layoutedGraphData);
-        }      
+        }
         setNodes(layoutedGraphData.nodes);
         setEdges(layoutedGraphData.edges);
         isLayouting.value = false;
@@ -867,7 +881,7 @@ const buildPipelineElements = async () => {
   // Clear the previous pipeline's graph and show loading so the stale graph
   // isn't left on screen while this (possibly slow) build runs.
   pipelineElements.value = { nodes: [], edges: [] };
-  isLayouting.value = true;
+  isBuildingView.value = true;
   try {
     const lineageData = buildPipelineLineage(props.pipelineData);
     const { nodes: initialNodes, edges: initialEdges } = (await import("@/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder")).generateGraph(
@@ -878,7 +892,7 @@ const buildPipelineElements = async () => {
     pipelineElements.value = { nodes: layoutNodes, edges: layoutEdges };
     console.log(`[LT] buildPipeline DONE nodes=${layoutNodes.length} edges=${layoutEdges.length} t=${Math.round(performance.now())}`);
   } finally {
-    isLayouting.value = false;
+    isBuildingView.value = false;
   }
 };
 
@@ -1073,7 +1087,7 @@ const buildColumnElements = async () => {
   // Clear the previous graph and show loading so a stale column graph isn't
   // left on screen while this build runs.
   columnElements.value = { nodes: [], edges: [] };
-  isLayouting.value = true;
+  isBuildingView.value = true;
   try {
     const lineageData = buildColumnLineage(newPipelineData);
     // In pipeline view there is no single focus asset, so render column lineage
@@ -1095,7 +1109,7 @@ const buildColumnElements = async () => {
 
     columnElements.value = { nodes: layoutNodes, edges: layoutEdges };
   } finally {
-    isLayouting.value = false;
+    isBuildingView.value = false;
   }
 };
 

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -211,6 +211,7 @@ import {
 import { fetchAllDownstreams, fetchAllUpstreams } from "@/utilities/assetDependencies";
 import { buildPipelineLineage, applyLayout as applyPipelineLayout } from "@/components/lineage-flow/pipeline-lineage/pipelineLineageBuilder";
 import { buildColumnLineage } from "@/components/lineage-flow/column-level/useColumnLevel";
+import { vscode } from "@/utilities/vscode";
 import type { AssetDataset } from "@/types";
 
 const props = defineProps<{
@@ -224,13 +225,14 @@ const props = defineProps<{
 const error = ref<string | null>(props.LineageError);
 const showPipelineView = ref(false);
 const showColumnView = ref(false);
+const columnFetchPending = ref(false);
 const showLoadingIndicator = ref(false);
 let loadingTimer: NodeJS.Timeout | null = null;
 const shouldAutoFit = ref(true); 
 
 // Debug computed properties
 const shouldShowLoading = computed(() => {
-  const isActuallyLoading = (props.isLoading || isLoadingLocal.value) || isLayouting.value;
+  const isActuallyLoading = (props.isLoading || isLoadingLocal.value) || isLayouting.value || columnFetchPending.value;
   
   // Start timer when loading begins
   if (isActuallyLoading && !loadingTimer) {
@@ -686,6 +688,19 @@ const handlePipelineView = async () => {
   await buildPipelineElements();
 };
 
+// Column lineage is only present when parsed with `-c` (fetched on demand).
+const hasColumnLineageData = (pd: any): boolean => {
+  if (!pd) {
+    return false;
+  }
+  return Boolean(pd.column_lineage) ||
+    (Array.isArray(pd.assets) && pd.assets.some((a: any) =>
+      a.columns?.length > 0 && a.columns.some((c: any) =>
+        Array.isArray(c.upstreams) && c.upstreams.length > 0
+      )
+    ));
+};
+
 const handleColumnLevelLineage = async () => {
   showColumnView.value = true;
   showPipelineView.value = false;
@@ -694,6 +709,16 @@ const handleColumnLevelLineage = async () => {
   columnFilterType.value = "all";
   columnExpandAllUpstreams.value = false;
   columnExpandAllDownstreams.value = false;
+
+  // Column data not loaded yet: fetch it on demand (-c) and show a spinner.
+  // When it arrives, the pipelineData watcher rebuilds the column view.
+  if (!hasColumnLineageData(props.pipelineData)) {
+    error.value = null;
+    columnElements.value = { nodes: [], edges: [] };
+    columnFetchPending.value = true;
+    vscode.postMessage({ command: "bruin.fetchColumnLineage" });
+    return;
+  }
   await buildColumnElements();
 };
 
@@ -998,18 +1023,18 @@ const buildColumnElements = async () => {
     columnElements.value = { nodes: [], edges: [] };
     return;
   }
-  const hasColumnData = newPipelineData.column_lineage || 
-    (newPipelineData.assets && newPipelineData.assets.some((asset: any) => 
-      asset.columns?.length > 0 && asset.columns.some((col: any) => 
-        col.upstreams && Array.isArray(col.upstreams) && col.upstreams.length > 0
-      )
-    ));
-  if (!hasColumnData) {
+  if (!hasColumnLineageData(newPipelineData)) {
+    // Still waiting on the on-demand `-c` fetch: keep the spinner, no error yet.
+    if (columnFetchPending.value) {
+      columnElements.value = { nodes: [], edges: [] };
+      return;
+    }
     console.warn("No column lineage data available. The data may have been parsed without the -c flag.");
     columnElements.value = { nodes: [], edges: [] };
     error.value = "No column lineage data found. To view column-level lineage, ensure the pipeline data includes column information";
     return;
   }
+  columnFetchPending.value = false;
   error.value = null;
   const lineageData = buildColumnLineage(newPipelineData);
   // In pipeline view there is no single focus asset, so render column lineage


### PR DESCRIPTION
Makes the lineage panel fast to open and smooth to switch, especially on large pipelines.

## What changed
- **Cache pipeline parses** — switching between assets of the same pipeline reuses the parse instead of re-running the CLI. Invalidated on document edit and executable change.
- **Load columns on demand** — the first load runs only the plain (fast) parse; column-level lineage (`-c`, much slower) is fetched only when the Column view is opened, then cached. This is the main first-load speedup.
- **Smoother switching**
  - Each view (asset / pipeline / column) gets its own Vue Flow instance so viewports no longer leak between them.
  - On a file switch the panel shows a loading state instead of leaving the previous graph on screen.
  - The previous graph is cleared before a rebuild, so an old/other graph is never shown while the new one builds (fixes the "wrong pipeline shows first" and "old asset flashes" cases).
  - Pipeline/column builds show a "Building … lineage" indicator.

## Known limitation
Very large pipelines (~700+ assets) still take a few seconds to lay out and render the full pipeline view (ELK layout + rendering runs on the webview thread). A "Building pipeline lineage…" indicator shows during it. Speeding that up further is a separate effort.