### PR TITLE
Add DAC dashboard preview via embedded dac frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ example.txt
 integration-test-coverage-analysis.csv
 generate-coverage-analysis.js
 real-coverage-calculator.js
+
+# dac's React SPA copied from dac repo (use scripts/copy-dac-assets.js)
+webview-ui/build/dac-spa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.83.0]
+- Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.
+
 ## [0.82.6] - [2026-07-22]
 - Made the asset lineage panel faster to open and switch, with column lineage loaded on demand and pipeline parses cached.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.83.0**: Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.
 - **0.82.6**: Made the asset lineage panel faster to open and switch, with column lineage loaded on demand and pipeline parses cached.
 - **0.82.5**: Fixed the Run dropdown being clipped on ingestr assets, and added a "Run with debug" option that runs the asset with `--debug`.
 - **0.82.4**: Fixed the "Apply-Sensor-Mode" checkbox using a stale mode: changing the `bruin.run.sensorMode` setting now takes effect immediately in an open asset panel instead of only after reopening it. The checkbox tooltip also shows the active mode and points to the setting.

--- a/gitleaks-baseline.json
+++ b/gitleaks-baseline.json
@@ -42,8 +42,8 @@
  {
   "RuleID": "generic-api-key",
   "Description": "Detected a Generic API Key, potentially exposing access to various services and sensitive operations.",
-  "StartLine": 39,
-  "EndLine": 39,
+  "StartLine": 41,
+  "EndLine": 41,
   "StartColumn": 8,
   "EndColumn": 48,
   "Match": "WRITE_KEY = \"2q3zybBJRd9ErKIpkTRSdIahQ0C\"",
@@ -57,7 +57,7 @@
   "Date": "",
   "Message": "",
   "Tags": [],
-  "Fingerprint": "src/extension/extension.ts:generic-api-key:39"
+  "Fingerprint": "src/extension/extension.ts:generic-api-key:41"
  },
  {
   "RuleID": "generic-api-key",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.82.6",
+  "version": "0.83.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.82.6",
+      "version": "0.83.0",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^3.0.3",
@@ -42,6 +42,7 @@
         "eslint": "^8.57.0",
         "mocha": "^11.0.0",
         "prettier": "^3.2.5",
+        "tar": "^7.5.20",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.3",
         "vscode-extension-tester": "^8.2.0",
@@ -492,6 +493,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -6234,6 +6248,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -8598,6 +8625,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -8644,6 +8688,26 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/targz": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.82.6",
+  "version": "0.83.0",
+  "dacFrontend": {
+    "repo": "bruin-data/dac",
+    "version": "v0.7.0",
+    "asset": "dac-frontend.tar.gz"
+  },
   "engines": {
     "vscode": "^1.87.0"
   },
@@ -230,6 +235,11 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically update the Bruin CLI when a new version is available."
+        },
+        "bruin.dac.executable": {
+          "type": "string",
+          "default": "",
+          "description": "Full path to the 'dac' executable used by the Preview Dashboard command. Leave empty to discover it on PATH."
         }
       }
     },
