### PR TITLE
Add "+" button to open a new query connected to a database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [0.84.1]
-- Added a "+" button on databases in the Databases panel to open a new empty query already connected to that database, without having to pick a table and clear the generated SELECT.
+- Added a "+" button on databases in the Databases panel to open a new empty query connected to that database.
 
 ## [0.84.0]
 - Add Bruin MCP to any client that uses the standard `mcpServers` config (e.g. CoCo) by pointing at its config file, alongside the built-in one-click clients.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.84.1]
+- Added a "+" button on databases in the Databases panel to open a new empty query already connected to that database, without having to pick a table and clear the generated SELECT.
+
 ## [0.84.0]
 - Add Bruin MCP to any client that uses the standard `mcpServers` config (e.g. CoCo) by pointing at its config file, alongside the built-in one-click clients.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.84.1**: Added a "+" button on databases in the Databases panel to open a new empty query already connected to that database.
+- **0.84.1**: Added a "+" button on databases in the Databases panel to open a new empty query connected to that database.
 - **0.84.0**: Configure Bruin MCP for any client using the standard `mcpServers` config (e.g. CoCo) via a custom config path, alongside the built-in one-click clients.
 - **0.83.6**: Fixed column lineage not drawing edges (or highlighting on hover) for assets with uppercase letters in their names.
 - **0.83.5**: Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.84.1**: Added a "+" button on databases in the Databases panel to open a new empty query already connected to that database.
 - **0.84.0**: Configure Bruin MCP for any client using the standard `mcpServers` config (e.g. CoCo) via a custom config path, alongside the built-in one-click clients.
 - **0.83.6**: Fixed column lineage not drawing edges (or highlighting on hover) for assets with uppercase letters in their names.
 - **0.83.5**: Fixed column lineage not drawing edges (and hover highlighting nothing) when a query references its upstreams with a catalog-qualified name.

--- a/package.json
+++ b/package.json
@@ -327,6 +327,11 @@
           "group": "inline"
         },
         {
+          "command": "bruin.newQueryFromSchema",
+          "when": "view == bruinConnections && viewItem == 'schema'",
+          "group": "inline@1"
+        },
+        {
           "command": "bruin.refreshSchema",
           "when": "view == bruinConnections && viewItem == 'schema'",
           "group": "inline@2"
@@ -362,6 +367,13 @@
         "category": "Bruin",
         "icon": "$(refresh)",
         "description": "Refresh a single schema."
+      },
+      {
+        "command": "bruin.newQueryFromSchema",
+        "title": "New Query",
+        "category": "Bruin",
+        "icon": "$(add)",
+        "description": "Open a new empty query connected to this database."
       },
       {
         "command": "bruin.showConnectionDetails",

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -658,6 +658,21 @@ export async function activate(context: ExtensionContext) {
         vscode.window.showErrorMessage(`Error showing walkthrough: ${errorMessage}`);
       }
     }),
+    commands.registerCommand("bruin.newQueryFromSchema", (item: any) => {
+      try {
+        trackEvent("Command Executed", { command: "newQueryFromSchema", source: "user" });
+        if (item && item.itemData) {
+          TableDetailsPanel.renderNewQuery(
+            context.extensionUri,
+            item.itemData.connectionName,
+            item.itemData.environment
+          );
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Error opening new query: ${errorMessage}`);
+      }
+    }),
     commands.registerCommand(
       "bruin.showTableDetails",
       (tableName: string, schemaName?: string, connectionName?: string, environmentName?: string) => {

--- a/src/panels/TableDetailsPanel.ts
+++ b/src/panels/TableDetailsPanel.ts
@@ -88,6 +88,42 @@ import {
       }
     }
   
+    public static async renderNewQuery(extensionUri: Uri, connectionName?: string, environmentName?: string) {
+      try {
+        const workspaceFolder = workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+          throw new Error("Workspace folder not found");
+        }
+
+        const tempDir = path.join(workspaceFolder.uri.fsPath, "logs");
+        if (!fs.existsSync(tempDir)) {
+          fs.mkdirSync(tempDir, { recursive: true });
+        }
+
+        const tempFileName = `tmp_${Date.now()}.sql`;
+        const tempFilePath = path.join(tempDir, tempFileName);
+        this.tempFiles.add(tempFilePath);
+
+        let initialContent = `-- environment: ${environmentName || 'default'}\n`;
+        initialContent += `-- connection: ${connectionName || 'default'}\n\n`;
+
+        fs.writeFileSync(tempFilePath, initialContent);
+
+        const uri = Uri.file(tempFilePath);
+        const doc = await workspace.openTextDocument(uri);
+
+        await window.showTextDocument(doc, {
+          viewColumn: ViewColumn.One,
+          preview: false,
+          selection: new Range(new Position(2, 0), new Position(2, 0))
+        });
+
+        await QueryPreviewPanel.focusSafely();
+      } catch (error) {
+        window.showErrorMessage(`New query error: ${error}`);
+      }
+    }
+
     private static cleanup() {
       this.tempFiles.forEach(filePath => {
         try {


### PR DESCRIPTION
## What

Adds a `+` inline button on each database node in the Databases panel. Clicking it opens a fresh, empty query already connected to that database.

Previously, starting a query against a connection meant clicking a table (which generates a `SELECT * FROM ...`), then deleting that statement to write your own. This makes that a one-click action.

The new query is created with just the connection context header and the cursor ready on the empty line:

```sql
-- environment: dev
-- connection: fabric_silver

```

This reuses the existing comment-based connection detection, so running the query already knows which connection/environment to use.

## Changes

- `TableDetailsPanel.renderNewQuery()` — opens a temp `.sql` with only the connection/environment header (no `SELECT`) and focuses the Query Preview panel.
- Registered `bruin.newQueryFromSchema`, sourcing connection/environment from the clicked schema tree item.
- `package.json`: new command (icon `$(add)`) + inline `view/item/context` entry on schema nodes, ordered just left of the refresh icon.