### PR TITLE
Smooth asset switching (no SQL/lineage flicker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.83.2]
+- Switching assets updates the SQL editor and lineage in place instead of reloading.
+
 ## [0.83.1]
 - Preview Dashboard offers to install or update `dac` when it's missing or below the required version.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.83.2**: Switching assets updates the SQL editor and lineage in place instead of reloading.
 - **0.83.1**: Preview Dashboard offers to install or update `dac` when it's missing or below the required version.
 - **0.83.0**: Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.
 - **0.82.6**: Made the asset lineage panel faster to open and switch, with column lineage loaded on demand and pipeline parses cached.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.83.1",
+  "version": "0.83.2",
   "dacFrontend": {
     "repo": "bruin-data/dac",
     "version": "v0.7.0",

--- a/src/bruin/bruinFlowLineage.ts
+++ b/src/bruin/bruinFlowLineage.ts
@@ -147,6 +147,7 @@ export class BruinLineageInternalParse extends BruinCommand {
         updateLineageData({
           status: "success",
           message: lineageData,
+          filePath,
         });
       } else {
         // For individual assets, find the specific asset
@@ -169,6 +170,7 @@ export class BruinLineageInternalParse extends BruinCommand {
           updateLineageData({
             status: "success",
             message: lineageData,
+            filePath,
           });
         } else {
           throw new Error("Asset not found in pipeline data");
@@ -185,11 +187,13 @@ export class BruinLineageInternalParse extends BruinCommand {
         updateLineageData({
           status: "error",
           message: formattedError,
+          filePath,
         });
       } else {
         updateLineageData({
           status: "error",
           message: errorMessage,
+          filePath,
         });
       }
   

--- a/src/bruin/bruinRender.ts
+++ b/src/bruin/bruinRender.ts
@@ -58,6 +58,7 @@ export class BruinRender extends BruinCommand {
       BruinPanel?.postMessage("render-message", {
         status: "non-asset-alert",
         message: "-- This is not a BRUIN asset --",
+        filePath,
       });
       console.log("This is not a BRUIN asset");
       return;
@@ -69,6 +70,7 @@ export class BruinRender extends BruinCommand {
       BruinPanel?.postMessage("render-message", {
         status: "bruin-asset-alert",
         message: "-- Python, Yaml, or Pipeline BRUIN asset detected --",
+        filePath,
       });
       return;
     }
@@ -81,6 +83,7 @@ export class BruinRender extends BruinCommand {
             BruinPanel?.postMessage("render-message", {
               status: "success",
               message: parsed.query,
+              filePath,
             });
           } catch (parseErr) {
             console.error("Invalid JSON from bruin render output", parseErr);
@@ -91,6 +94,7 @@ export class BruinRender extends BruinCommand {
               BruinPanel?.postMessage("render-message", {
                 status: "error",
                 message: this.parseError(fallbackErr),
+                filePath,
               });
             }
           }
@@ -101,7 +105,8 @@ export class BruinRender extends BruinCommand {
         setTimeout(() => {
           BruinPanel?.postMessage("render-message", {
             status: "error",
-            message: this.parseError(error)
+            message: this.parseError(error),
+            filePath,
           });
         }, 1000);
     
@@ -143,6 +148,7 @@ export class BruinRender extends BruinCommand {
       BruinPanel?.postMessage("render-message", {
         status: "non-asset-alert",
         message: "-- This is not a BRUIN asset --",
+        filePath,
       });
       console.log("This is not a BRUIN asset");
       return false;
@@ -161,6 +167,7 @@ export class BruinRender extends BruinCommand {
       BruinPanel?.postMessage("render-message", {
         status: "bruin-asset-alert",
         message: "-- Python or Yaml BRUIN asset detected --",
+        filePath,
       });
       console.log("Python or Yaml BRUIN asset detected");
       return true;
@@ -182,6 +189,7 @@ export class BruinRender extends BruinCommand {
         BruinPanel?.postMessage("render-message", {
           status: "success",
           message: result,
+          filePath,
         });
       },
       (err) => {
@@ -189,6 +197,7 @@ export class BruinRender extends BruinCommand {
         BruinPanel?.postMessage("render-message", {
           status: "error",
           message: JSON.stringify({ error: err }),
+          filePath,
         });
         console.error("Error rendering SQL asset without JSON", err);
       }

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -689,33 +689,36 @@ export class BruinPanel {
               break;
             }
 
+            // Capture the request's path up front so a failure is tagged with
+            // the file it was requested for, not whatever is active by the time
+            // it rejects (the user may have switched assets in between).
+            const ddlFilePath = this._lastRenderedDocumentUri.fsPath;
             try {
               const ddlRenderer = new BruinRenderDdl(
                 getBruinExecutablePath(),
                 vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || ""
               );
-              
-              const filePath = this._lastRenderedDocumentUri.fsPath;
+
               const flagArgs: string[] = [];
-              
+
               if (this._currentStartDate) {
                 flagArgs.push("--start-date", this._currentStartDate);
               }
-              
+
               if (this._currentEndDate) {
                 flagArgs.push("--end-date", this._currentEndDate);
               }
-              
+
               if (this._checkboxState?.["Interval-modifiers"]) {
                 flagArgs.push("--apply-interval-modifiers");
               }
-              
-              const ddl = await ddlRenderer.renderDdl(filePath, flagArgs, false);
+
+              const ddl = await ddlRenderer.renderDdl(ddlFilePath, flagArgs, false);
               this._panel.webview.postMessage({
                 command: "ddlResponse",
                 status: "success",
                 ddl,
-                filePath
+                filePath: ddlFilePath
               });
             } catch (error) {
               const errorMessage = error instanceof Error ? error.message : String(error);
@@ -723,7 +726,7 @@ export class BruinPanel {
                 command: "ddlResponse",
                 status: "error",
                 message: `Failed to generate DDL: ${errorMessage}`,
-                filePath: this._lastRenderedDocumentUri?.fsPath
+                filePath: ddlFilePath
               });
             }
             break;

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -396,7 +396,7 @@ export class BruinPanel {
 
   public static postMessage(
     name: string,
-    data: string | { status: string; message: string | any },
+    data: string | { status: string; message: string | any; [key: string]: any },
     panelType?: string
   ) {
     if (BruinPanel.currentPanel?._panel) {
@@ -714,14 +714,16 @@ export class BruinPanel {
               this._panel.webview.postMessage({
                 command: "ddlResponse",
                 status: "success",
-                ddl
+                ddl,
+                filePath
               });
             } catch (error) {
               const errorMessage = error instanceof Error ? error.message : String(error);
               this._panel.webview.postMessage({
                 command: "ddlResponse",
                 status: "error",
-                message: `Failed to generate DDL: ${errorMessage}`
+                message: `Failed to generate DDL: ${errorMessage}`,
+                filePath: this._lastRenderedDocumentUri?.fsPath
               });
             }
             break;

--- a/src/panels/LineagePanel.ts
+++ b/src/panels/LineagePanel.ts
@@ -189,6 +189,7 @@ export abstract class BaseLineagePanel implements vscode.WebviewViewProvider, vs
       this._view.webview.postMessage({
         command: "flow-lineage-loading",
         panelType: this.panelType,
+        filePath: this._lastRenderedDocumentUri?.fsPath,
       });
     }
   }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -4262,7 +4262,8 @@ suite(" Query export Tests", () => {
             id: "asset-1",
             name: "test-asset",
             pipeline: JSON.stringify(mockPipelineData)
-          }
+          },
+          filePath
         });
       });
 
@@ -4294,7 +4295,8 @@ suite(" Query export Tests", () => {
         sinon.assert.calledWith(showErrorMessageStub, "Bruin CLI command not recognized. Please check that Bruin CLI is installed and the command is correct.");
         sinon.assert.calledWith(updateLineageDataStub, {
           status: "error",
-          message: "Bruin CLI command not recognized. Please check that Bruin CLI is installed and the command is correct."
+          message: "Bruin CLI command not recognized. Please check that Bruin CLI is installed and the command is correct.",
+          filePath
         });
       });
 
@@ -4310,7 +4312,8 @@ suite(" Query export Tests", () => {
         
         sinon.assert.calledWith(updateLineageDataStub, {
           status: "error",
-          message: "String error message"
+          message: "String error message",
+          filePath
         });
       });
 
@@ -4326,7 +4329,8 @@ suite(" Query export Tests", () => {
         
         sinon.assert.calledWith(updateLineageDataStub, {
           status: "error",
-          message: "Object error message"
+          message: "Object error message",
+          filePath
         });
       });
 

--- a/webview-ui/src/App.vue
+++ b/webview-ui/src/App.vue
@@ -118,7 +118,7 @@
         <component
           v-if="isTabActive(index)"
           :is="tab.component"
-          :key="`${index}-${lastRenderedDocument}`"
+          :key="`tab-view-${index}`"
           v-bind="tab.props"
           class="flex w-full h-full"
           @update:description="updateDescription"

--- a/webview-ui/src/AssetLineage.vue
+++ b/webview-ui/src/AssetLineage.vue
@@ -12,7 +12,7 @@
 <script setup lang="ts">
 import Lineage from "@/components/lineage-flow/Lineage.vue";
 import { ref, onUnmounted, computed, watch, onMounted } from "vue";
-import { updateValue } from "./utilities/helper";
+import { updateValue, normalizePath } from "./utilities/helper";
 import { getAssetDataset } from "@/components/lineage-flow/asset-lineage/useAssetLineage";
 
 /**
@@ -59,7 +59,13 @@ const handleMessage = (event) => {
       const responseFile = message.payload?.filePath;
       // Drop a response for a file we're no longer waiting on — an out-of-order
       // result from a previous asset must not touch the current graph/state.
-      if (expectedFile && responseFile && responseFile !== expectedFile) {
+      // Compare normalized paths so Windows/macOS case and separator differences
+      // don't wrongly reject a matching response.
+      if (
+        expectedFile &&
+        responseFile &&
+        normalizePath(responseFile) !== normalizePath(expectedFile)
+      ) {
         return;
       }
       isReloading.value = false;
@@ -84,7 +90,9 @@ const handleMessage = (event) => {
       // A response for a different file than what's drawn is a switch; on
       // failure that must drop the previous asset's graph. A same-file re-parse
       // that errors keeps the last good graph and just surfaces the error.
-      const isSwitch = !displayedFile || (responseFile && responseFile !== displayedFile);
+      const isSwitch =
+        !displayedFile ||
+        (responseFile && normalizePath(responseFile) !== normalizePath(displayedFile));
       if (newData || isSwitch) {
         lineageData.value = newData;
       }

--- a/webview-ui/src/AssetLineage.vue
+++ b/webview-ui/src/AssetLineage.vue
@@ -25,6 +25,10 @@ const lineageData = ref(); // Holds the lineage data received from the extension
 const lineageError = ref(); // Holds any errors related to lineage data
 const hasTimedOut = ref(false); // Tracks if initial load has timed out
 const isReloading = ref(false); // A new parse is in flight (file switch / edit)
+// True while an asset switch is in flight (the panel only sends the loading
+// signal on a real file change). Lets us tell a switch apart from a same-file
+// re-parse so a failed switch drops the graph while a same-file error keeps it.
+const switchPending = ref(false);
 
 let lastMessageId: string | null = null;
 
@@ -39,10 +43,11 @@ const handleMessage = (event) => {
   
   switch (message.command) {
     case "flow-lineage-loading":
-      // A new parse started (file switch / edit). Only fall back to the loading
-      // spinner when there's nothing to show yet; if we already have a graph,
-      // keep it on screen and let the incoming data swap it in place so the
-      // switch is smooth instead of blanking to a spinner.
+      // A real file switch started (this signal is only sent on a file change).
+      // Only fall back to the loading spinner when there's nothing to show yet;
+      // if we already have a graph, keep it on screen and let the incoming data
+      // swap it in place so the switch is smooth instead of blanking.
+      switchPending.value = true;
       if (!lineageData.value) {
         isReloading.value = true;
       }
@@ -67,8 +72,18 @@ const handleMessage = (event) => {
         return;
       }
       lastMessageId = messageId;
-      
-      lineageData.value = newData;
+
+      const wasSwitch = switchPending.value;
+      switchPending.value = false;
+
+      if (newData || wasSwitch) {
+        // Valid data, or a switch that failed: adopt the result (null on a
+        // failed switch clears the previous asset's graph so it isn't left
+        // showing under the new file).
+        lineageData.value = newData;
+      }
+      // Otherwise this is a same-file re-parse that errored — keep the last
+      // good graph on screen and just surface the error.
       lineageError.value = newError;
       break;
   }

--- a/webview-ui/src/AssetLineage.vue
+++ b/webview-ui/src/AssetLineage.vue
@@ -25,10 +25,12 @@ const lineageData = ref(); // Holds the lineage data received from the extension
 const lineageError = ref(); // Holds any errors related to lineage data
 const hasTimedOut = ref(false); // Tracks if initial load has timed out
 const isReloading = ref(false); // A new parse is in flight (file switch / edit)
-// True while an asset switch is in flight (the panel only sends the loading
-// signal on a real file change). Lets us tell a switch apart from a same-file
-// re-parse so a failed switch drops the graph while a same-file error keeps it.
-const switchPending = ref(false);
+// The file whose parse we're now waiting on (from the loading signal, sent only
+// on a real file change) and the file currently drawn. Correlating responses by
+// path — rather than a shared flag — means an out-of-order response for an older
+// asset can't be mistaken for the current one when loads overlap.
+let expectedFile: string | undefined;
+let displayedFile: string | undefined;
 
 let lastMessageId: string | null = null;
 
@@ -44,20 +46,26 @@ const handleMessage = (event) => {
   switch (message.command) {
     case "flow-lineage-loading":
       // A real file switch started (this signal is only sent on a file change).
-      // Only fall back to the loading spinner when there's nothing to show yet;
-      // if we already have a graph, keep it on screen and let the incoming data
-      // swap it in place so the switch is smooth instead of blanking.
-      switchPending.value = true;
+      // Remember the target so we can correlate the eventual response. Only fall
+      // back to the loading spinner when there's nothing to show yet; if we
+      // already have a graph, keep it on screen and swap in place.
+      expectedFile = message.filePath;
       if (!lineageData.value) {
         isReloading.value = true;
       }
       lineageError.value = undefined;
       return;
     case "flow-lineage-message":
+      const responseFile = message.payload?.filePath;
+      // Drop a response for a file we're no longer waiting on — an out-of-order
+      // result from a previous asset must not touch the current graph/state.
+      if (expectedFile && responseFile && responseFile !== expectedFile) {
+        return;
+      }
       isReloading.value = false;
       const newData = updateValue(message, "success");
       const newError = updateValue(message, "error");
-      
+
       // Create a detailed hash to detect truly identical messages
       const messageId = JSON.stringify({ 
         assetId: newData?.id, 
@@ -73,17 +81,16 @@ const handleMessage = (event) => {
       }
       lastMessageId = messageId;
 
-      const wasSwitch = switchPending.value;
-      switchPending.value = false;
-
-      if (newData || wasSwitch) {
-        // Valid data, or a switch that failed: adopt the result (null on a
-        // failed switch clears the previous asset's graph so it isn't left
-        // showing under the new file).
+      // A response for a different file than what's drawn is a switch; on
+      // failure that must drop the previous asset's graph. A same-file re-parse
+      // that errors keeps the last good graph and just surfaces the error.
+      const isSwitch = !displayedFile || (responseFile && responseFile !== displayedFile);
+      if (newData || isSwitch) {
         lineageData.value = newData;
       }
-      // Otherwise this is a same-file re-parse that errored — keep the last
-      // good graph on screen and just surface the error.
+      if (responseFile) {
+        displayedFile = responseFile;
+      }
       lineageError.value = newError;
       break;
   }

--- a/webview-ui/src/AssetLineage.vue
+++ b/webview-ui/src/AssetLineage.vue
@@ -39,9 +39,13 @@ const handleMessage = (event) => {
   
   switch (message.command) {
     case "flow-lineage-loading":
-      // A new parse started (file switch / edit): show loading instead of the
-      // previous graph so stale content isn't left on screen.
-      isReloading.value = true;
+      // A new parse started (file switch / edit). Only fall back to the loading
+      // spinner when there's nothing to show yet; if we already have a graph,
+      // keep it on screen and let the incoming data swap it in place so the
+      // switch is smooth instead of blanking to a spinner.
+      if (!lineageData.value) {
+        isReloading.value = true;
+      }
       lineageError.value = undefined;
       return;
     case "flow-lineage-message":

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -490,6 +490,7 @@ import {
   concatCommandFlags,
   adjustEndDateForExclusive,
   resetStartEndDate,
+  normalizePath,
 } from "@/utilities/helper";
 import "@/assets/index.css";
 import DateInput from "@/components/ui/date-inputs/DateInput.vue";
@@ -2131,6 +2132,16 @@ function receiveMessage(event: { data: any }) {
       isNotAsset.value = true;
       break;
     case "render-message":
+      // The component now persists across asset switches, so ignore render
+      // responses tagged for a different file — a slow render for the previous
+      // asset must not overwrite the current asset's preview.
+      if (
+        envelope.payload?.filePath &&
+        props.filePath &&
+        normalizePath(envelope.payload.filePath) !== normalizePath(props.filePath)
+      ) {
+        break;
+      }
       renderSQLAssetSuccess.value = updateValue(envelope, "success");
       renderSQLAssetError.value = updateValue(envelope, "error");
       renderPythonAsset.value = updateValue(envelope, "bruin-asset-alert");

--- a/webview-ui/src/components/asset/AssetGeneral.vue
+++ b/webview-ui/src/components/asset/AssetGeneral.vue
@@ -463,7 +463,7 @@
           <!-- SqlEditor handles both success and error cost display in its header -->
           <SqlEditor :code="code" :copied="false" :language="language" :showIntervalAlert="showIntervalAlert"
             :assetType="props.assetType" :bigqueryMetadata="bigqueryMetadata"
-            :bigqueryError="props.assetMetadataError" />
+            :bigqueryError="props.assetMetadataError" :filePath="props.filePath" />
           <div class="overflow-hidden w-full h-20"></div>
         </div>
         <div v-else class="overflow-hidden w-full h-40">
@@ -1401,18 +1401,7 @@ onMounted(() => {
     applyVariableOverrides.value = persistedState.applyVariableOverrides;
   }
   // Restore tags for the current pipeline (only if we have a valid file path)
-  try {
-    const currentFilePath = props.filePath;
-    if (currentFilePath && persistedState?.tagFiltersByPipeline?.[currentFilePath]) {
-      const pipelineTags = persistedState.tagFiltersByPipeline[currentFilePath];
-      if (Array.isArray(pipelineTags.includeTags)) {
-        includeTags.value = [...pipelineTags.includeTags];
-      }
-      if (Array.isArray(pipelineTags.excludeTags)) {
-        excludeTags.value = [...pipelineTags.excludeTags];
-      }
-    }
-  } catch (_) { }
+  restoreTagFiltersForCurrentFile();
 
   sendInitialMessage();
   window.addEventListener("message", receiveMessage);
@@ -1556,6 +1545,14 @@ watch(
       requestTimeout = null;
     }
     isRequestingVariables.value = false;
+    // The panel no longer remounts on asset switch (to avoid flicker), so the
+    // per-file setup that used to run in onMounted is re-run here: reload this
+    // pipeline's tag filters and request a fresh render so the SQL preview
+    // updates in place instead of showing the previous asset's code.
+    if (newPath && newPath !== oldPath) {
+      restoreTagFiltersForCurrentFile();
+      sendInitialMessage();
+    }
   }
 );
 
@@ -1578,6 +1575,28 @@ watch(
   },
   { immediate: true }
 );
+// Restore the include/exclude tag filters persisted for the current pipeline
+// file. Called on mount and whenever the active asset changes.
+function restoreTagFiltersForCurrentFile() {
+  try {
+    const currentFilePath = props.filePath;
+    const persistedState = (vscode.getState() as {
+      tagFiltersByPipeline?: Record<string, { includeTags: string[]; excludeTags: string[] }>;
+    }) || {};
+    const pipelineTags = currentFilePath
+      ? persistedState?.tagFiltersByPipeline?.[currentFilePath]
+      : undefined;
+    if (pipelineTags) {
+      includeTags.value = Array.isArray(pipelineTags.includeTags) ? [...pipelineTags.includeTags] : [];
+      excludeTags.value = Array.isArray(pipelineTags.excludeTags) ? [...pipelineTags.excludeTags] : [];
+    } else {
+      // No saved filters for this file: clear any carried over from the previous asset.
+      includeTags.value = [];
+      excludeTags.value = [];
+    }
+  } catch (_) { }
+}
+
 function sendInitialMessage() {
   const checkboxState = checkboxItems.value.reduce(
     (acc, item) => {
@@ -2121,7 +2140,9 @@ function receiveMessage(event: { data: any }) {
       if (renderSQLAssetSuccess.value) {
         code.value = renderSQLAssetSuccess.value;
         language.value = "sql";
-      } else if (!renderPythonAsset.value) {
+      } else {
+        // No SQL to preview (python/non-asset/empty): clear so the previous
+        // asset's rendered SQL isn't left on screen after an in-place switch.
         code.value = null;
         language.value = "";
       }

--- a/webview-ui/src/components/asset/SqlEditor.vue
+++ b/webview-ui/src/components/asset/SqlEditor.vue
@@ -153,7 +153,7 @@ import "highlight.js/styles/default.css";
 import hljs from "highlight.js/lib/core";
 import { DynamicScroller, DynamicScrollerItem } from "vue3-virtual-scroller";
 import "vue3-virtual-scroller/dist/vue3-virtual-scroller.css";
-import { formatBytes, calculateBigQueryCost } from "@/utilities/helper";
+import { formatBytes, calculateBigQueryCost, normalizePath } from "@/utilities/helper";
 import { vscode } from "@/utilities/vscode";
 
 const props = defineProps({
@@ -452,7 +452,11 @@ const handleMessage = (event) => {
     // The editor persists across asset switches, so ignore a DDL response that
     // resolved for a previously active file — otherwise it would populate the
     // current asset's tab with stale DDL and suppress the correct request.
-    if (envelope.filePath && props.filePath && envelope.filePath !== props.filePath) {
+    if (
+      envelope.filePath &&
+      props.filePath &&
+      normalizePath(envelope.filePath) !== normalizePath(props.filePath)
+    ) {
       return;
     }
     console.log('Processing DDL response:', envelope);

--- a/webview-ui/src/components/asset/SqlEditor.vue
+++ b/webview-ui/src/components/asset/SqlEditor.vue
@@ -181,6 +181,10 @@ const props = defineProps({
     type: String,
     default: 'Preview',
   },
+  filePath: {
+    type: String,
+    default: '',
+  },
 });
 
 const activeTab = ref('preview');
@@ -476,6 +480,19 @@ watch(
   () => props.showIntervalAlert,
   (newVal) => {
     showIntervalAlert.value = newVal;
+  }
+);
+
+// The editor stays mounted across asset switches now, so reset the DDL tab when
+// the active file changes — otherwise the previous asset's DDL would linger.
+watch(
+  () => props.filePath,
+  (newPath, oldPath) => {
+    if (newPath !== oldPath) {
+      activeTab.value = 'preview';
+      ddlContent.value = '';
+      ddlLoading.value = false;
+    }
   }
 );
 </script>

--- a/webview-ui/src/components/asset/SqlEditor.vue
+++ b/webview-ui/src/components/asset/SqlEditor.vue
@@ -449,6 +449,12 @@ const handleMessage = (event) => {
   console.log('SqlEditor received message:', envelope);
   
   if (envelope.command === 'ddlResponse') {
+    // The editor persists across asset switches, so ignore a DDL response that
+    // resolved for a previously active file — otherwise it would populate the
+    // current asset's tab with stale DDL and suppress the correct request.
+    if (envelope.filePath && props.filePath && envelope.filePath !== props.filePath) {
+      return;
+    }
     console.log('Processing DDL response:', envelope);
     handleDdlResponse(envelope);
   }

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -805,11 +805,26 @@ watch(
   { immediate: false }
 );
 
+// Clear every view's graph. Used when the new target has no lineage (error or
+// empty parse) so the previous asset's graph isn't left visible in place.
+const clearAllGraphs = () => {
+  setNodes([]);
+  setEdges([]);
+  pipelineElements.value = { nodes: [], edges: [] };
+  columnElements.value = { nodes: [], edges: [] };
+};
+
 watch(
   () => [props.assetDataset, props.pipelineData],
   () => {
     const key = computeTargetKey();
-    if (!props.assetDataset) return;
+    if (!props.assetDataset) {
+      // The replacement asset produced no lineage: drop the stale graph rather
+      // than leaving the previous asset's nodes under the current file.
+      clearAllGraphs();
+      lastViewKey = "";
+      return;
+    }
 
     if (key !== lastViewKey) {
       // Switched target: reset to its default view.

--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -526,11 +526,16 @@ const fitViewSmooth = async (forceAutoFit = false, useAnimation = false) => {
 
 const _updateGraph = async () => {
   if (!showPipelineView.value && !showColumnView.value) {
-    isLoadingLocal.value = true;
-    isLayouting.value = true;
-    // Clear the previous asset's graph so it isn't shown while this builds.
-    setNodes([]);
-    setEdges([]);
+    // Keep any existing graph on screen while the new one is laid out so an
+    // asset switch swaps in place instead of flashing an empty canvas/spinner.
+    // Only show the loading state (and clear) when there's nothing to show yet.
+    const hasExistingGraph = nodes.value.length > 0;
+    if (!hasExistingGraph) {
+      isLoadingLocal.value = true;
+      isLayouting.value = true;
+      setNodes([]);
+      setEdges([]);
+    }
 
     const gen = ++buildGeneration;
     try {
@@ -600,10 +605,9 @@ const processProperties = async () => {
   
   // Don't set loading states here - let _updateGraph handle it
   error.value = null;
-  // updateGraph is debounced, so clear the previous asset's graph now to avoid
-  // showing it for the debounce window before the new one is built.
-  setNodes([]);
-  setEdges([]);
+  // Keep the previous graph on screen through the debounce window; _updateGraph
+  // swaps in the new layout in place (and only clears when there's nothing to
+  // show yet), so switching assets no longer flashes an empty canvas.
   console.log('🔄 [Lineage] Starting graph update');
   try {
     await updateGraph();


### PR DESCRIPTION
Switching between assets flickered: the SQL editor fully reloaded and the lineage graph blanked to a spinner on every switch.

Both surfaces now update in place instead of tearing down.

**SQL editor**
- The main panel keyed the active tab on the file path, so every switch destroyed and recreated the `AssetDetails → AssetGeneral → SqlEditor` subtree. The key is now stable per-tab, so the components stay mounted.
- The render was only being re-triggered as a side effect of that remount. A `filePath` watch now re-runs the per-file setup (reload tag filters, request a fresh render) so the preview swaps in place.
- `render-message` clears the code when the new asset has no SQL, so a previous asset's query can't linger.
- `SqlEditor` resets its DDL tab on asset change.

**Lineage**
- On a file switch the previous graph now stays on screen until the new one is laid out, then swaps, instead of blanking to a loading spinner / empty canvas. Existing build-generation guards still prevent a slow older build from overwriting a newer one.

Verified with `build:webview` and the webview unit tests.