### PR TITLE
Support custom MCP clients (e.g. CoCo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.84.0]
+- Add Bruin MCP to any client that uses the standard `mcpServers` config (e.g. CoCo) by pointing at its config file, alongside the built-in one-click clients.
+
 ## [0.83.6]
 - Fixed column lineage not drawing edges (or highlighting on hover) for assets with uppercase letters in their names.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.84.0**: Configure Bruin MCP for any client using the standard `mcpServers` config (e.g. CoCo) via a custom config path, alongside the built-in one-click clients.
 - **0.83.6**: Fixed column lineage not drawing edges (or highlighting on hover) for assets with uppercase letters in their names.
 - **0.83.5**: Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name.
 - **0.83.4**: Restored the column lineage highlight on hover, and fixed syntax highlighting breaking on apostrophes inside Jinja comments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.83.6",
+  "version": "0.84.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.83.6",
+      "version": "0.84.0",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.83.6",
+  "version": "0.84.0",
   "dacFrontend": {
     "repo": "bruin-data/dac",
     "version": "v0.9.0",

--- a/src/extension/commands/manageMcpIntegrations.ts
+++ b/src/extension/commands/manageMcpIntegrations.ts
@@ -1131,8 +1131,3 @@ export async function setCustomMcpConfig(
 
   await writeBruinMcpJsonConfig(configPath, "mcpServers");
 }
-
-export async function removeCustomMcpConfigServers(configPath: string): Promise<void> {
-  await removeMcpJsonServerConfig(configPath, BRUIN_LOCAL_SERVER_NAME);
-  await removeMcpJsonServerConfig(configPath, BRUIN_CLOUD_SERVER_NAME);
-}

--- a/src/extension/commands/manageMcpIntegrations.ts
+++ b/src/extension/commands/manageMcpIntegrations.ts
@@ -43,6 +43,16 @@ export interface McpIntegrationUninstallResult {
   message: string;
 }
 
+export interface CustomMcpConfigStatus {
+  path: string;
+  label: string;
+  status: McpIntegrationStatusType;
+  configured: boolean;
+  bruinAvailable: boolean;
+  exists: boolean;
+  details: string;
+}
+
 function formatExecError(error: unknown): string {
   if (!error) {
     return "";
@@ -1025,4 +1035,104 @@ export async function uninstallMcpIntegration(
     default:
       throw new Error(`Unsupported Bruin Cloud MCP integration target: ${target}`);
   }
+}
+
+// --- Custom (bring-your-own-path) MCP clients -------------------------------
+// Any MCP client that uses the standard `mcpServers` JSON schema (CoCo, Windsurf,
+// Zed, etc.) can be configured by pointing at its config file, so we don't need a
+// hardcoded entry per client.
+
+export function normalizeCustomConfigPath(inputPath: string): string {
+  const trimmed = inputPath.trim();
+  const expanded = trimmed.startsWith("~") ? path.join(os.homedir(), trimmed.slice(1)) : trimmed;
+  return path.resolve(expanded);
+}
+
+async function evaluateCustomConfigStatus(
+  configPath: string,
+  variant: McpVariant,
+  bruinAvailable: boolean
+): Promise<CustomMcpConfigStatus> {
+  const label = path.basename(configPath);
+  const base = { path: configPath, label, bruinAvailable };
+  const isConfigured = variant === "cloud" ? hasBruinCloudMcpServerDefinition : hasBruinMcpServerDefinition;
+
+  if (!fs.existsSync(configPath)) {
+    return {
+      ...base,
+      exists: false,
+      configured: false,
+      status: "not_configured",
+      details: "File does not exist yet; it will be created when enabled.",
+    };
+  }
+
+  try {
+    const config = await readJsonFile(configPath);
+    const configured = isConfigured(config);
+    if (configured && variant === "bruin" && !bruinAvailable) {
+      return {
+        ...base,
+        exists: true,
+        configured: true,
+        status: "bruin_missing",
+        details: "Configured, but Bruin CLI is not available.",
+      };
+    }
+    return {
+      ...base,
+      exists: true,
+      configured,
+      status: configured ? "ready" : "not_configured",
+      details: configured ? `Configured in ${configPath}.` : "Config exists but Bruin MCP entry is missing.",
+    };
+  } catch (error) {
+    return {
+      ...base,
+      exists: true,
+      configured: false,
+      status: "error",
+      details: `Invalid JSON in ${configPath}: ${error}`,
+    };
+  }
+}
+
+export async function getCustomMcpConfigStatuses(
+  configPaths: string[],
+  variant: McpVariant = "bruin"
+): Promise<CustomMcpConfigStatus[]> {
+  const bruinAvailable = variant === "cloud" ? true : await isBruinCliAvailable();
+  return Promise.all(
+    configPaths.map((configPath) => evaluateCustomConfigStatus(configPath, variant, bruinAvailable))
+  );
+}
+
+export async function setCustomMcpConfig(
+  configPath: string,
+  variant: McpVariant,
+  enable: boolean,
+  bearerToken?: string
+): Promise<void> {
+  const serverName = variant === "cloud" ? BRUIN_CLOUD_SERVER_NAME : BRUIN_LOCAL_SERVER_NAME;
+
+  if (!enable) {
+    await removeMcpJsonServerConfig(configPath, serverName);
+    return;
+  }
+
+  if (variant === "cloud") {
+    const token = bearerToken?.trim();
+    if (!token) {
+      throw new Error("API token is required for Bruin Cloud MCP.");
+    }
+    await writeBruinCloudCursorMcpJsonConfig(configPath, token);
+    return;
+  }
+
+  await writeBruinMcpJsonConfig(configPath, "mcpServers");
+}
+
+export async function removeCustomMcpConfigServers(configPath: string): Promise<void> {
+  await removeMcpJsonServerConfig(configPath, BRUIN_LOCAL_SERVER_NAME);
+  await removeMcpJsonServerConfig(configPath, BRUIN_CLOUD_SERVER_NAME);
 }

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -48,7 +48,6 @@ import {
   uninstallMcpIntegration,
   getCustomMcpConfigStatuses,
   setCustomMcpConfig,
-  removeCustomMcpConfigServers,
   normalizeCustomConfigPath,
   McpClientId,
   McpVariant,
@@ -1324,13 +1323,14 @@ export class BruinPanel {
               if (!configPath) {
                 throw new Error("No custom MCP config path provided.");
               }
-              await removeCustomMcpConfigServers(configPath);
+              // Only stop tracking the path; leave the client's config file untouched
+              // so we never disconnect a working integration (Disable removes servers).
               await BruinPanel.setCustomMcpConfigPaths(
                 BruinPanel.getCustomMcpConfigPaths().filter((entry) => entry !== configPath)
               );
               this._panel.webview.postMessage({
                 command: "mcp-custom-config-action-message",
-                payload: { status: "success", message: `Removed ${configPath}.`, variant },
+                payload: { status: "success", message: `Stopped tracking ${configPath}.`, variant },
               });
               await this.postCustomMcpStatuses(variant);
             } catch (error) {

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -46,6 +46,10 @@ import {
   getMcpIntegrationStatuses,
   installMcpIntegration,
   uninstallMcpIntegration,
+  getCustomMcpConfigStatuses,
+  setCustomMcpConfig,
+  removeCustomMcpConfigServers,
+  normalizeCustomConfigPath,
   McpClientId,
   McpVariant,
 } from "../extension/commands/manageMcpIntegrations";
@@ -81,6 +85,7 @@ export class BruinPanel {
   public static readonly viewId = "bruin.panel";
   private static _extensionContext: vscode.ExtensionContext | undefined;
   private static readonly CLOUD_MCP_BEARER_TOKEN_SECRET_KEY = "bruin.mcp.cloudBearerToken";
+  private static readonly CUSTOM_MCP_CONFIG_PATHS_KEY = "bruin.mcp.customConfigPaths";
   private readonly _panel: WebviewPanel;
   private readonly _extensionUri: Uri;
   private _disposables: Disposable[] = [];
@@ -125,6 +130,36 @@ export class BruinPanel {
       return; // no-op write avoidance
     }
     await ctx.globalState.update(BruinPanel.CLI_INSTALLED_CACHE_KEY, installed);
+  }
+
+  private static getCustomMcpConfigPaths(): string[] {
+    const stored = BruinPanel._extensionContext?.globalState.get<string[]>(
+      BruinPanel.CUSTOM_MCP_CONFIG_PATHS_KEY
+    );
+    return Array.isArray(stored) ? stored.filter((entry) => typeof entry === "string") : [];
+  }
+
+  private static async setCustomMcpConfigPaths(paths: string[]): Promise<void> {
+    const unique = Array.from(new Set(paths));
+    await BruinPanel._extensionContext?.globalState.update(
+      BruinPanel.CUSTOM_MCP_CONFIG_PATHS_KEY,
+      unique
+    );
+  }
+
+  private async postCustomMcpStatuses(variant: McpVariant): Promise<void> {
+    try {
+      const statuses = await getCustomMcpConfigStatuses(BruinPanel.getCustomMcpConfigPaths(), variant);
+      this._panel.webview.postMessage({
+        command: "mcp-custom-config-status-message",
+        payload: { status: "success", message: statuses, variant },
+      });
+    } catch (error) {
+      this._panel.webview.postMessage({
+        command: "mcp-custom-config-status-message",
+        payload: { status: "error", message: `Failed to load custom MCP status: ${error}`, variant },
+      });
+    }
   }
 
   /**
@@ -1027,6 +1062,7 @@ export class BruinPanel {
             break;
           case "bruin.getMcpIntegrationStatus":
             const variant = (message.payload?.variant as McpVariant | undefined) ?? "bruin";
+            await this.postCustomMcpStatuses(variant);
             try {
               const mcpStatuses = await getMcpIntegrationStatuses(this._lastRenderedDocumentUri, variant);
               this._panel.webview.postMessage({
@@ -1196,6 +1232,115 @@ export class BruinPanel {
               });
             }
             break;
+
+          case "bruin.addCustomMcpConfig": {
+            const variant = (message.payload?.variant as McpVariant | undefined) ?? "bruin";
+            try {
+              const input = await vscode.window.showInputBox({
+                title: "Add custom MCP config",
+                prompt: "Absolute path to the client's MCP config file (JSON using an \"mcpServers\" key)",
+                placeHolder: "e.g. ~/.config/<client>/mcp.json",
+                ignoreFocusOut: true,
+                validateInput: (value) =>
+                  value.trim().length === 0 ? "A config file path is required." : undefined,
+              });
+              if (!input) {
+                this._panel.webview.postMessage({
+                  command: "mcp-custom-config-action-message",
+                  payload: { status: "cancelled", variant },
+                });
+                break;
+              }
+
+              const configPath = normalizeCustomConfigPath(input);
+              let bearerToken: string | undefined;
+              if (variant === "cloud") {
+                bearerToken = await BruinPanel._extensionContext?.secrets.get(
+                  BruinPanel.CLOUD_MCP_BEARER_TOKEN_SECRET_KEY
+                );
+              }
+
+              await setCustomMcpConfig(configPath, variant, true, bearerToken);
+              await BruinPanel.setCustomMcpConfigPaths([
+                ...BruinPanel.getCustomMcpConfigPaths(),
+                configPath,
+              ]);
+
+              this._panel.webview.postMessage({
+                command: "mcp-custom-config-action-message",
+                payload: { status: "success", message: `Configured Bruin MCP in ${configPath}.`, variant },
+              });
+              await this.postCustomMcpStatuses(variant);
+            } catch (error) {
+              this._panel.webview.postMessage({
+                command: "mcp-custom-config-action-message",
+                payload: { status: "error", message: `Failed to add custom MCP config: ${error}`, variant },
+              });
+            }
+            break;
+          }
+
+          case "bruin.toggleCustomMcpConfig": {
+            const variant = (message.payload?.variant as McpVariant | undefined) ?? "bruin";
+            const configPath =
+              typeof message.payload?.path === "string" ? message.payload.path : undefined;
+            const enable = Boolean(message.payload?.enable);
+            try {
+              if (!configPath) {
+                throw new Error("No custom MCP config path provided.");
+              }
+              let bearerToken: string | undefined;
+              if (variant === "cloud" && enable) {
+                bearerToken = await BruinPanel._extensionContext?.secrets.get(
+                  BruinPanel.CLOUD_MCP_BEARER_TOKEN_SECRET_KEY
+                );
+              }
+              await setCustomMcpConfig(configPath, variant, enable, bearerToken);
+              this._panel.webview.postMessage({
+                command: "mcp-custom-config-action-message",
+                payload: {
+                  status: "success",
+                  message: enable
+                    ? `Enabled Bruin MCP in ${configPath}.`
+                    : `Disabled Bruin MCP in ${configPath}.`,
+                  variant,
+                },
+              });
+              await this.postCustomMcpStatuses(variant);
+            } catch (error) {
+              this._panel.webview.postMessage({
+                command: "mcp-custom-config-action-message",
+                payload: { status: "error", message: `Failed to update custom MCP config: ${error}`, variant },
+              });
+            }
+            break;
+          }
+
+          case "bruin.removeCustomMcpConfig": {
+            const variant = (message.payload?.variant as McpVariant | undefined) ?? "bruin";
+            const configPath =
+              typeof message.payload?.path === "string" ? message.payload.path : undefined;
+            try {
+              if (!configPath) {
+                throw new Error("No custom MCP config path provided.");
+              }
+              await removeCustomMcpConfigServers(configPath);
+              await BruinPanel.setCustomMcpConfigPaths(
+                BruinPanel.getCustomMcpConfigPaths().filter((entry) => entry !== configPath)
+              );
+              this._panel.webview.postMessage({
+                command: "mcp-custom-config-action-message",
+                payload: { status: "success", message: `Removed ${configPath}.`, variant },
+              });
+              await this.postCustomMcpStatuses(variant);
+            } catch (error) {
+              this._panel.webview.postMessage({
+                command: "mcp-custom-config-action-message",
+                payload: { status: "error", message: `Failed to remove custom MCP config: ${error}`, variant },
+              });
+            }
+            break;
+          }
 
           case "bruin.getConnectionsList":
             getConnections(this._lastRenderedDocumentUri);

--- a/src/test/mcpCustomConfig.test.ts
+++ b/src/test/mcpCustomConfig.test.ts
@@ -1,0 +1,130 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  normalizeCustomConfigPath,
+  setCustomMcpConfig,
+  getCustomMcpConfigStatuses,
+  removeCustomMcpConfigServers,
+} from "../extension/commands/manageMcpIntegrations";
+
+/**
+ * Real, runnable coverage for the "Custom MCP config" feature (BRU-5720).
+ * These tests exercise the exact functions the extension calls when a user
+ * clicks Add / Enable / Disable — pointed at a throwaway temp file instead of a
+ * real client's config, so no CoCo / Snowflake / Cursor install is needed.
+ */
+suite("Custom MCP config", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  setup(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bruin-mcp-"));
+    // Nested to also prove parent dirs get created on first write.
+    configPath = path.join(tmpDir, "client", "mcp.json");
+  });
+
+  teardown(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function readConfig(): any {
+    return JSON.parse(fs.readFileSync(configPath, "utf8"));
+  }
+
+  test("normalizeCustomConfigPath expands ~ and returns an absolute path", () => {
+    const expanded = normalizeCustomConfigPath("~/foo/mcp.json");
+    assert.strictEqual(expanded, path.join(os.homedir(), "foo", "mcp.json"));
+    assert.ok(path.isAbsolute(normalizeCustomConfigPath("./relative/mcp.json")));
+  });
+
+  test("enabling (local) writes the Bruin server and creates missing dirs", async () => {
+    await setCustomMcpConfig(configPath, "bruin", true);
+
+    const config = readConfig();
+    assert.deepStrictEqual(config.mcpServers.bruin, {
+      command: "bruin",
+      args: ["mcp"],
+    });
+  });
+
+  test("enabling preserves existing unrelated servers", async () => {
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: { other: { command: "other", args: [] } } }, null, 2)
+    );
+
+    await setCustomMcpConfig(configPath, "bruin", true);
+
+    const config = readConfig();
+    assert.ok(config.mcpServers.other, "existing server should be preserved");
+    assert.ok(config.mcpServers.bruin, "bruin server should be added");
+  });
+
+  test("status reports configured=true after enabling, false before", async () => {
+    const before = await getCustomMcpConfigStatuses([configPath], "bruin");
+    assert.strictEqual(before[0].configured, false);
+    assert.strictEqual(before[0].exists, false);
+
+    await setCustomMcpConfig(configPath, "bruin", true);
+
+    const after = await getCustomMcpConfigStatuses([configPath], "bruin");
+    assert.strictEqual(after[0].configured, true);
+    // Status is "ready" when the Bruin CLI is installed, "bruin_missing" otherwise.
+    assert.ok(["ready", "bruin_missing"].includes(after[0].status));
+  });
+
+  test("disabling (local) removes only the Bruin server", async () => {
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: { other: { command: "other", args: [] } } }, null, 2)
+    );
+    await setCustomMcpConfig(configPath, "bruin", true);
+
+    await setCustomMcpConfig(configPath, "bruin", false);
+
+    const config = readConfig();
+    assert.strictEqual(config.mcpServers.bruin, undefined);
+    assert.ok(config.mcpServers.other, "unrelated server should remain");
+  });
+
+  test("cloud enable writes a bearer-authed streamable-http entry and reports ready", async () => {
+    await setCustomMcpConfig(configPath, "cloud", true, "test-token-123");
+
+    const config = readConfig();
+    assert.strictEqual(config.mcpServers.bruin_cloud.type, "streamable-http");
+    assert.strictEqual(config.mcpServers.bruin_cloud.url, "https://cloud.getbruin.com/mcp");
+    assert.strictEqual(
+      config.mcpServers.bruin_cloud.headers.Authorization,
+      "Bearer test-token-123"
+    );
+
+    // Cloud status does not depend on a local CLI, so it is deterministically "ready".
+    const status = await getCustomMcpConfigStatuses([configPath], "cloud");
+    assert.strictEqual(status[0].configured, true);
+    assert.strictEqual(status[0].status, "ready");
+  });
+
+  test("cloud enable without a token throws", async () => {
+    await assert.rejects(
+      () => setCustomMcpConfig(configPath, "cloud", true, "   "),
+      /API token is required/
+    );
+  });
+
+  test("removeCustomMcpConfigServers strips both local and cloud entries", async () => {
+    await setCustomMcpConfig(configPath, "bruin", true);
+    await setCustomMcpConfig(configPath, "cloud", true, "test-token-123");
+
+    await removeCustomMcpConfigServers(configPath);
+
+    const config = readConfig();
+    assert.strictEqual(config.mcpServers.bruin, undefined);
+    assert.strictEqual(config.mcpServers.bruin_cloud, undefined);
+  });
+});

