### PR TITLE
Release 0.83.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.83.5]
+- Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name, e.g. Fabric's `wh_silver.schema.table`.
+
 ## [0.83.4]
 - Restored the column lineage highlight on hover, and fixed syntax highlighting breaking on apostrophes inside Jinja comments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [0.83.5]
-- Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name, e.g. Fabric's `wh_silver.schema.table`.
+- Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name.
 
 ## [0.83.4]
 - Restored the column lineage highlight on hover, and fixed syntax highlighting breaking on apostrophes inside Jinja comments.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.83.5**: Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name, e.g. Fabric's `wh_silver.schema.table`.
+- **0.83.5**: Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name.
 - **0.83.4**: Restored the column lineage highlight on hover, and fixed syntax highlighting breaking on apostrophes inside Jinja comments.
 - **0.83.3**: Show Fabric, MSSQL and Synapse connections in the Databases panel, and fixed pipeline lineage getting stuck on "Building pipeline lineage…".
 - **0.83.2**: Switching assets updates the SQL editor and lineage in place instead of reloading.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.83.5**: Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name, e.g. Fabric's `wh_silver.schema.table`.
 - **0.83.4**: Restored the column lineage highlight on hover, and fixed syntax highlighting breaking on apostrophes inside Jinja comments.
 - **0.83.3**: Show Fabric, MSSQL and Synapse connections in the Databases panel, and fixed pipeline lineage getting stuck on "Building pipeline lineage…".
 - **0.83.2**: Switching assets updates the SQL editor and lineage in place instead of reloading.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.83.4",
+  "version": "0.83.5",
   "dacFrontend": {
     "repo": "bruin-data/dac",
     "version": "v0.9.0",


### PR DESCRIPTION
Bumps the extension to 0.83.5 and adds a changelog/README entry:

- Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name, e.g. Fabric's `wh_silver.schema.table` (code in PR #818).