### PR TITLE
chore: bump version to 0.84.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.84.0",
+      "version": "0.84.1",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "dacFrontend": {
     "repo": "bruin-data/dac",
     "version": "v0.13.2",


### PR DESCRIPTION
Bumps `package.json` / `package-lock.json` to `0.84.1` to match the CHANGELOG/README entries already merged in #828 (the "+" new-query button). The version bump was missed in that PR.