--- a/src/test/mcpCustomConfig.test.ts
+++ b/src/test/mcpCustomConfig.test.ts
@@ -8,15 +8,8 @@ import {
   normalizeCustomConfigPath,
   setCustomMcpConfig,
   getCustomMcpConfigStatuses,
-  removeCustomMcpConfigServers,
 } from "../extension/commands/manageMcpIntegrations";
 
-/**
- * Real, runnable coverage for the "Custom MCP config" feature (BRU-5720).
- * These tests exercise the exact functions the extension calls when a user
- * clicks Add / Enable / Disable — pointed at a throwaway temp file instead of a
- * real client's config, so no CoCo / Snowflake / Cursor install is needed.
- */
 suite("Custom MCP config", () => {
   let tmpDir: string;
   let configPath: string;
@@ -115,16 +108,5 @@ suite("Custom MCP config", () => {
       () => setCustomMcpConfig(configPath, "cloud", true, "   "),
       /API token is required/
     );
-  });
-
-  test("removeCustomMcpConfigServers strips both local and cloud entries", async () => {
-    await setCustomMcpConfig(configPath, "bruin", true);
-    await setCustomMcpConfig(configPath, "cloud", true, "test-token-123");
-
-    await removeCustomMcpConfigServers(configPath);
-
-    const config = readConfig();
-    assert.strictEqual(config.mcpServers.bruin, undefined);
-    assert.strictEqual(config.mcpServers.bruin_cloud, undefined);
   });
 });

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -9,6 +9,11 @@ export function run(): Promise<void> {
     timeout: 20000,
   });
 
