### PR TITLE
Offer to install/update dac from Preview Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [0.83.1]
-- Preview Dashboard now offers to install or update the `dac` CLI (and retries) when it's missing or older than the required version, instead of just failing.
+- Preview Dashboard offers to install or update `dac` when it's missing or outdated.
 
 ## [0.83.0]
 - Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [0.83.1]
-- Preview Dashboard offers to install or update `dac` when it's missing or outdated.
+- Preview Dashboard offers to install or update `dac` when it's missing or below the required version.
 
 ## [0.83.0]
 - Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.83.1]
+- Preview Dashboard now offers to install or update the `dac` CLI (and retries) when it's missing or older than the required version, instead of just failing.
+
 ## [0.83.0]
 - Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.83.1**: Preview Dashboard now offers to install or update the `dac` CLI (and retries) when it's missing or older than the required version, instead of just failing.
 - **0.83.0**: Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.
 - **0.82.6**: Made the asset lineage panel faster to open and switch, with column lineage loaded on demand and pipeline parses cached.
 - **0.82.5**: Fixed the Run dropdown being clipped on ingestr assets, and added a "Run with debug" option that runs the asset with `--debug`.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.83.1**: Preview Dashboard now offers to install or update the `dac` CLI (and retries) when it's missing or older than the required version, instead of just failing.
+- **0.83.1**: Preview Dashboard offers to install or update `dac` when it's missing or outdated.
 - **0.83.0**: Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.
 - **0.82.6**: Made the asset lineage panel faster to open and switch, with column lineage loaded on demand and pipeline parses cached.
 - **0.82.5**: Fixed the Run dropdown being clipped on ingestr assets, and added a "Run with debug" option that runs the asset with `--debug`.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.83.1**: Preview Dashboard offers to install or update `dac` when it's missing or outdated.
+- **0.83.1**: Preview Dashboard offers to install or update `dac` when it's missing or below the required version.
 - **0.83.0**: Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.
 - **0.82.6**: Made the asset lineage panel faster to open and switch, with column lineage loaded on demand and pipeline parses cached.
 - **0.82.5**: Fixed the Run dropdown being clipped on ingestr assets, and added a "Run with debug" option that runs the asset with `--debug`.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.83.0",
