### PR TITLE
Release 0.83.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.83.4]
+- Restored the column lineage highlight on hover, and fixed syntax highlighting breaking on apostrophes inside Jinja comments.
+
 ## [0.83.3]
 - Show Fabric, MSSQL and Synapse connections in the Databases panel, and fixed pipeline lineage getting stuck on "Building pipeline lineage…".
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.83.4**: Restored the column lineage highlight on hover, and fixed syntax highlighting breaking on apostrophes inside Jinja comments.
 - **0.83.3**: Show Fabric, MSSQL and Synapse connections in the Databases panel, and fixed pipeline lineage getting stuck on "Building pipeline lineage…".
 - **0.83.2**: Switching assets updates the SQL editor and lineage in place instead of reloading.
 - **0.83.1**: Preview Dashboard offers to install or update `dac` when it's missing or below the required version.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.83.3",
+  "version": "0.83.4",
   "dacFrontend": {
     "repo": "bruin-data/dac",
     "version": "v0.9.0",


### PR DESCRIPTION
Bumps the extension to 0.83.4 and adds a changelog/README entry:

- Restored the column lineage highlight on hover (PR #815).
- Fixed syntax highlighting breaking on apostrophes inside Jinja comments (PR #814).