### PR TITLE
Fix pipeline lineage stuck on loading when opened before any asset

### DIFF
--- a/webview-ui/src/components/lineage-flow/Lineage.vue
+++ b/webview-ui/src/components/lineage-flow/Lineage.vue
@@ -934,6 +934,10 @@ const buildPipelineElements = async () => {
   } finally {
     if (gen === buildGeneration) {
       isBuildingView.value = false;
+      // The pipeline graph is now drawn. Clear the initial loading flag, which
+      // otherwise only ever gets cleared by the asset-view path (_updateGraph) —
+      // leaving the spinner stuck when a pipeline is opened before any asset.
+      isLoadingLocal.value = false;
     }
   }
 };
@@ -1153,6 +1157,9 @@ const buildColumnElements = async () => {
   } finally {
     if (gen === buildGeneration) {
       isBuildingView.value = false;
+      // Same as the pipeline path: clear the initial loading flag so a column
+      // view opened cold doesn't leave the spinner stuck.
+      isLoadingLocal.value = false;
     }
   }
 };


### PR DESCRIPTION
Opening a `pipeline.yml` before visiting any asset left the lineage panel stuck on its loading spinner forever. Switching to an asset and back made the pipeline lineage appear — the graph had actually built the whole time, it was just hidden behind the overlay.

`isLoadingLocal` starts `true` and was only ever cleared in the asset-view path (`_updateGraph`). The pipeline and column build paths never cleared it, so a pipeline (or column view) opened cold kept the overlay up. Visiting an asset ran `_updateGraph`, which latched the flag off permanently — hence the "works after switching" behavior.

Fix: clear `isLoadingLocal` in the `finally` blocks of `buildPipelineElements` and `buildColumnElements`, alongside the existing `isBuildingView` reset.