### PR TITLE
Draw column lineage for catalog-qualified upstream tables

### DIFF
--- a/webview-ui/src/components/lineage-flow/column-level/useColumnLevel.ts
+++ b/webview-ui/src/components/lineage-flow/column-level/useColumnLevel.ts
@@ -7,6 +7,28 @@ import {
 } from '@/utilities/graphGenerator';
 import { findDownstreamAssets, getDownstreamAssetNames } from '@/utilities/assetDependencies';
 
+// Column-level lineage from the CLI tags a source with the table name used in the
+// query's FROM clause. When that is fully qualified with a catalog (e.g. Fabric's
+// `wh_silver.schema.table`) it won't match a two-part asset node (`schema.table`),
+// so the column edge is silently dropped. Resolve such names back to the canonical
+// asset name by stripping the leading catalog when the remainder matches an asset.
+const makeUpstreamAssetResolver = (assets: any[]) => {
+  const byLower = new Map<string, string>();
+  (assets || []).forEach((a: any) => {
+    if (a?.name) byLower.set(String(a.name).toLowerCase(), a.name);
+  });
+  return (table: string): string => {
+    if (!table) return table;
+    if (byLower.has(table.toLowerCase())) return byLower.get(table.toLowerCase())!;
+    const parts = table.split(".");
+    if (parts.length > 2) {
+      const stripped = parts.slice(-2).join(".").toLowerCase();
+      if (byLower.has(stripped)) return byLower.get(stripped)!;
+    }
+    return table;
+  };
+};
+
 export const getAssetDatasetWithColumns = (
   pipelineData: any,
   assetId: string,
@@ -26,17 +48,18 @@ export const getAssetDatasetWithColumns = (
     // If no column_lineage at pipeline level, build it from individual column upstreams
     if (!pipelineData.column_lineage || Object.keys(pipelineData.column_lineage).length === 0) {
       columnLineageMap = {};
-      
+      const resolveUpstreamAsset = makeUpstreamAssetResolver(pipelineData.assets);
+
       pipelineData.assets.forEach(asset => {
         if (asset.columns && Array.isArray(asset.columns)) {
           const assetColumnLineage: ColumnLineage[] = [];
-          
+
           asset.columns.forEach((column: ColumnInfo) => {
             if (column.upstreams && Array.isArray(column.upstreams) && column.upstreams.length > 0) {
               const lineageEntry: ColumnLineage = {
                 column: column.name,
                 source_columns: column.upstreams.map((upstream: ColumnUpstream) => ({
-                  asset: upstream.table,
+                  asset: resolveUpstreamAsset(upstream.table),
                   column: upstream.column
                 }))
               };
@@ -156,17 +179,18 @@ export const buildColumnLineage = (pipelineData: { assets: any[], column_lineage
   // If no column_lineage at pipeline level, build it from individual column upstreams
   if (!pipelineData.column_lineage || Object.keys(pipelineData.column_lineage).length === 0) {
     columnLineageMap = {};
-    
+    const resolveUpstreamAsset = makeUpstreamAssetResolver(assets);
+
     assets.forEach(asset => {
       if (asset.columns && Array.isArray(asset.columns)) {
         const assetColumnLineage: ColumnLineage[] = [];
-        
+
         asset.columns.forEach((column: ColumnInfo) => {
           if (column.upstreams && Array.isArray(column.upstreams) && column.upstreams.length > 0) {
             const lineageEntry: ColumnLineage = {
               column: column.name,
               source_columns: column.upstreams.map((upstream: ColumnUpstream) => ({
-                asset: upstream.table,
+                asset: resolveUpstreamAsset(upstream.table),
                 column: upstream.column
               }))
             };


### PR DESCRIPTION
Column-level lineage rendered no edges (so hovering a column highlighted nothing) whenever an asset's query referenced its upstreams with a **catalog-qualified** table name — e.g. Fabric's three-part `wh_silver.schema.table` — while the asset itself is named two-part (`schema.table`).

The CLI resolves the lineage correctly but tags the source with the fully-qualified name from the `FROM` clause. The column view then does an exact match of that source against the asset nodes (`processedAssets.has(sourceColumn.asset)`), which fails for the three-part name, so every column edge is silently dropped.

Fix: when building the column lineage map, resolve a catalog-qualified source back to its asset node by stripping the leading catalog when the remaining `schema.table` matches a known asset. Names that already match, and genuinely unknown sources, are left unchanged. Verified the resolver maps `wh_silver.schema.table` → `schema.table` and reproduced the original failure with a real 3-part-referencing pipeline.