### PR TITLE
Sync materialization & ingestr strategy lists with Bruin CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [0.83.3]
-- Synced the materialization strategy options with the Bruin CLI: added `time_interval` and the Data Vault strategies (`datavault_hub`, `datavault_link`, `datavault_satellite`) for SQL assets, and updated the ingestr strategy set to add `scd2` and drop the removed `truncate+insert`.
+- Synced the materialization strategy options with the Bruin CLI: added `time_interval` and the Data Vault strategies (`datavault_hub`, `datavault_link`, `datavault_satellite`) for SQL assets, accepted `replace` as an alias for `create+replace`, and updated the ingestr strategy set to add `scd2` and drop the removed `truncate+insert`.
 
 ## [0.83.2]
 - Switching assets updates the SQL editor and lineage in place instead of reloading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.83.3]
+- Synced the materialization strategy options with the Bruin CLI: added `time_interval` and the Data Vault strategies (`datavault_hub`, `datavault_link`, `datavault_satellite`) for SQL assets, and updated the ingestr strategy set to add `scd2` and drop the removed `truncate+insert`.
+
 ## [0.83.2]
 - Switching assets updates the SQL editor and lineage in place instead of reloading.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.83.3**: Synced the materialization strategy options with the Bruin CLI — added `time_interval` and the Data Vault strategies (`datavault_hub`, `datavault_link`, `datavault_satellite`) for SQL assets, and updated the ingestr strategy set to add `scd2` and drop the removed `truncate+insert`.
+- **0.83.3**: Synced the materialization strategy options with the Bruin CLI — added `time_interval` and the Data Vault strategies (`datavault_hub`, `datavault_link`, `datavault_satellite`) for SQL assets, accepted `replace` as an alias for `create+replace`, and updated the ingestr strategy set to add `scd2` and drop the removed `truncate+insert`.
 - **0.83.2**: Switching assets updates the SQL editor and lineage in place instead of reloading.
 - **0.83.1**: Preview Dashboard offers to install or update `dac` when it's missing or below the required version.
 - **0.83.0**: Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.83.3**: Synced the materialization strategy options with the Bruin CLI — added `time_interval` and the Data Vault strategies (`datavault_hub`, `datavault_link`, `datavault_satellite`) for SQL assets, and updated the ingestr strategy set to add `scd2` and drop the removed `truncate+insert`.
 - **0.83.2**: Switching assets updates the SQL editor and lineage in place instead of reloading.
 - **0.83.1**: Preview Dashboard offers to install or update `dac` when it's missing or below the required version.
 - **0.83.0**: Added a Dashboards-as-Code preview — open a dashboard YAML and click the Preview Dashboard button in the editor toolbar to render it in a theme-matched webview backed by `dac serve`, with live reload on edit and an Open-in-Browser button.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.83.2",
+  "version": "0.83.3",
   "dacFrontend": {
     "repo": "bruin-data/dac",
     "version": "v0.7.0",

--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -217,7 +217,8 @@
                 "merge",
                 "replace",
                 "append",
-                "scd2"
+                "scd2",
+                "none"
               ]
             },
             "incremental_key": {
@@ -501,12 +502,16 @@
       "enum": [
         "create+replace",
         "delete+insert",
+        "truncate+insert",
         "append",
         "merge",
+        "time_interval",
         "ddl",
-        "truncate+insert",
+        "scd2_by_time",
         "scd2_by_column",
-        "scd2_by_time"
+        "datavault_hub",
+        "datavault_link",
+        "datavault_satellite"
       ],
       "description": "Materialization strategy"
     },

--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -380,9 +380,10 @@
                       "delete+insert",
                       "append",
                       "merge",
-                      "truncate+insert"
+                      "scd2_by_time",
+                      "scd2_by_column"
                     ],