+  // Optional: run only matching suites/tests, e.g. MOCHA_GREP="Custom MCP config".
+  if (process.env.MOCHA_GREP) {
+    mocha.grep(process.env.MOCHA_GREP);
+  }
+
   // __dirname points to out/test/suite at runtime; go up one to out/test
   const testsRoot = path.resolve(__dirname, "..");
 

--- a/webview-ui/src/components/bruin-settings/BruinMCPIntegrations.vue
+++ b/webview-ui/src/components/bruin-settings/BruinMCPIntegrations.vue
@@ -186,7 +186,7 @@
                 </vscode-button>
                 <vscode-button
                   appearance="icon"
-                  title="Forget this config"
+                  title="Stop tracking (leaves the config file unchanged)"
                   @click="removeCustomConfig(config.path)"
                   :disabled="isCustomButtonDisabled(config.path)"
                 >

--- a/webview-ui/src/components/bruin-settings/BruinMCPIntegrations.vue
+++ b/webview-ui/src/components/bruin-settings/BruinMCPIntegrations.vue
@@ -135,6 +135,69 @@
         </div>
       </div>
 
+      <!-- Custom clients -->
+      <div class="mt-3">
+        <div class="flex items-center justify-between">
+          <span class="text-xs font-medium text-editor-fg">Custom clients</span>
+          <vscode-button
+            appearance="secondary"
+            class="mcp-btn"
+            @click="addCustomConfig"
+            :disabled="isAddCustomDisabled"
+            :title="getAddCustomTitle()"
+          >
+            {{ isAddingCustom ? "..." : "Add config…" }}
+          </vscode-button>
+        </div>
+        <p class="text-3xs text-editor-fg opacity-60 mt-1">
+          Point Bruin at any client using the standard <code>mcpServers</code> JSON config (e.g. CoCo).
+        </p>
+
+        <div class="mt-2 space-y-1.5">
+          <div
+            v-for="config in customConfigs"
+            :key="config.path"
+            class="rounded border border-commandCenter-border px-3 py-2"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <div class="flex items-center gap-2 min-w-0">
+                <span class="text-xs text-editor-fg truncate" :title="config.path">{{ config.label }}</span>
+                <span
+                  class="inline-flex items-center px-1.5 py-px rounded-sm text-3xs font-medium whitespace-nowrap border"
+                  :class="getStatusClass(config.status)"
+                >
+                  {{ MCP_STATUS_CONFIG[config.status]?.label ?? "Unknown" }}
+                </span>
+              </div>
+
+              <div class="flex items-center gap-1">
+                <span
+                  v-if="config.details"
+                  class="codicon codicon-info text-[10px] opacity-40 cursor-help hover:opacity-70"
+                  :title="config.details"
+                ></span>
+                <vscode-button
+                  appearance="secondary"
+                  class="mcp-btn"
+                  @click="toggleCustomConfig(config.path, config.configured)"
+                  :disabled="isCustomButtonDisabled(config.path)"
+                >
+                  {{ getCustomButtonLabel(config.path, config.configured) }}
+                </vscode-button>
+                <vscode-button
+                  appearance="icon"
+                  title="Forget this config"
+                  @click="removeCustomConfig(config.path)"
+                  :disabled="isCustomButtonDisabled(config.path)"
+                >
+                  <span class="codicon codicon-trash"></span>
+                </vscode-button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div
         v-if="mcpFeedbackMessage"
         class="mt-2 rounded border px-1.5 py-1 flex items-center justify-between gap-1"
