### PR TITLE
Fix syntax highlighting breaking on apostrophes in Jinja comments

### DIFF
--- a/syntaxes/bruin-sql-injection.json
+++ b/syntaxes/bruin-sql-injection.json
@@ -3,10 +3,19 @@
     "injectionSelector": "L:source.sql, L:source.sql-bigquery, L:source.pgsql",
     "patterns": [
         {
+            "include": "#jinja-comment"
+        },
+        {
             "include": "#bruin-sql"
         }
     ],
     "repository": {
+        "jinja-comment": {
+            "name": "comment.block.jinja.bruin",
+            "begin": "\\{#-?",
+            "end": "-?#\\}",
+            "patterns": []
+        },
         "bruin-sql": {
             "name": "bruin-sql",
             "patterns": [


### PR DESCRIPTION
An apostrophe inside a Jinja comment (`{#- Yardi's quirks -#}`) broke syntax highlighting for the rest of the file — the grammar had no rule for Jinja comments, so the base SQL grammar treated the `'` as the start of a string literal that never closed.

Adds a `{# ... #}` / `{#- ... -#}` comment rule to the SQL injection grammar so comment contents (including apostrophes) are consumed as comment text. Verified with a vscode-textmate tokenizer test: with the rule the comment is scoped correctly and the following SQL highlights normally; without it the `SELECT` gets swallowed into a string.