-                    "description": "For ingestr assets, materialization.strategy uses Bruin strategy names (create+replace maps to ingestr's \"replace\"). Valid: create+replace, delete+insert, append, merge, truncate+insert. To use raw ingestr names like \"replace\" or \"scd2\", set parameters.incremental_strategy instead."
+                    "description": "For ingestr assets, materialization.strategy uses Bruin strategy names (create+replace maps to ingestr's \"replace\"; scd2_by_time/scd2_by_column map to ingestr's \"scd2\"). Valid: create+replace, delete+insert, append, merge, scd2_by_time, scd2_by_column. To use raw ingestr names like \"replace\" or \"scd2\", set parameters.incremental_strategy instead."
                   }
                 }
               }

--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -377,13 +377,14 @@
                   "strategy": {
                     "enum": [
                       "create+replace",
+                      "replace",
                       "delete+insert",
                       "append",
                       "merge",
                       "scd2_by_time",
                       "scd2_by_column"
                     ],
-                    "description": "For ingestr assets, materialization.strategy uses Bruin strategy names (create+replace maps to ingestr's \"replace\"; scd2_by_time/scd2_by_column map to ingestr's \"scd2\"). Valid: create+replace, delete+insert, append, merge, scd2_by_time, scd2_by_column. To use raw ingestr names like \"replace\" or \"scd2\", set parameters.incremental_strategy instead."
+                    "description": "For ingestr assets, materialization.strategy uses Bruin strategy names. create+replace (or its alias replace) maps to ingestr's \"replace\"; scd2_by_time/scd2_by_column map to ingestr's \"scd2\". Valid: create+replace, replace, delete+insert, append, merge, scd2_by_time, scd2_by_column."
                   }
                 }
               }
@@ -528,6 +529,7 @@
       "type": "string",
       "enum": [
         "create+replace",
+        "replace",
         "delete+insert",
         "truncate+insert",
         "append",

--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -362,6 +362,32 @@
           "then": {
             "required": ["parameters"]
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": { "const": "ingestr" }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "materialization": {
+                "properties": {
+                  "strategy": {
+                    "enum": [
+                      "create+replace",
+                      "delete+insert",
+                      "append",
+                      "merge",
+                      "truncate+insert"
+                    ],
+                    "description": "For ingestr assets, materialization.strategy uses Bruin strategy names (create+replace maps to ingestr's \"replace\"). Valid: create+replace, delete+insert, append, merge, truncate+insert. To use raw ingestr names like \"replace\" or \"scd2\", set parameters.incremental_strategy instead."
+                  }
+                }
+              }
+            }
+          }
         }
       ]
     },

