### PR TITLE
fix: bump nanoid to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6387,9 +6387,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -2412,9 +2412,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Resolves the high-severity nanoid advisory (GHSA-2v37-7h3g-55p8) flagged in both lockfiles.

nanoid is a transitive dependency (pulled by postcss via `^3.3.16`), so this is a semver-compatible patch bump applied via `npm audit fix` in both the root and webview-ui projects. No package.json changes.

- package-lock.json: nanoid 3.3.17 → 3.3.18
- webview-ui/package-lock.json: nanoid 3.3.17 → 3.3.18

`npm audit` reports 0 vulnerabilities in both projects after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)