@@ -153,7 +216,13 @@
 <script setup lang="ts">
 import { ref, onBeforeUnmount, onMounted, computed, watch } from "vue";
 import { vscode } from "@/utilities/vscode";
-import type { McpClientId, McpIntegrationStatus, McpVariant, McpIntegrationStatusType } from "@/types";
+import type {
+  McpClientId,
+  McpIntegrationStatus,
+  McpVariant,
+  McpIntegrationStatusType,
+  CustomMcpConfigStatus,
+} from "@/types";
 import {
   BRUIN_MCP_DOCS_URL,
   DEFAULT_MCP_STATUS,
@@ -194,6 +263,10 @@ const cloudApiToken = ref("");
 const hasCloudApiToken = ref(false);
 const isSavingToken = ref(false);
 const isClearingToken = ref(false);
+
+const customConfigs = ref<CustomMcpConfigStatus[]>([]);
+const isAddingCustom = ref(false);
+const togglingCustomPath = ref<string | null>(null);
 
 const STATUS_CLASSES: Record<McpIntegrationStatusType, string> = {
   checking: "bg-status-info-bg text-status-info-fg border-status-info-border",
@@ -256,6 +329,57 @@ function getButtonLabel(integrationId: McpClientId, isConfigured: boolean): stri
   return isConfigured ? "Disable" : "Enable";
 }
 
+const isAddCustomDisabled = computed(() => {
+  if (isAddingCustom.value) return true;
+  if (activeTab.value === "cloud" && !hasCloudApiToken.value) return true;
+  return false;
+});
+
+function getAddCustomTitle(): string {
+  if (activeTab.value === "cloud" && !hasCloudApiToken.value) {
+    return "Save API token first";
+  }
+  return "";
+}
+
+function isCustomButtonDisabled(configPath: string): boolean {
+  if (togglingCustomPath.value === configPath) return true;
+  if (activeTab.value === "cloud" && !hasCloudApiToken.value) return true;
+  return false;
+}
+
+function getCustomButtonLabel(configPath: string, isConfigured: boolean): string {
+  if (togglingCustomPath.value === configPath) return "...";
+  return isConfigured ? "Disable" : "Enable";
+}
+
+function addCustomConfig() {
+  isAddingCustom.value = true;
+  dismissMcpFeedback();
+  vscode.postMessage({
+    command: "bruin.addCustomMcpConfig",
+    payload: { variant: activeTab.value },
+  });
+}
+
+function toggleCustomConfig(configPath: string, isConfigured: boolean) {
+  togglingCustomPath.value = configPath;
+  dismissMcpFeedback();
+  vscode.postMessage({
+    command: "bruin.toggleCustomMcpConfig",
+    payload: { path: configPath, variant: activeTab.value, enable: !isConfigured },
+  });
+}
+
+function removeCustomConfig(configPath: string) {
+  togglingCustomPath.value = configPath;
+  dismissMcpFeedback();
+  vscode.postMessage({
+    command: "bruin.removeCustomMcpConfig",
+    payload: { path: configPath, variant: activeTab.value },
+  });
+}
+
 function handleMessage(event: MessageEvent) {
   const message = event.data;
   switch (message.command) {
@@ -294,6 +418,27 @@ function handleMessage(event: MessageEvent) {
       }
       break;
 
+    case "mcp-custom-config-status-message": {
+      const variant = message.payload?.variant as McpVariant | undefined;
+      if (variant && variant !== activeTab.value) break;
+      if (message.payload?.status === "success" && Array.isArray(message.payload?.message)) {
+        customConfigs.value = message.payload.message as CustomMcpConfigStatus[];
+      } else if (message.payload?.status === "error") {
+        showFeedback("error", message.payload?.message || "Failed to load custom MCP status.");
+      }
+      break;
+    }
+
+    case "mcp-custom-config-action-message":
+      isAddingCustom.value = false;
+      togglingCustomPath.value = null;
+      if (message.payload?.status === "success") {
+        showFeedback("success", message.payload?.message || "Custom MCP config updated.");
+      } else if (message.payload?.status === "error") {
+        showFeedback("error", message.payload?.message || "Failed to update custom MCP config.");
+      }
+      break;
+
     case "mcp-cloud-bearer-token-message":
       if (message.payload?.status === "success") {
         hasCloudApiToken.value = !!message.payload?.token;
@@ -315,6 +460,7 @@ function handleMessage(event: MessageEvent) {
 }
 
 function refreshMcpStatuses() {
+  customConfigs.value = [];
   if (activeTab.value === "bruin") {
     localMcpStatusByClient.value = { ...DEFAULT_MCP_STATUS };
     vscode.postMessage({ command: "bruin.getMcpIntegrationStatus", payload: { variant: "bruin" } });
@@ -383,6 +529,7 @@ function dismissMcpFeedback() {
 }
 
 watch(activeTab, (newTab) => {
+  customConfigs.value = [];
   if (newTab === "cloud") {
     cloudMcpStatusByClient.value = { ...DEFAULT_CLOUD_MCP_STATUS } as Partial<Record<McpClientId, McpIntegrationStatus>>;
     vscode.postMessage({ command: "bruin.getMcpIntegrationStatus", payload: { variant: "cloud" } });

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -270,3 +270,13 @@ export interface McpIntegrationStatus {
   configPath: string | null;
   details: string;
 }
+
+export interface CustomMcpConfigStatus {
+  path: string;
+  label: string;
+  status: McpIntegrationStatusType;
+  configured: boolean;
+  bruinAvailable: boolean;
+  exists: boolean;
+  details: string;
+}


### PR DESCRIPTION
Community request (BRU-5720): let users wire Bruin's MCP server into clients we don't ship a one-click button for, like Snowflake's CoCo.

Adds a **Custom clients** section to the Bruin MCP Integrations panel. Instead of hardcoding each new client, you point Bruin at any config file that uses the standard `mcpServers` JSON schema (CoCo, Windsurf, Zed, …) and enable/disable it there. Works for both the Local (`bruin mcp`) and Cloud variants, reusing the existing JSON config writers. Tracked paths persist in globalState so their status/enable state comes back on reload.

The built-in one-click clients (VS Code, Cursor, Codex, Claude) are unchanged.

## Testing
- New `src/test/mcpCustomConfig.test.ts` (8 tests): write/read/remove, dir creation, preserving unrelated servers, cloud bearer entry, missing-token error. Run: `MOCHA_GREP="Custom MCP config" npm test`.
- Verified end-to-end with a real MCP client: the file this feature writes is read by Claude Code and connects — `bruin: bruin mcp - ✓ Connected`.