### PR TITLE
Remove blind catalog-strip from column lineage; fix case-mismatched lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.83.6]
+- Fixed column lineage not drawing edges (or highlighting on hover) for assets whose names contain uppercase letters, and moved database-qualified name resolution to the Bruin CLI instead of stripping the qualifier in the extension.
+
 ## [0.83.5]
 - Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [0.83.6]
-- Fixed column lineage not drawing edges (or highlighting on hover) for assets whose names contain uppercase letters, and moved database-qualified name resolution to the Bruin CLI instead of stripping the qualifier in the extension.
+- Fixed column lineage not drawing edges (or highlighting on hover) for assets with uppercase letters in their names.
 
 ## [0.83.5]
 - Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.83.6**: Fixed column lineage not drawing edges (or highlighting on hover) for assets whose names contain uppercase letters, and moved database-qualified name resolution to the Bruin CLI instead of stripping the qualifier in the extension.
+- **0.83.6**: Fixed column lineage not drawing edges (or highlighting on hover) for assets with uppercase letters in their names.
 - **0.83.5**: Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name.
 - **0.83.4**: Restored the column lineage highlight on hover, and fixed syntax highlighting breaking on apostrophes inside Jinja comments.
 - **0.83.3**: Show Fabric, MSSQL and Synapse connections in the Databases panel, and fixed pipeline lineage getting stuck on "Building pipeline lineage…".

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.83.6**: Fixed column lineage not drawing edges (or highlighting on hover) for assets whose names contain uppercase letters, and moved database-qualified name resolution to the Bruin CLI instead of stripping the qualifier in the extension.
 - **0.83.5**: Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name.
 - **0.83.4**: Restored the column lineage highlight on hover, and fixed syntax highlighting breaking on apostrophes inside Jinja comments.
 - **0.83.3**: Show Fabric, MSSQL and Synapse connections in the Databases panel, and fixed pipeline lineage getting stuck on "Building pipeline lineage…".

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.83.5",
+  "version": "0.83.6",
   "dacFrontend": {
     "repo": "bruin-data/dac",
     "version": "v0.9.0",

--- a/webview-ui/src/components/lineage-flow/column-level/useColumnLevel.ts
+++ b/webview-ui/src/components/lineage-flow/column-level/useColumnLevel.ts
@@ -7,28 +7,6 @@ import {
 } from '@/utilities/graphGenerator';
 import { findDownstreamAssets, getDownstreamAssetNames } from '@/utilities/assetDependencies';
 
-// Column-level lineage from the CLI tags a source with the table name used in the
-// query's FROM clause. When that is fully qualified with a catalog (e.g. Fabric's
-// `wh_silver.schema.table`) it won't match a two-part asset node (`schema.table`),
-// so the column edge is silently dropped. Resolve such names back to the canonical
-// asset name by stripping the leading catalog when the remainder matches an asset.
-const makeUpstreamAssetResolver = (assets: any[]) => {
-  const byLower = new Map<string, string>();
-  (assets || []).forEach((a: any) => {
-    if (a?.name) byLower.set(String(a.name).toLowerCase(), a.name);
-  });
-  return (table: string): string => {
-    if (!table) return table;
-    if (byLower.has(table.toLowerCase())) return byLower.get(table.toLowerCase())!;
-    const parts = table.split(".");
-    if (parts.length > 2) {
-      const stripped = parts.slice(-2).join(".").toLowerCase();
-      if (byLower.has(stripped)) return byLower.get(stripped)!;
-    }
-    return table;
-  };
-};
-
 export const getAssetDatasetWithColumns = (
   pipelineData: any,
   assetId: string,
@@ -48,18 +26,17 @@ export const getAssetDatasetWithColumns = (
     // If no column_lineage at pipeline level, build it from individual column upstreams
     if (!pipelineData.column_lineage || Object.keys(pipelineData.column_lineage).length === 0) {
       columnLineageMap = {};
-      const resolveUpstreamAsset = makeUpstreamAssetResolver(pipelineData.assets);
-
+      
       pipelineData.assets.forEach(asset => {
         if (asset.columns && Array.isArray(asset.columns)) {
           const assetColumnLineage: ColumnLineage[] = [];
-
+          
           asset.columns.forEach((column: ColumnInfo) => {
             if (column.upstreams && Array.isArray(column.upstreams) && column.upstreams.length > 0) {
               const lineageEntry: ColumnLineage = {
                 column: column.name,
                 source_columns: column.upstreams.map((upstream: ColumnUpstream) => ({
-                  asset: resolveUpstreamAsset(upstream.table),
+                  asset: upstream.table,
                   column: upstream.column
                 }))
               };
@@ -179,18 +156,17 @@ export const buildColumnLineage = (pipelineData: { assets: any[], column_lineage
   // If no column_lineage at pipeline level, build it from individual column upstreams
   if (!pipelineData.column_lineage || Object.keys(pipelineData.column_lineage).length === 0) {
     columnLineageMap = {};
-    const resolveUpstreamAsset = makeUpstreamAssetResolver(assets);
-
+    
     assets.forEach(asset => {
       if (asset.columns && Array.isArray(asset.columns)) {
         const assetColumnLineage: ColumnLineage[] = [];
-
+        
         asset.columns.forEach((column: ColumnInfo) => {
           if (column.upstreams && Array.isArray(column.upstreams) && column.upstreams.length > 0) {
             const lineageEntry: ColumnLineage = {
               column: column.name,
               source_columns: column.upstreams.map((upstream: ColumnUpstream) => ({
-                asset: resolveUpstreamAsset(upstream.table),
+                asset: upstream.table,
                 column: upstream.column
               }))
             };

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -1220,6 +1220,33 @@ suite('createColumnLevelEdges', () => {
     expect(edges[0].data.targetAsset).toBe('asset2');
   });
 
+  test('should create edges when the target asset name has uppercase letters', () => {
+    // processedAssets stores lowercased names; columnLineageMap is keyed by the
+    // original-case asset name. A mixed-case name like dbo.DimAccount must still match.
+    const processedAssets = new Set(['dbo.dimaccount', 'wh_silver.yardi.int_yardi__gl_transactions']);
+    const columnLineageMap = {
+      'dbo.DimAccount': [
+        {
+          column: 'AccountName',
+          source_columns: [
+            { asset: 'wh_silver.yardi.int_yardi__gl_transactions', column: 'AccountName' }
+          ]
+        }
+      ]
+    };
+
+    const assetMap = {
+      'wh_silver.yardi.int_yardi__gl_transactions': { columns: [{ name: 'AccountName' }] },
+      'dbo.DimAccount': { columns: [{ name: 'AccountName' }] }
+    };
+
+    const edges = createColumnLevelEdges(processedAssets, columnLineageMap, assetMap);
+
+    expect(edges).toHaveLength(1);
+    expect(edges[0].data.targetAsset).toBe('dbo.DimAccount');
+    expect(edges[0].data.sourceAsset).toBe('wh_silver.yardi.int_yardi__gl_transactions');
+  });
+
   test('should not create edges for assets not in processedAssets', () => {
     const processedAssets = new Set(['asset2']);
     const columnLineageMap = {

--- a/webview-ui/src/test/webview.test.ts
+++ b/webview-ui/src/test/webview.test.ts
@@ -1221,8 +1221,7 @@ suite('createColumnLevelEdges', () => {
   });
 
   test('should create edges when the target asset name has uppercase letters', () => {
-    // processedAssets stores lowercased names; columnLineageMap is keyed by the
-    // original-case asset name. A mixed-case name like dbo.DimAccount must still match.
+    // A mixed-case asset name (e.g. dbo.DimAccount) must still match.
     const processedAssets = new Set(['dbo.dimaccount', 'wh_silver.yardi.int_yardi__gl_transactions']);
     const columnLineageMap = {
       'dbo.DimAccount': [

--- a/webview-ui/src/utilities/graphGenerator.ts
+++ b/webview-ui/src/utilities/graphGenerator.ts
@@ -233,10 +233,10 @@ export const createColumnLevelEdges = (
   const edges: Edge[] = [];
   const edgeSet = new Set<string>(); // Track unique edges to prevent duplicates
   
-  processedAssets.forEach(assetName => {
-    const assetColumnLineage = columnLineageMap[assetName];
+  Object.entries(columnLineageMap).forEach(([assetName, assetColumnLineage]) => {
+    if (!processedAssets.has(assetName.toLowerCase())) return;
     if (!assetColumnLineage || assetColumnLineage.length === 0) return;
-    
+
     assetColumnLineage.forEach(lineage => {
       lineage.source_columns.forEach(sourceColumn => {
         if (!processedAssets.has(sourceColumn.asset.toLowerCase())) return;


### PR DESCRIPTION
## What

Two fixes to column-lineage edge drawing:

1. **Revert the catalog-strip** shipped in 0.83.5. It dropped the leading qualifier from a source table (`db.schema.table` → `schema.table`) whenever the two-part remainder matched a known asset. That merges names that may be distinct tables in different databases, and it papered over a naming mismatch that belongs in the CLI (which knows each connection's database). The CLI now resolves these correctly using the database from `.bruin.yml`.

2. **Fix a case-mismatched lookup** in `createColumnLevelEdges`: it iterated the lowercased `processedAssets` set but looked up `columnLineageMap` by that lowercased key, while the map is keyed by the original-case asset name. Any target asset with an uppercase letter (e.g. `dbo.DimAccount`) missed the lookup and dropped every column edge. Now it iterates the map by its real keys and gates membership case-insensitively.

## Test

New regression test in `webview.test.ts` covering a mixed-case target asset name; full `webview.test.ts` suite passes (145/145).