### PR TITLE
Show Fabric/MSSQL/Synapse connections in Databases panel; fix dac SPA in dev:watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -474,10 +474,11 @@
   "scripts": {
     "install:all": "npm install && cd webview-ui && npm install",
     "start:webview": "cd webview-ui && npm run start",
-    "dev:watch": "concurrently -n EXTENSION,WEBVIEW -c yellow,blue \"tsc -watch -p ./\" \"cd webview-ui && npm run watch\"",
+    "dev:watch": "npm run ensure:dac-spa && concurrently -n EXTENSION,WEBVIEW -c yellow,blue \"tsc -watch -p ./\" \"cd webview-ui && npm run watch\"",
     "build:webview": "cd webview-ui && npm run build-only && node scripts/copy-codicons.js",
     "copy:dac-spa": "node scripts/copy-dac-assets.js",
     "fetch:dac-spa": "node scripts/fetch-dac-assets.js",
+    "ensure:dac-spa": "node scripts/fetch-dac-assets.js --if-missing",
     "vscode:prepublish": "npm run compile && npm run fetch:dac-spa",
     "selenium:setup-tests": "extest setup-tests",
     "selenium:run-tests:connections": "node webview-ui/scripts/copy-test-assets.js && extest setup-and-run './out/ui-test/connections-integration.test.js' --code_version 1.103.0 --code_settings settings.json --mocha_config .mocharc-ui.js",

--- a/scripts/fetch-dac-assets.js
+++ b/scripts/fetch-dac-assets.js
@@ -50,6 +50,14 @@ function download(tmpFile) {
 }
 
 async function main() {
+  // `--if-missing` (used by `dev:watch`) skips the download when the SPA is
+  // already in place, so iterating locally needs no network and works offline.
+  const ifMissing = process.argv.includes("--if-missing") || process.env.DAC_FETCH_IF_MISSING === "1";
+  if (ifMissing && fs.existsSync(path.join(destDir, "index.html"))) {
+    console.log(`dac frontend already present at ${path.relative(process.cwd(), destDir)}; skipping fetch.`);
+    return;
+  }
+
   if (!REPO || !VERSION) {
     throw new Error(
       "Missing dac frontend pin. Set package.json `dacFrontend.repo` and `dacFrontend.version` " +

--- a/src/providers/ActivityBarConnectionsProvider.ts
+++ b/src/providers/ActivityBarConnectionsProvider.ts
@@ -104,6 +104,9 @@ export class ActivityBarConnectionsProvider implements vscode.TreeDataProvider<C
     "clickhouse",
     "databricks",
     "athena",
+    "fabric",
+    "mssql",
+    "synapse",
   ];
 
   constructor(private extensionPath: string) {

--- a/src/utilities/helperUtils.ts
+++ b/src/utilities/helperUtils.ts
@@ -294,6 +294,7 @@ type ConnectionType =
   | "postgres"
   | "redshift"
   | "mssql"
+  | "fabric"
   | "databricks"
   | "synapse"
   | "mongo"

--- a/webview-ui/src/components/connections/connectionUtility.ts
+++ b/webview-ui/src/components/connections/connectionUtility.ts
@@ -79,6 +79,7 @@ export const formatConnectionName = (option) => {
     mongo: "MongoDB",
     aws: "Amazon Web Services (AWS)",
     mssql: "Microsoft SQL Server",
+    fabric: "Microsoft Fabric",
     mysql: "MySQL",
     google_cloud_platform: "Google Cloud Platform",
     synapse: "Azure Synapse",

--- a/webview-ui/vite.config.mjs
+++ b/webview-ui/vite.config.mjs
@@ -40,7 +40,7 @@ const copyTestAssetsPlugin = () => {
         }
     };
 };
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
     css: {
         postcss: {
             plugins: [tailwind(), autoprefixer()],
@@ -60,6 +60,10 @@ export default defineConfig({
     },
     build: {
         outDir: "build",
+        // The dev watch build (`--mode development`) must not empty `build/` — the
+        // dac SPA lives in `build/dac-spa` and would be wiped on the first rebuild.
+        // Production builds still clean the dir.
+        emptyOutDir: mode !== "development",
         // Webviews run in VS Code's modern Electron/Chromium, so target a recent
         // baseline. This also avoids esbuild >=0.28 attempting (and failing) to lower
         // destructuring for the legacy Safari 14 target in its default browser list.
@@ -79,4 +83,4 @@ export default defineConfig({
             },
         },
     },
-});
+}));


### PR DESCRIPTION
Fabric, MSSQL and Synapse connections are queryable by the Bruin CLI but were hidden from the Databases panel by a stale hardcoded allowlist; this adds them to the allowlist, extends the `ConnectionType` union, and maps Fabric to a "Microsoft Fabric" display label.

Separately, `dev:watch` never populated `build/dac-spa`, so the dac preview was broken in the dev host — it now fetches the SPA (only when missing) before the watchers start, and the dev Vite build no longer empties `build/` so it can't wipe `dac-spa`.