+  "version": "0.83.1",
   "dacFrontend": {
     "repo": "bruin-data/dac",
     "version": "v0.7.0",

--- a/src/bruin/dacInstallCli.ts
+++ b/src/bruin/dacInstallCli.ts
@@ -1,0 +1,60 @@
+import * as vscode from "vscode";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import { findGitBashPath } from "./bruinUtils";
+
+const DAC_INSTALL_SCRIPT = "https://getbruin.com/install/dac";
+const TASK_NAME = "DAC Install";
+
+/** Shell command that installs (or updates) dac, routed through Git Bash on Windows. */
+function installCommand(): string {
+  const base = `curl -LsSL ${DAC_INSTALL_SCRIPT} | sh`;
+  if (os.platform() !== "win32") {
+    return base;
+  }
+  const gitBashPath = findGitBashPath();
+  if (!gitBashPath) {
+    throw new Error("Git Bash not found. Install Git or set its path in settings.");
+  }
+  const profile = vscode.workspace
+    .getConfiguration("terminal.integrated.defaultProfile")
+    .get<string>("windows");
+  if (profile && profile.toLowerCase().includes("bash")) {
+    return base;
+  }
+  const batchFilePath = path.join(os.tmpdir(), "dac-install.bat");
+  fs.writeFileSync(batchFilePath, `@echo off\r\n"${gitBashPath}" -c "${base}"\r\n`);
+  return batchFilePath;
+}
+
+/** Runs the dac install script in a VS Code task; resolves when it exits 0. */
+export async function installDac(): Promise<void> {
+  const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const task = new vscode.Task(
+    { type: "shell" },
+    vscode.TaskScope.Workspace,
+    TASK_NAME,
+    "dac",
+    new vscode.ShellExecution(installCommand(), { cwd })
+  );
+  task.presentationOptions = {
+    reveal: vscode.TaskRevealKind.Always,
+    panel: vscode.TaskPanelKind.Shared,
+    close: false,
+  };
+  await new Promise<void>((resolve, reject) => {
+    const disposable = vscode.tasks.onDidEndTaskProcess((e) => {
+      if (e.execution.task.name !== TASK_NAME) {
+        return;
+      }
+      disposable.dispose();
+      if (e.exitCode === 0) {
+        resolve();
+      } else {
+        reject(new Error(`dac install failed with exit code ${e.exitCode}`));
+      }
+    });
+    vscode.tasks.executeTask(task);
+  });
+}

--- a/src/panels/DacPreviewPanel.ts
+++ b/src/panels/DacPreviewPanel.ts
@@ -231,14 +231,35 @@ export class DacPreviewPanel {
     extensionUri: vscode.Uri,
     output: vscode.OutputChannel
   ): Promise<void> {
+    const svc = DacExecutableService.getInstance();
     try {
       await installDac();
-      DacExecutableService.getInstance().invalidateCache();
-      await DacPreviewPanel.open(documentUri, extensionUri);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       output.appendLine(`[dac] install failed: ${msg}`);
       vscode.window.showErrorMessage(`Bruin: dac install failed — ${msg}`);
+      return;
+    }
+    // The script installs to the default location. If the resolved binary is
+    // still missing/old it's because `bruin.dac.executable` pins another path
+    // that wins — retrying would just re-prompt, so point the user at the setting.
+    svc.invalidateCache();
+    const version = await svc.getVersion();
+    if (version && isDacVersionSupported(version)) {
+      await DacPreviewPanel.open(documentUri, extensionUri);
+      return;
+    }
+    const configured = vscode.workspace.getConfiguration("bruin").get<string>("dac.executable") || "";
+    const detail = configured
+      ? `\`bruin.dac.executable\` points to ${configured}, which overrides the installed dac`
+      : `the installed dac still isn't resolving`;
+    output.appendLine(`[dac] post-install still unsupported (version=${version}); ${detail}`);
+    const choice = await vscode.window.showWarningMessage(
+      `Bruin: dac installed, but ${detail}. Update or clear that setting, then run Preview Dashboard again.`,
+      "Open Settings"
+    );
+    if (choice === "Open Settings") {
+      await vscode.commands.executeCommand("workbench.action.openSettings", "bruin.dac.executable");
     }
   }
 

--- a/src/panels/DacPreviewPanel.ts
+++ b/src/panels/DacPreviewPanel.ts
@@ -7,6 +7,7 @@ import {
   isDacVersionSupported,
   MIN_DAC_VERSION,
 } from "../providers/DacExecutableService";
+import { installDac } from "../bruin/dacInstallCli";
 import { getNonce } from "../utilities/getNonce";
 import { getUri } from "../utilities/getUri";
 
@@ -224,6 +225,23 @@ export class DacPreviewPanel {
     return DacPreviewPanel.output;
   }
 
+  /** Runs the dac install script, then re-opens the preview against the fresh binary. */
+  private static async installDacAndRetry(
+    documentUri: vscode.Uri,
+    extensionUri: vscode.Uri,
+    output: vscode.OutputChannel
+  ): Promise<void> {
+    try {
+      await installDac();
+      DacExecutableService.getInstance().invalidateCache();
+      await DacPreviewPanel.open(documentUri, extensionUri);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      output.appendLine(`[dac] install failed: ${msg}`);
+      vscode.window.showErrorMessage(`Bruin: dac install failed — ${msg}`);
+    }
+  }
+
   public static async open(documentUri: vscode.Uri, extensionUri: vscode.Uri): Promise<void> {
     const dashboardDir = path.dirname(documentUri.fsPath);
     const output = DacPreviewPanel.getOutput();
@@ -245,10 +263,13 @@ export class DacPreviewPanel {
     if (!isDacVersionSupported(version)) {
       output.appendLine(`[dac] version ${version} < required ${MIN_DAC_VERSION}`);
       const choice = await vscode.window.showErrorMessage(
-        `Bruin: Dashboard Preview needs dac ${MIN_DAC_VERSION} or newer (found ${version}). Run \`dac upgrade\`.`,
+        `Bruin: Dashboard Preview needs dac ${MIN_DAC_VERSION} or newer (found ${version}).`,
+        "Update dac",
         "Show Output"
       );
-      if (choice === "Show Output") {
+      if (choice === "Update dac") {
+        await DacPreviewPanel.installDacAndRetry(documentUri, extensionUri, output);
+      } else if (choice === "Show Output") {
         output.show();
       }
       return;
@@ -275,17 +296,20 @@ export class DacPreviewPanel {
     } catch (err) {
       if (err instanceof DacNotFoundError) {
         output.appendLine(`[dac] ${err.message}`);
+        panel.dispose();
         const choice = await vscode.window.showErrorMessage(
           "Bruin: the 'dac' executable was not found.",
+          "Install dac",
           "Open Settings"
         );
-        if (choice === "Open Settings") {
+        if (choice === "Install dac") {
+          await DacPreviewPanel.installDacAndRetry(documentUri, extensionUri, output);
+        } else if (choice === "Open Settings") {
           await vscode.commands.executeCommand(
             "workbench.action.openSettings",
             "bruin.dac.executable"
           );
         }
-        panel.dispose();
         return;
       }
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
When the `dac` CLI is missing or older than the required version, Preview Dashboard now offers to install or update it (via the dac install script) and retries automatically, instead of just failing with a settings link.

Follow-up to the DAC preview feature (#801).