@@ -282,6 +292,18 @@
         {
           "command": "bruin.renderSQL",
           "group": "navigation"
+        },
+        {
+          "command": "bruin.previewDashboard",
+          "group": "navigation",
+          "when": "resourceExtname == .yml || resourceExtname == .yaml"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "bruin.dacPreview.openInBrowser",
+          "group": "navigation",
+          "when": "activeWebviewPanelId == 'bruin.dacPreview'"
         }
       ],
       "editor/context": [
@@ -378,6 +400,20 @@
         "title": "Show Getting Started Walkthrough",
         "category": "Bruin",
         "description": "Show the Bruin getting started walkthrough."
+      },
+      {
+        "command": "bruin.previewDashboard",
+        "title": "Preview Dashboard",
+        "category": "Bruin",
+        "icon": "$(dashboard)",
+        "description": "Spawn `dac serve` on the current DAC project and preview it in a webview."
+      },
+      {
+        "command": "bruin.dacPreview.openInBrowser",
+        "title": "Open Dashboard in Browser",
+        "category": "Bruin",
+        "icon": "$(link-external)",
+        "description": "Open the current DAC dashboard in an external browser."
       }
     ],
     "keybindings": [
@@ -440,7 +476,9 @@
     "start:webview": "cd webview-ui && npm run start",
     "dev:watch": "concurrently -n EXTENSION,WEBVIEW -c yellow,blue \"tsc -watch -p ./\" \"cd webview-ui && npm run watch\"",
     "build:webview": "cd webview-ui && npm run build-only && node scripts/copy-codicons.js",
-    "vscode:prepublish": "npm run compile",
+    "copy:dac-spa": "node scripts/copy-dac-assets.js",
+    "fetch:dac-spa": "node scripts/fetch-dac-assets.js",
+    "vscode:prepublish": "npm run compile && npm run fetch:dac-spa",
     "selenium:setup-tests": "extest setup-tests",
     "selenium:run-tests:connections": "node webview-ui/scripts/copy-test-assets.js && extest setup-and-run './out/ui-test/connections-integration.test.js' --code_version 1.103.0 --code_settings settings.json --mocha_config .mocharc-ui.js",
     "selenium:run-tests:ingestr": "node webview-ui/scripts/copy-test-assets.js && extest setup-and-run './out/ui-test/ingestr-asset-ui-integration.test.js' --code_version 1.103.0 --code_settings settings.json --mocha_config .mocharc-ui.js",
@@ -474,6 +512,7 @@
     "eslint": "^8.57.0",
     "mocha": "^11.0.0",
     "prettier": "^3.2.5",
+    "tar": "^7.5.20",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.3",
     "vscode-extension-tester": "^8.2.0",

--- a/scripts/copy-dac-assets.js
+++ b/scripts/copy-dac-assets.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Copies dac's built frontend into the extension from a local dac checkout.
+ * Usage: node scripts/copy-dac-assets.js [path-to-dac-repo]  (defaults to ../dac)
+ */
+
+const fs = require("fs-extra");
+const path = require("path");
+
+const DEFAULT_DAC_PATH = path.resolve(__dirname, "../../dac");
+const dacPath = process.argv[2] || DEFAULT_DAC_PATH;
+
+// Prefer the relative-path embed build (dist-embed, DAC_EMBED=1); else dist.
+const embedDir = path.join(dacPath, "frontend/dist-embed");
+const srcDir = fs.existsSync(embedDir) ? embedDir : path.join(dacPath, "frontend/dist");
+const destDir = path.join(__dirname, "../webview-ui/build/dac-spa");
+
+async function main() {
+  // Check source exists
+  if (!fs.existsSync(srcDir)) {
+    console.error(`Error: dac frontend embed build not found at ${embedDir}`);
+    console.error("Build it first: DAC_EMBED=1 npm run build -- --outDir dist-embed  (in dac/frontend)");
+    process.exit(1);
+  }
+
+  // Clean destination
+  await fs.remove(destDir);
+  await fs.ensureDir(destDir);
+
+  // Copy assets
+  await fs.copy(srcDir, destDir);
+
+  console.log(`Copied dac frontend assets to ${destDir}`);
+
+  // List main files
+  const indexHtml = path.join(destDir, "index.html");
+  if (fs.existsSync(indexHtml)) {
+    const html = fs.readFileSync(indexHtml, "utf8");
+    const jsMatch = html.match(/src="\/assets\/(index-[^"]+\.js)"/);
+    const cssMatch = html.match(/href="\/assets\/(index-[^"]+\.css)"/);
+    if (jsMatch) console.log(`  Main JS: ${jsMatch[1]}`);
+    if (cssMatch) console.log(`  Main CSS: ${cssMatch[1]}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/fetch-dac-assets.js
+++ b/scripts/fetch-dac-assets.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Fetches dac's built frontend from the pinned GitHub release (package.json
+ * `dacFrontend`) into webview-ui/build/dac-spa. Needs no local dac checkout, so
+ * it works in CI. Prefers the `gh` CLI, falls back to `curl`; override the
+ * version with DAC_FRONTEND_VERSION.
+ */
+
+const fs = require("fs-extra");
+const path = require("path");
+const os = require("os");
+const tar = require("tar");
+const { execFileSync } = require("child_process");
+
+const pkg = require("../package.json");
+const cfg = pkg.dacFrontend || {};
+const REPO = process.env.DAC_FRONTEND_REPO || cfg.repo;
+const VERSION = process.env.DAC_FRONTEND_VERSION || cfg.version;
+const ASSET = process.env.DAC_FRONTEND_ASSET || cfg.asset || "dac-frontend.tar.gz";
+
+const destDir = path.join(__dirname, "..", "webview-ui", "build", "dac-spa");
+
+function has(cmd) {
+  try {
+    execFileSync(process.platform === "win32" ? "where" : "which", [cmd], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function download(tmpFile) {
+  // Prefer the direct release URL: it serves the public asset without touching
+  // api.github.com, so it avoids the unauthenticated rate limit `gh release
+  // download` hits in CI. Fall back to gh for private/edge cases.
+  const url = `https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}`;
+  try {
+    execFileSync("curl", ["-fsSL", url, "-o", tmpFile], { stdio: "inherit" });
+  } catch (err) {
+    if (!has("gh")) {
+      throw err;
+    }
+    console.log("curl download failed; retrying via gh...");
+    execFileSync(
+      "gh",
+      ["release", "download", VERSION, "--repo", REPO, "--pattern", ASSET, "--output", tmpFile, "--clobber"],
+      { stdio: "inherit" }
+    );
+  }
+}
+
+async function main() {
+  if (!REPO || !VERSION) {
+    throw new Error(
+      "Missing dac frontend pin. Set package.json `dacFrontend.repo` and `dacFrontend.version` " +
+        "(or DAC_FRONTEND_REPO / DAC_FRONTEND_VERSION)."
+    );
+  }
+
+  const tmpFile = path.join(os.tmpdir(), `dac-frontend-${VERSION.replace(/[^\w.-]/g, "_")}.tar.gz`);
+  console.log(`Fetching ${REPO}@${VERSION} (${ASSET})...`);
+  download(tmpFile);
+
+  await fs.remove(destDir);
+  await fs.ensureDir(destDir);
+  // Extract with the tar library rather than system tar — GNU tar on Windows
+  // mangles the drive-letter/backslash paths, so shelling out isn't portable.
+  await tar.x({ file: tmpFile, cwd: destDir });
+  await fs.remove(tmpFile);
+
+  if (!fs.existsSync(path.join(destDir, "index.html"))) {
+    throw new Error(
+      `Extracted archive has no index.html at its root. The release asset must be built with ` +
+        `\`tar -czf ${ASSET} -C frontend/dist .\``
+    );
+  }
+  console.log(`dac frontend ${VERSION} → ${path.relative(process.cwd(), destDir)}`);
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/src/bruin/dacServe.ts
+++ b/src/bruin/dacServe.ts
@@ -1,0 +1,320 @@
+import * as child_process from "child_process";
+import * as http from "http";
+import * as net from "net";
+import * as path from "path";
+import * as vscode from "vscode";
+import { getDacExecutablePath } from "../providers/DacExecutableService";
+import { getBruinExecutablePath } from "../providers/BruinExecutableService";
+
+/**
+ * dac serve shells out to the `bruin` CLI to run queries. The extension host's
+ * PATH may not include bruin (notably on Windows), so prepend the resolved bruin
+ * directory — mirroring how the extension runs bruin itself.
+ */
+function envWithBruinOnPath(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  const bruinDir = path.dirname(getBruinExecutablePath());
+  const key = Object.keys(env).find((k) => k.toUpperCase() === "PATH") || "PATH";
+  env[key] = bruinDir + path.delimiter + (env[key] || "");
+  return env;
+}
+
+/** Spawns and supervises a long-running `dac serve --dir <dir> --port <port>`. */
+export class DacServe {
+  private process: child_process.ChildProcess | undefined;
+  private readonly output: vscode.OutputChannel;
+  private readonly executable: string;
+  // Recent stdout/stderr lines, kept so a startup failure can report the real
+  // reason dac exited instead of a generic "exited before becoming ready".
+  private recentOutput: string[] = [];
+  private spawnError: Error | undefined;
+  private exitInfo: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+
+  public readonly port: number;
+  public readonly dir: string;
+  public readonly host: string = "127.0.0.1";
+  public readonly template: string;
+
+  constructor(
+    dir: string,
+    port: number,
+    output: vscode.OutputChannel,
+    template: string = "bruin",
+    executable: string = "dac"
+  ) {
+    this.dir = dir;
+    this.port = port;
+    this.output = output;
+    this.template = template;
+    this.executable = executable;
+  }
+
+  public get url(): string {
+    return `http://${this.host}:${this.port}`;
+  }
+
+  public get isRunning(): boolean {
+    return !!this.process && this.process.exitCode === null;
+  }
+
+  /** Picks an unused TCP port from the OS. */
+  public static async findFreePort(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const srv = net.createServer();
+      srv.unref();
+      srv.on("error", reject);
+      srv.listen(0, "127.0.0.1", () => {
+        const addr = srv.address();
+        if (addr && typeof addr === "object") {
+          const port = addr.port;
+          srv.close(() => resolve(port));
+        } else {
+          srv.close(() => reject(new Error("Failed to obtain free port")));
+        }
+      });
+    });
+  }
+
+  /** Spawns dac and resolves once it's accepting requests on the port. */
+  public async start(): Promise<void> {
+    const args = [
+      "serve",
+      "--dir", this.dir,
+      "--port", String(this.port),
+      "--host", this.host,
+      "--template", this.template,
+    ];
+    this.output.appendLine(`[dac] $ ${this.executable} ${args.join(" ")}`);
+
+    this.process = child_process.spawn(this.executable, args, {
+      cwd: this.dir,
+      env: envWithBruinOnPath(),
+    });
+
+    const capture = (line: string) => {
+      this.recentOutput.push(line);
+      if (this.recentOutput.length > 40) {
+        this.recentOutput.shift();
+      }
+    };
+
+    this.process.stdout?.on("data", (data: Buffer) => {
+      const text = data.toString();
+      this.output.append(`[dac] ${text}`);
+      capture(text.trimEnd());
+    });
+    this.process.stderr?.on("data", (data: Buffer) => {
+      const text = data.toString();
+      this.output.append(`[dac:err] ${text}`);
+      capture(text.trimEnd());
+    });
+    this.process.on("error", (err) => {
+      this.spawnError = err;
+      this.output.appendLine(`[dac] process error: ${err.message}`);
+    });
+    this.process.on("exit", (code, signal) => {
+      this.exitInfo = { code, signal };
+      this.output.appendLine(`[dac] exited (code=${code}, signal=${signal})`);
+    });
+
+    await this.waitUntilReady();
+  }
+
+  /** The last few lines dac printed — used to explain a startup failure. */
+  private tail(): string {
+    const text = this.recentOutput.join("\n").trim();
+    return text ? `\n${text}` : "";
+  }
+
+  private async waitUntilReady(timeoutMs: number = 15000): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (this.spawnError) {
+        throw new DacStartError(`Could not launch dac: ${this.spawnError.message}`, this.tail());
+      }
+      if (!this.process || this.process.exitCode !== null) {
+        const code = this.exitInfo?.code ?? this.process?.exitCode ?? "unknown";
+        throw new DacStartError(`dac exited (code=${code}) before it was ready.`, this.tail());
+      }
+      const reachable = await this.ping();
+      if (reachable) {
+        this.output.appendLine(`[dac] ready at ${this.url}`);
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    throw new DacStartError(`dac did not become ready within ${timeoutMs}ms.`, this.tail());
+  }
+
+  private ping(): Promise<boolean> {
+    return new Promise((resolve) => {
+      const req = http.get({ host: this.host, port: this.port, path: "/", timeout: 1000 }, (res) => {
+        res.resume();
+        resolve(true);
+      });
+      req.on("error", () => resolve(false));
+      req.on("timeout", () => {
+        req.destroy();
+        resolve(false);
+      });
+    });
+  }
+
+  public stop(): void {
+    if (!this.process || this.process.exitCode !== null) {
+      return;
+    }
+    this.output.appendLine(`[dac] stopping`);
+    try {
+      this.process.kill("SIGTERM");
+    } catch (err) {
+      this.output.appendLine(`[dac] kill failed: ${(err as Error).message}`);
+    }
+    // Hard kill fallback if it doesn't exit cleanly.
+    const proc = this.process;
+    setTimeout(() => {
+      if (proc.exitCode === null) {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          /* noop */
+        }
+      }
+    }, 2000);
+    this.process = undefined;
+  }
+}
+
+/** Raised when the `dac` executable can't be located (callers offer install help). */
+export class DacNotFoundError extends Error {
+  public readonly isDacNotFound = true;
+  constructor() {
+    super(
+      "Could not find the 'dac' executable. Install it, or set 'bruin.dac.executable' to its full path."
+    );
+    this.name = "DacNotFoundError";
+  }
+}
+
+/** Raised when `dac serve` failed to come up; `details` carries dac's own output. */
+export class DacStartError extends Error {
+  public readonly details: string;
+  constructor(message: string, details: string = "") {
+    super(details ? `${message}${details}` : message);
+    this.name = "DacStartError";
+    this.details = details.trim();
+  }
+  /** True when the failure looks like a transient port collision worth retrying. */
+  public get isPortInUse(): boolean {
+    return /address already in use|bind|in use|EADDRINUSE/i.test(this.details);
+  }
+}
+
+interface SharedServer {
+  /** Resolves to the ready server. Stored synchronously so concurrent
+   *  acquires for the same dir await one start instead of racing two. */
+  promise: Promise<DacServe>;
+  server?: DacServe;
+  refCount: number;
+}
+
+/**
+ * Ref-counted `dac serve` process per dashboard directory: acquire starts it on
+ * first use, release stops it when the last panel closes. Avoids leaking ports.
+ */
+export class DacServerManager {
+  private static servers: Map<string, SharedServer> = new Map();
+
+  /**
+   * Returns a ready DacServe for `dir`; pair each acquire with one release(dir).
+   * @throws {DacNotFoundError} when the dac executable cannot be resolved.
+   */
+  public static async acquire(
+    dir: string,
+    output: vscode.OutputChannel,
+    template: string
+  ): Promise<DacServe> {
+    const existing = DacServerManager.servers.get(dir);
+    if (existing) {
+      existing.refCount += 1;
+      output.appendLine(`[dac] reusing server for ${dir} (refs=${existing.refCount})`);
+      return existing.promise;
+    }
+
+    const executable = getDacExecutablePath();
+    if (!executable) {
+      throw new DacNotFoundError();
+    }
+
+    // Register the entry synchronously (with a pending promise) so a second
+    // acquire for the same dir joins this start instead of spawning its own.
+    let entry!: SharedServer;
+    const promise = DacServerManager.startServer(dir, output, template, executable).then(
+      (server) => {
+        entry.server = server;
+        return server;
+      }
+    );
+    entry = { refCount: 1, promise };
+    DacServerManager.servers.set(dir, entry);
+
+    try {
+      return await entry.promise;
+    } catch (err) {
+      DacServerManager.servers.delete(dir);
+      throw err;
+    }
+  }
+
+  /**
+   * Starts a `dac serve`, retrying only on a transient port collision
+   * (findFreePort → bind is a TOCTOU window); real failures throw immediately.
+   */
+  private static async startServer(
+    dir: string,
+    output: vscode.OutputChannel,
+    template: string,
+    executable: string
+  ): Promise<DacServe> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const port = await DacServe.findFreePort();
+      const server = new DacServe(dir, port, output, template, executable);
+      try {
+        await server.start();
+        return server;
+      } catch (err) {
+        lastError = err;
+        server.stop();
+        if (err instanceof DacStartError && err.isPortInUse && attempt < 3) {
+          output.appendLine(`[dac] port ${port} was taken, retrying on a new port…`);
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw lastError;
+  }
+
+  /** Decrements the ref-count for `dir`, stopping the server at zero. */
+  public static release(dir: string): void {
+    const entry = DacServerManager.servers.get(dir);
+    if (!entry) {
+      return;
+    }
+    entry.refCount -= 1;
+    if (entry.refCount <= 0) {
+      DacServerManager.servers.delete(dir);
+      // Stop once the start settles — covers release during a pending start.
+      entry.promise.then((s) => s.stop()).catch(() => {});
+    }
+  }
+
+  /** Stops every running server. Call on extension deactivate. */
+  public static disposeAll(): void {
+    for (const entry of DacServerManager.servers.values()) {
+      entry.promise.then((s) => s.stop()).catch(() => {});
+    }
+    DacServerManager.servers.clear();
+  }
+}

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -25,6 +25,8 @@ import { QueryPreviewPanel } from "../panels/QueryPreviewPanel";
 import { TableDiffPanel } from "../panels/TableDiffPanel";
 import { RunHistoryPanel } from "../panels/RunHistoryPanel";
 import { BruinPanel } from "../panels/BruinPanel";
+import { DacPreviewPanel } from "../panels/DacPreviewPanel";
+import { DacServerManager } from "../bruin/dacServe";
 import { QueryCodeLensProvider } from "../providers/queryCodeLensProvider";
 import { ScheduleCodeLensProvider } from "../providers/scheduleCodeLensProvider";
 import { QuerySelectionCodeLensProvider } from "../providers/querySelectionCodeLensProvider";
@@ -94,13 +96,19 @@ export function trackEvent(eventName: string, properties: Record<string, any> = 
 
 async function ensureAutoLockEnabled(config: WorkspaceConfiguration): Promise<void> {
   const autoLockGroups: Record<string, boolean> = config.get("autoLockGroups") || {};
-  const viewTypeKey = `mainThreadWebview-${BruinPanel.viewId}`;
+  // Auto-lock the editor groups of our webview panels so opening a file doesn't
+  // hijack the panel's slot. Applies to the main side panel and the DAC preview.
+  const viewTypeKeys = [
+    `mainThreadWebview-${BruinPanel.viewId}`,
+    `mainThreadWebview-${DacPreviewPanel.viewType}`,
+  ];
 
-  if (!autoLockGroups[viewTypeKey]) {
-    const updatedAutoLockGroups = {
-      ...autoLockGroups,
-      [viewTypeKey]: true,
-    };
+  const missing = viewTypeKeys.filter((key) => !autoLockGroups[key]);
+  if (missing.length) {
+    const updatedAutoLockGroups = { ...autoLockGroups };
+    for (const key of missing) {
+      updatedAutoLockGroups[key] = true;
+    }
 
     try {
       await config.update("autoLockGroups", updatedAutoLockGroups, true);
@@ -618,6 +626,29 @@ export async function activate(context: ExtensionContext) {
         vscode.window.showErrorMessage(`Error triggering completions: ${errorMessage}`);
       }
     }),
+    commands.registerCommand("bruin.previewDashboard", async (uri?: vscode.Uri) => {
+      try {
+        trackEvent("Command Executed", { command: "previewDashboard", source: "user" });
+        const targetUri = uri ?? window.activeTextEditor?.document.uri;
+        if (!targetUri) {
+          vscode.window.showWarningMessage("Open a dashboard YAML file before running Preview Dashboard.");
+          return;
+        }
+        const ext = targetUri.fsPath.toLowerCase();
+        if (!ext.endsWith(".yml") && !ext.endsWith(".yaml")) {
+          vscode.window.showWarningMessage("Preview Dashboard only supports .yml / .yaml files.");
+          return;
+        }
+        await DacPreviewPanel.open(targetUri, context.extensionUri);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error previewing dashboard: ${errorMessage}`);
+      }
+    }),
+    commands.registerCommand("bruin.dacPreview.openInBrowser", () => {
+      trackEvent("Command Executed", { command: "dacPreviewOpenInBrowser", source: "user" });
+      DacPreviewPanel.openActiveInBrowser();
+    }),
     commands.registerCommand("bruin.showWalkthrough", async () => {
       try {
         trackEvent("Command Executed", { command: "showWalkthrough", source: "user" });
@@ -696,4 +727,6 @@ export function deactivate(): void {
     clearInterval(cliCheckInterval);
     cliCheckInterval = undefined;
   }
+  // Stop any running dac serve processes.
+  DacServerManager.disposeAll();
 }

--- a/src/panels/DacPreviewPanel.ts
+++ b/src/panels/DacPreviewPanel.ts
@@ -1,0 +1,498 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import { DacServe, DacServerManager, DacNotFoundError, DacStartError } from "../bruin/dacServe";
+import {
+  DacExecutableService,
+  isDacVersionSupported,
+  MIN_DAC_VERSION,
+} from "../providers/DacExecutableService";
+import { getNonce } from "../utilities/getNonce";
+import { getUri } from "../utilities/getUri";
+
+/**
+ * Reads the top-level `name:` field from a dashboard YAML file. Returns the
+ * raw string (unquoted) or undefined if the file isn't readable / doesn't have
+ * one. Deliberately regex-based — adding a full YAML parser dep is overkill and
+ * dac's dashboard files put `name:` near the top.
+ */
+function readDashboardName(filePath: string): string | undefined {
+  if (!/\.ya?ml$/i.test(filePath)) {
+    return undefined;
+  }
+  let text: string;
+  try {
+    text = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return undefined;
+  }
+  const match = text.match(/^name:\s*(.+?)\s*$/m);
+  if (!match) {
+    return undefined;
+  }
+  let value = match[1].trim();
+  // Block/folded scalar (`name: >`/`|`): value is on later lines, so treat as
+  // unresolved and let the caller fall back to dac's listing.
+  if (/^[|>][+\-0-9]*$/.test(value)) {
+    return undefined;
+  }
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+  return value || undefined;
+}
+
+/**
+ * Classifies a YAML file so we can reject non-dashboards before spawning dac.
+ * `dac serve` validates *every* YAML in the served directory as a dashboard and
+ * exits if one isn't (e.g. a semantic-model file with top-level
+ * `metrics`/`dimensions`/`source`). Catching that here gives a clear message
+ * instead of a cryptic "additional properties not allowed" from dac.
+ */
+function classifyYaml(filePath: string): "dashboard" | "semantic-model" | "unknown" {
+  if (!/\.ya?ml$/i.test(filePath)) {
+    return "unknown";
+  }
+  let text: string;
+  try {
+    text = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "unknown";
+  }
+  const hasTop = (key: string) => new RegExp(`^${key}:`, "m").test(text);
+  if (hasTop("rows") || hasTop("widgets")) {
+    return "dashboard";
+  }
+  // Semantic models declare these at the top level; dashboards nest them.
+  if (hasTop("metrics") || hasTop("dimensions") || hasTop("source") || hasTop("segments")) {
+    return "semantic-model";
+  }
+  return "unknown";
+}
+
+/**
+ * Finds the main JS and CSS filenames from dac's built index.html.
+ * Returns [jsFilename, cssFilename] or throws if not found.
+ */
+function findDacAssets(extensionPath: string): { js: string; css: string } {
+  const indexPath = path.join(extensionPath, "webview-ui", "build", "dac-spa", "index.html");
+  const html = fs.readFileSync(indexPath, "utf8");
+  const jsMatch = html.match(/src="\.?\/assets\/(index-[^"]+\.js)"/);
+  const cssMatch = html.match(/href="\.?\/assets\/(index-[^"]+\.css)"/);
+  if (!jsMatch || !cssMatch) {
+    throw new Error("Could not find dac assets in index.html");
+  }
+  return { js: jsMatch[1], css: cssMatch[1] };
+}
+
+/** Encodes a value as a safe JS string literal for inline-script injection (escapes `<` so `</script>` can't break out). */
+function jsLiteral(value: string): string {
+  return JSON.stringify(String(value)).replace(/</g, "\\u003c");
+}
+
+/**
+ * Dashboard preview panel that embeds dac's React SPA directly in the webview.
+ * The React app fetches data from the running `dac serve` process via injected
+ * API base URL, providing full chart/table rendering without reimplementing
+ * dac's components in Vue.
+ */
+export class DacPreviewPanel {
+  public static readonly viewType = "bruin.dacPreview";
+  private static output: vscode.OutputChannel | undefined;
+  /** The most recently focused preview, so the title-bar command can target it. */
+  private static active: DacPreviewPanel | undefined;
+
+  private readonly panel: vscode.WebviewPanel;
+  private readonly server: DacServe;
+  private readonly dashboardDir: string;
+  private readonly extensionUri: vscode.Uri;
+  private readonly disposables: vscode.Disposable[] = [];
+  private currentName: string | undefined;
+  private disposed: boolean = false;
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    server: DacServe,
+    dashboardDir: string,
+    extensionUri: vscode.Uri,
+    initialName: string | undefined
+  ) {
+    this.panel = panel;
+    this.server = server;
+    this.dashboardDir = dashboardDir;
+    this.extensionUri = extensionUri;
+    this.currentName = initialName;
+
+    DacPreviewPanel.active = this;
+    this.disposables.push(
+      this.panel.onDidChangeViewState((e) => {
+        if (e.webviewPanel.active) {
+          DacPreviewPanel.active = this;
+        }
+      })
+    );
+
+    this.disposables.push(
+      this.panel.webview.onDidReceiveMessage((msg) => {
+        if (msg && msg.type === "openExternal") {
+          this.openInBrowser();
+        }
+      })
+    );
+
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+
+    // Switch dashboards when the user activates another dashboard YAML in the
+    // same directory dac is serving. Navigate via hash change.
+    this.disposables.push(
+      vscode.window.onDidChangeActiveTextEditor((editor) => {
+        if (!editor || !this.isInDashboardDir(editor.document.uri.fsPath)) {
+          return;
+        }
+        if (classifyYaml(editor.document.uri.fsPath) === "semantic-model") {
+          return;
+        }
+        const name = readDashboardName(editor.document.uri.fsPath);
+        if (name && name !== this.currentName) {
+          this.currentName = name;
+          DacPreviewPanel.getOutput().appendLine(`[dac] switching to dashboard: ${name}`);
+          // Navigate the React app via hash
+          void this.panel.webview.postMessage({
+            type: "navigate",
+            path: `/d/${encodeURIComponent(name)}`,
+          });
+        }
+      })
+    );
+
+    // Follow renames: the webview navigates by name, so on save re-read `name:`
+    // and re-navigate, else it stays pinned to the old name and 404s.
+    this.disposables.push(
+      vscode.workspace.onDidSaveTextDocument((doc) => {
+        if (!this.isInDashboardDir(doc.uri.fsPath)) {
+          return;
+        }
+        if (classifyYaml(doc.uri.fsPath) === "semantic-model") {
+          return;
+        }
+        const name = readDashboardName(doc.uri.fsPath);
+        if (name && name !== this.currentName) {
+          this.currentName = name;
+          DacPreviewPanel.getOutput().appendLine(`[dac] dashboard renamed to: ${name}`);
+          void this.panel.webview.postMessage({
+            type: "navigate",
+            path: `/d/${encodeURIComponent(name)}`,
+            name,
+            smooth: true,
+          });
+        }
+      })
+    );
+  }
+
+  /** Opens this preview's dashboard in the system browser (full dac SPA). */
+  private openInBrowser(): void {
+    const base = this.server.url;
+    const url = this.currentName
+      ? `${base}/d/${encodeURIComponent(this.currentName)}`
+      : base;
+    void vscode.env.openExternal(vscode.Uri.parse(url));
+  }
+
+  /** Title-bar command entry point: open the active preview in the browser. */
+  public static openActiveInBrowser(): void {
+    const panel = DacPreviewPanel.active;
+    if (!panel) {
+      void vscode.window.showInformationMessage("Bruin: no DAC dashboard preview is open.");
+      return;
+    }
+    panel.openInBrowser();
+  }
+
+  private isInDashboardDir(filePath: string): boolean {
+    const rel = path.relative(this.dashboardDir, filePath);
+    return !!rel && !rel.startsWith("..") && !path.isAbsolute(rel);
+  }
+
+  private static getOutput(): vscode.OutputChannel {
+    if (!DacPreviewPanel.output) {
+      DacPreviewPanel.output = vscode.window.createOutputChannel("Bruin DAC");
+    }
+    return DacPreviewPanel.output;
+  }
+
+  public static async open(documentUri: vscode.Uri, extensionUri: vscode.Uri): Promise<void> {
+    const dashboardDir = path.dirname(documentUri.fsPath);
+    const output = DacPreviewPanel.getOutput();
+
+    // dac serves the whole dir and rejects non-dashboard YAML, crashing on
+    // startup — guard the common mistake of previewing a semantic model.
+    if (classifyYaml(documentUri.fsPath) === "semantic-model") {
+      output.appendLine(`[dac] ${path.basename(documentUri.fsPath)} looks like a semantic model, not a dashboard.`);
+      vscode.window.showWarningMessage(
+        "Bruin: this file looks like a semantic model, not a dashboard. " +
+          "Open a dashboard file (one with a top-level `rows:`) and run Preview Dashboard again."
+      );
+      return;
+    }
+
+    // The embed needs the CORS middleware added in MIN_DAC_VERSION; older binaries
+    // serve without it and the webview's cross-origin fetches fail silently.
+    const version = await DacExecutableService.getInstance().getVersion();
+    if (!isDacVersionSupported(version)) {
+      output.appendLine(`[dac] version ${version} < required ${MIN_DAC_VERSION}`);
+      const choice = await vscode.window.showErrorMessage(
+        `Bruin: Dashboard Preview needs dac ${MIN_DAC_VERSION} or newer (found ${version}). Run \`dac upgrade\`.`,
+        "Show Output"
+      );
+      if (choice === "Show Output") {
+        output.show();
+      }
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      DacPreviewPanel.viewType,
+      `DAC Preview: ${path.basename(documentUri.fsPath)}`,
+      vscode.ViewColumn.Beside,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [extensionUri],
+      }
+    );
+    const iconPath = vscode.Uri.joinPath(extensionUri, "img", "bruin-logo-sm128.png");
+    panel.iconPath = { light: iconPath, dark: iconPath };
+
+    try {
+      const server = await DacServerManager.acquire(dashboardDir, output, "bruin");
+      const name = readDashboardName(documentUri.fsPath);
+      const preview = new DacPreviewPanel(panel, server, dashboardDir, extensionUri, name);
+      panel.webview.html = preview.renderHtml();
+    } catch (err) {
+      if (err instanceof DacNotFoundError) {
+        output.appendLine(`[dac] ${err.message}`);
+        const choice = await vscode.window.showErrorMessage(
+          "Bruin: the 'dac' executable was not found.",
+          "Open Settings"
+        );
+        if (choice === "Open Settings") {
+          await vscode.commands.executeCommand(
+            "workbench.action.openSettings",
+            "bruin.dac.executable"
+          );
+        }
+        panel.dispose();
+        return;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      output.appendLine(`[dac] failed to start: ${message}`);
+      panel.dispose();
+      const detail =
+        err instanceof DacStartError && err.details ? err.details.split("\n").pop() : "";
+      const summary = detail
+        ? `Bruin: dac serve failed — ${detail}`
+        : `Bruin: Failed to start dac serve — ${message}`;
+      const choice = await vscode.window.showErrorMessage(summary, "Show Output");
+      if (choice === "Show Output") {
+        output.show();
+      }
+    }
+  }
+
+  private dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    if (DacPreviewPanel.active === this) {
+      DacPreviewPanel.active = undefined;
+    }
+    DacServerManager.release(this.dashboardDir);
+    while (this.disposables.length) {
+      this.disposables.pop()?.dispose();
+    }
+  }
+
+  private renderHtml(): string {
+    const webview = this.panel.webview;
+    const nonce = getNonce();
+    const extensionPath = this.extensionUri.fsPath;
+
+    // Find the hashed asset filenames from dac's build
+    const assets = findDacAssets(extensionPath);
+
+    // Get URIs for dac's React bundle
+    const scriptUri = getUri(webview, this.extensionUri, [
+      "webview-ui",
+      "build",
+      "dac-spa",
+      "assets",
+      assets.js,
+    ]);
+    const stylesUri = getUri(webview, this.extensionUri, [
+      "webview-ui",
+      "build",
+      "dac-spa",
+      "assets",
+      assets.css,
+    ]);
+
+    // The API base URL for dac serve
+    const apiBase = this.server.url;
+
+    // Initial dashboard to navigate to
+    const initialDashboard = this.currentName || "";
+
+    return /*html*/ `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'none';
+      img-src ${webview.cspSource} https: data:;
+      script-src 'nonce-${nonce}' 'strict-dynamic' 'wasm-unsafe-eval';
+      style-src ${webview.cspSource} 'unsafe-inline';
+      font-src ${webview.cspSource} https: data:;
+      connect-src ${apiBase} ${apiBase.replace('http:', 'ws:')};
+  " />
+  <link rel="stylesheet" href="${stylesUri}" />
+  <style nonce="${nonce}">
+    /* Map dac's theme tokens onto the editor's live --vscode-* variables so the
+       dashboard tracks the VS Code theme (including light/dark switches). dac
+       sets these tokens as an inline style on .dac-root; an !important rule
+       here overrides that in the cascade without any dac-side code. */
+    .dac-root {
+      font-family: var(--vscode-font-family) !important;
+      --dac-background: var(--vscode-editor-background) !important;
+      --dac-surface: var(--vscode-sideBar-background) !important;
+      --dac-surface-hover: var(--vscode-list-hoverBackground) !important;
+      --dac-border: var(--vscode-panel-border) !important;
+      --dac-text-primary: var(--vscode-editor-foreground) !important;
+      --dac-text-secondary: var(--vscode-descriptionForeground) !important;
+      --dac-text-muted: var(--vscode-disabledForeground) !important;
+      --dac-accent: var(--vscode-textLink-foreground) !important;
+      --dac-accent-hover: var(--vscode-textLink-activeForeground) !important;
+      --dac-success: var(--vscode-charts-green) !important;
+      --dac-warning: var(--vscode-charts-yellow) !important;
+      --dac-error: var(--vscode-charts-red) !important;
+      --dac-chart-1: var(--vscode-charts-blue) !important;
+      --dac-chart-2: var(--vscode-charts-green) !important;
+      --dac-chart-3: var(--vscode-charts-purple) !important;
+      --dac-chart-4: var(--vscode-charts-red) !important;
+      --dac-chart-5: var(--vscode-charts-yellow) !important;
+      --dac-chart-6: var(--vscode-charts-orange) !important;
+      --dac-chart-7: var(--vscode-charts-foreground) !important;
+      --dac-chart-8: var(--vscode-charts-lines) !important;
+    }
+    /* Hide the "← Dashboards" back-link — there's no list to return to here. */
+    .dac-root header a[href="#/"] { display: none !important; }
+    /* Hide dac's header actions (Export + View YAML) — the header group is a
+       <div>; scoped to div so the per-widget QueryInfo <button> (same attr,
+       used to strip controls from exports) stays and shows the SQL on hover. */
+    .dac-root div[data-dac-export-control] { display: none !important; }
+    #dac-open-browser {
+      position: fixed; top: 10px; right: 12px; z-index: 2147483646;
+      display: inline-flex; align-items: center; gap: 5px;
+      font: 11px/1 var(--vscode-font-family, system-ui, sans-serif);
+      color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+      background: var(--vscode-button-secondaryBackground, rgba(127,127,127,0.15));
+      border: 1px solid var(--vscode-widget-border, transparent);
+      padding: 4px 8px; border-radius: 4px; cursor: pointer; opacity: 0.8;
+    }
+    #dac-open-browser:hover { opacity: 1; background: var(--vscode-button-secondaryHoverBackground, rgba(127,127,127,0.25)); }
+  </style>
+  <title>DAC Preview</title>
+  <script nonce="${nonce}">
+    // Register a pass-through Trusted Types policy before the bundle loads so
+    // dac's Shiki HTML is accepted; done inline as ES imports evaluate too late.
+    try {
+      if (window.trustedTypes && !window.trustedTypes.defaultPolicy) {
+        window.trustedTypes.createPolicy("default", {
+          createHTML: function (s) { return s; },
+          createScript: function (s) { return s; },
+          createScriptURL: function (s) { return s; },
+        });
+      }
+    } catch (e) {
+      console.error("DAC Preview: failed to register Trusted Types policy", e);
+    }
+
+    // Inject configuration for dac's React app
+    window.__DAC_API_BASE__ = ${jsLiteral(apiBase)};
+    window.__DAC_INITIAL_DASHBOARD__ = ${jsLiteral(initialDashboard)};
+
+    // The dac SPA talks to its server over HTTP, not the VS Code message
+    // channel, so we're free to acquire the API here for our own controls.
+    var __vscodeApi;
+    try { __vscodeApi = acquireVsCodeApi(); } catch (e) { /* not in a webview */ }
+    window.addEventListener("DOMContentLoaded", function () {
+      var btn = document.getElementById("dac-open-browser");
+      if (btn && __vscodeApi) {
+        btn.addEventListener("click", function () {
+          __vscodeApi.postMessage({ type: "openExternal" });
+        });
+      }
+    });
+
+    // Handle navigation messages from extension.
+    window.addEventListener("message", (event) => {
+      const msg = event.data;
+      if (!msg || msg.type !== "navigate" || !msg.path) return;
+      if (msg.smooth && msg.name) {
+        smoothNavigate(msg.path, msg.name);
+      } else {
+        window.location.hash = msg.path;
+      }
+    });
+
+    // Hide the remount flash on rename: freeze a snapshot over the panel,
+    // navigate underneath, fade out once the new title paints (or on timeout).
+    function smoothNavigate(path, name) {
+      const root = document.getElementById("root");
+      const current = root && root.firstElementChild;
+      if (!current) { window.location.hash = path; return; }
+
+      const overlay = document.createElement("div");
+      overlay.style.cssText =
+        "position:fixed;inset:0;z-index:2147483647;overflow:hidden;" +
+        "background:var(--vscode-editor-background,#1e1e1e);" +
+        "transition:opacity .2s ease;opacity:1;pointer-events:none";
+      overlay.appendChild(current.cloneNode(true));
+      document.body.appendChild(overlay);
+
+      window.location.hash = path;
+
+      const start = Date.now();
+      const timer = setInterval(() => {
+        const h1 = document.querySelector("#root h1");
+        const ready = h1 && (h1.textContent || "").trim() === name;
+        if (ready || Date.now() - start > 2500) {
+          clearInterval(timer);
+          overlay.style.opacity = "0";
+          setTimeout(() => overlay.remove(), 220);
+        }
+      }, 80);
+    }
+  </script>
+</head>
+<body>
+  <button id="dac-open-browser" title="Open this dashboard in your browser">
+    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M6 3H3.5A1.5 1.5 0 0 0 2 4.5v8A1.5 1.5 0 0 0 3.5 14h8a1.5 1.5 0 0 0 1.5-1.5V10" />
+      <path d="M10 2h4v4" />
+      <path d="M14 2 7 9" />
+    </svg>
+    Open in browser
+  </button>
+  <div id="root"></div>
+  <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+  }
+}

--- a/src/providers/DacExecutableService.ts
+++ b/src/providers/DacExecutableService.ts
@@ -1,0 +1,132 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+import { execFile } from "child_process";
+
+/** Dashboard Preview needs the CORS middleware added to `dac serve` in this release. */
+export const MIN_DAC_VERSION = "0.7.0";
+
+/** True unless `version` is a parseable semver older than MIN_DAC_VERSION (dev/unknown pass). */
+export function isDacVersionSupported(version: string | null): boolean {
+  if (!version) {
+    return true;
+  }
+  const cur = version.split(".").map(Number);
+  const min = MIN_DAC_VERSION.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (cur[i] !== min[i]) {
+      return cur[i] > min[i];
+    }
+  }
+  return true;
+}
+
+/**
+ * Singleton resolving the `dac` executable: `bruin.dac.executable` setting, then
+ * PATH and common install dirs. Returns null when not found so callers can warn.
+ */
+export class DacExecutableService {
+  private static instance: DacExecutableService;
+  private cachedExecutablePath: string | null = null;
+  private lastConfigCheckTime: number = 0;
+  private readonly CONFIG_CACHE_MS = 300_000; // 5 minutes
+
+  private constructor() {
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("bruin.dac.executable")) {
+        this.invalidateCache();
+      }
+    });
+  }
+
+  public static getInstance(): DacExecutableService {
+    if (!DacExecutableService.instance) {
+      DacExecutableService.instance = new DacExecutableService();
+    }
+    return DacExecutableService.instance;
+  }
+
+  private get binaryName(): string {
+    return process.platform === "win32" ? "dac.exe" : "dac";
+  }
+
+  /** Resolves the dac executable to an absolute path, or null. Cached for CONFIG_CACHE_MS. */
+  public getExecutablePath(): string | null {
+    const now = Date.now();
+    if (this.cachedExecutablePath !== null && now - this.lastConfigCheckTime < this.CONFIG_CACHE_MS) {
+      return this.cachedExecutablePath;
+    }
+    this.lastConfigCheckTime = now;
+
+    // 1. Explicit setting wins.
+    const configured = vscode.workspace.getConfiguration("bruin").get<string>("dac.executable") || "";
+    if (configured.length > 0) {
+      this.cachedExecutablePath = configured;
+      return configured;
+    }
+
+    // 2. Scan PATH.
+    const paths = (process.env.PATH || "").split(path.delimiter);
+    for (const p of paths) {
+      if (!p) {
+        continue;
+      }
+      const candidate = path.join(p, this.binaryName);
+      if (this.isExecutable(candidate)) {
+        this.cachedExecutablePath = candidate;
+        return candidate;
+      }
+    }
+
+    // 3. Common install locations not always on the GUI-app PATH.
+    const home = os.homedir();
+    const fallbacks = [
+      path.join(home, ".local", "bin", this.binaryName),
+      path.join(home, "go", "bin", this.binaryName),
+      "/usr/local/bin/" + this.binaryName,
+      "/opt/homebrew/bin/" + this.binaryName,
+    ];
+    for (const candidate of fallbacks) {
+      if (this.isExecutable(candidate)) {
+        this.cachedExecutablePath = candidate;
+        return candidate;
+      }
+    }
+
+    this.cachedExecutablePath = null;
+    return null;
+  }
+
+  private isExecutable(filePath: string): boolean {
+    try {
+      fs.accessSync(filePath, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  public invalidateCache(): void {
+    this.cachedExecutablePath = null;
+    this.lastConfigCheckTime = 0;
+  }
+
+  /** Runs `dac --version` and returns the parsed x.y.z, or null (dev/unknown/unresolved). */
+  public async getVersion(): Promise<string | null> {
+    const exe = this.getExecutablePath();
+    if (!exe) {
+      return null;
+    }
+    return new Promise((resolve) => {
+      execFile(exe, ["--version"], { timeout: 5000 }, (err, stdout) => {
+        const m = err ? null : /(\d+)\.(\d+)\.(\d+)/.exec(stdout || "");
+        resolve(m ? `${m[1]}.${m[2]}.${m[3]}` : null);
+      });
+    });
+  }
+}
+
+export function getDacExecutablePath(): string | null {
+  return DacExecutableService.getInstance().getExecutablePath();
+}


### PR DESCRIPTION
Adds a **Preview Dashboard** command that spawns `dac serve` and embeds dac's own built SPA in a webview, themed to the editor.

- in-panel *Open in Browser* button; live reload and a smooth transition on rename
- fetches dac's frontend from a pinned GitHub release (`scripts/fetch-dac-assets.js`), so the build needs no local dac checkout
- theme, layout, and chrome tweaks are injected as CSS from the extension — dac is unmodified beyond the companion PR

**Depends on** a dac release that includes the `dac-frontend.tar.gz` asset (see bruin-data/dac#48). Bump `dacFrontend.version` in package.json to that tag before merge, and wire `fetch:dac-spa` into packaging.