--- a/src/language-server/providers/materializationCompletions.ts
+++ b/src/language-server/providers/materializationCompletions.ts
@@ -272,7 +272,7 @@ export class MaterializationCompletions {
             { 
                 name: 'table', 
                 description: 'Materialize as a table - requires strategy',
-                insertText: new vscode.SnippetString('table\n  strategy: ${1|create+replace,delete+insert,merge,append,truncate+insert,ddl,scd2_by_column,scd2_by_time|}')
+                insertText: new vscode.SnippetString('table\n  strategy: ${1|create+replace,delete+insert,truncate+insert,append,merge,time_interval,ddl,scd2_by_time,scd2_by_column,datavault_hub,datavault_link,datavault_satellite|}')
             },
             { 
                 name: 'view', 
@@ -344,10 +344,25 @@ export class MaterializationCompletions {
                 description: 'SCD2 by column',
                 requiresIncrementalKey: true
             },
-            { 
-                name: 'scd2_by_time', 
+            {
+                name: 'scd2_by_time',
                 description: 'SCD2 by time (requires incremental_key)',
                 requiresIncrementalKey: true
+            },
+            {
+                name: 'datavault_hub',
+                description: 'Data Vault hub table (business keys)',
+                requiresIncrementalKey: false
+            },
+            {
+                name: 'datavault_link',
+                description: 'Data Vault link table (relationships between hubs)',
+                requiresIncrementalKey: false
+            },
+            {
+                name: 'datavault_satellite',
+                description: 'Data Vault satellite table (descriptive/historical attributes)',
+                requiresIncrementalKey: false
             }
         ];
 

--- a/webview-ui/src/components/asset/IngestrAssetDisplay.vue
+++ b/webview-ui/src/components/asset/IngestrAssetDisplay.vue
@@ -353,7 +353,8 @@ const INCREMENTAL_STRATEGIES = [
   { value: 'replace', label: 'Replace' },
   { value: 'append', label: 'Append' },
   { value: 'merge', label: 'Merge' },
-  { value: 'delete+insert', label: 'Delete + Insert' }
+  { value: 'delete+insert', label: 'Delete + Insert' },
+  { value: 'scd2', label: 'SCD2' }
 ] as const;
 
 import assetsSchema from '../../../../schemas/yaml-assets-schema.json';

--- a/webview-ui/src/components/asset/materialization/Materialization.vue
+++ b/webview-ui/src/components/asset/materialization/Materialization.vue
@@ -923,7 +923,8 @@ const allStrategyOptions = [
 
 // Ingestr assets delegate the load to ingestr's incremental engine, which only
 // supports these strategies (the SQL-only strategies are rejected by the CLI).
-const INGESTR_STRATEGIES = ["create+replace", "delete+insert", "append", "merge", "truncate+insert"];
+// scd2_by_time/scd2_by_column map to ingestr's "scd2".
+const INGESTR_STRATEGIES = ["create+replace", "delete+insert", "append", "merge", "scd2_by_time", "scd2_by_column"];
 
 const strategyOptions = computed(() =>
   props.assetType === "ingestr"

--- a/webview-ui/src/components/asset/materialization/Materialization.vue
+++ b/webview-ui/src/components/asset/materialization/Materialization.vue
@@ -916,6 +916,9 @@ const allStrategyOptions = [
   { value: "ddl", label: "DDL" },
   { value: "scd2_by_time", label: "SCD2 by Time" },
   { value: "scd2_by_column", label: "SCD2 by Column" },
+  { value: "datavault_hub", label: "Data Vault Hub" },
+  { value: "datavault_link", label: "Data Vault Link" },
+  { value: "datavault_satellite", label: "Data Vault Satellite" },
 ];
 
 // Ingestr assets delegate the load to ingestr's incremental engine, which only
@@ -1303,6 +1306,11 @@ function getStrategyDescription(strategy) {
     "time_interval": "Process time-based data using incremental key",
     "ddl":
       "Use DDL to create a new table using the information provided in the embedded Bruin section",
+    "scd2_by_time": "Track history using a time column (requires incremental key)",
+    "scd2_by_column": "Track history by comparing column values",
+    "datavault_hub": "Load into a Data Vault hub table (business keys)",
+    "datavault_link": "Load into a Data Vault link table (relationships between hubs)",
+    "datavault_satellite": "Load into a Data Vault satellite table (descriptive/historical attributes)",
   }[strategy];
 }
 


### PR DESCRIPTION
The extension's strategy lists had drifted from the Bruin CLI, so valid strategies showed up as validation errors / missing autocomplete in the editor.

**Sync the strategy lists with the CLI source of truth:**
- Materialization strategies (`AllAvailableMaterializationStrategies`, bruin `pkg/pipeline/pipeline.go`): added `time_interval` (was missing from the schema) and `datavault_hub`, `datavault_link`, `datavault_satellite`.
- Ingestr incremental strategies (ingestr `internal/config/config.go`): added `scd2`; added `none` to the schema enum.

**Make `materialization.strategy` type-aware for ingestr assets:**
The schema applied one flat strategy enum to every asset type, but ingestr assets only accept a subset. Added an `if type == ingestr` conditional so the editor rejects SQL-only strategies (`ddl`, `datavault_*`, `time_interval`) and guides `replace` → `create+replace`.

The ingestr set reflects what ingestr supports now: `create+replace, delete+insert, append, merge, scd2_by_time, scd2_by_column`. This drops `truncate+insert` (ingestr removed it — "use replace") and adds scd2 (the `scd2_*` names map to ingestr's `scd2`), matching the Bruin CLI once its bruin→ingestr strategy map is updated.

Verified with a draft-07 validator across ingestr + SQL assets.

Strategies change far less often than connection types, so these lists stay hand-maintained (unlike `config-schema.json`, which is synced daily) — the CLI has no command to enumerate strategies.
