### PR TITLE
Add full refresh toggle to ingestr assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [Unreleased]
+## [0.84.2] - [2026-08-28]
 - Added a "Full Refresh" toggle to ingestr assets that sets `parameters.full_refresh: true`, so the asset always runs in full-refresh mode (e.g. for a periodic full load to detect deleted source records), independent of the run-time full-refresh checkbox.
 
 ## [0.84.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [Unreleased]
+- Added a "Full Refresh" toggle to ingestr assets that sets `parameters.full_refresh: true`, so the asset always runs in full-refresh mode (e.g. for a periodic full load to detect deleted source records), independent of the run-time full-refresh checkbox.
+
 ## [0.84.1]
 - Added a "+" button on databases in the Databases panel to open a new empty query connected to that database.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.84.2**: Added a "Full Refresh" toggle to ingestr assets that sets `parameters.full_refresh: true`, so the asset always runs in full-refresh mode (e.g. for a periodic full load to detect deleted source records), independent of the run-time full-refresh checkbox.
 - **0.84.1**: Added a "+" button on databases in the Databases panel to open a new empty query connected to that database.
 - **0.84.0**: Configure Bruin MCP for any client using the standard `mcpServers` config (e.g. CoCo) via a custom config path, alongside the built-in one-click clients.
 - **0.83.6**: Fixed column lineage not drawing edges (or highlighting on hover) for assets with uppercase letters in their names.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.84.1",
+  "version": "0.84.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.84.1",
+      "version": "0.84.2",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.84.1",
+  "version": "0.84.2",
   "dacFrontend": {
     "repo": "bruin-data/dac",
     "version": "v0.13.2",

--- a/schemas/yaml-assets-schema.json
+++ b/schemas/yaml-assets-schema.json
@@ -259,6 +259,10 @@
                 "default",
                 "direct"
               ]
+            },
+            "full_refresh": {
+              "type": "boolean",
+              "description": "When true, this asset always runs in full-refresh mode, even when the run does not use --full-refresh. Use full_refresh_restricted to opt an asset out of full-refresh runs."
             }
           },
           "additionalProperties": true,

--- a/webview-ui/src/components/asset/IngestrAssetDisplay.vue
+++ b/webview-ui/src/components/asset/IngestrAssetDisplay.vue
@@ -285,7 +285,7 @@
             </div>
 
             <!-- Empty state -->
-            <div v-if="!displayParams.source_connection && !displayParams.source_table && !displayParams.destination" class="text-xs text-editor-fg opacity-60 italic py-2 text-center">
+            <div v-if="!displayParams.source_connection && !displayParams.source_table && !displayParams.destination && !displayParams.full_refresh" class="text-xs text-editor-fg opacity-60 italic py-2 text-center">
               No parameters configured
             </div>
           </div>

--- a/webview-ui/src/components/asset/IngestrAssetDisplay.vue
+++ b/webview-ui/src/components/asset/IngestrAssetDisplay.vue
@@ -221,6 +221,38 @@
               </span>
             </div>
           </div>
+
+          <!-- Full Refresh -->
+          <div id="full-refresh-row" class="flex items-start gap-2">
+            <span
+              id="full-refresh-label"
+              class="text-2xs text-editor-fg opacity-70 min-w-[140px] pt-1"
+            >Full Refresh:</span>
+            <div id="full-refresh-field" class="flex-1 text-xs text-editor-fg">
+              <div class="flex items-center gap-2 px-2 py-1">
+                <button
+                  id="full-refresh-toggle"
+                  type="button"
+                  role="switch"
+                  :aria-checked="!!localParameters.full_refresh"
+                  @click="toggleFullRefresh"
+                  class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-1 focus:ring-editorLink-activeFg"
+                  :class="localParameters.full_refresh ? 'bg-button-bg' : 'bg-input-background border border-commandCenter-border'"
+                >
+                  <span
+                    class="inline-block h-3 w-3 transform rounded-full bg-editor-fg transition-transform duration-150"
+                    :class="localParameters.full_refresh ? 'translate-x-3.5' : 'translate-x-0.5'"
+                  ></span>
+                </button>
+                <span class="opacity-80">{{ localParameters.full_refresh ? 'Always full refresh' : 'Off' }}</span>
+                <span
+                  id="full-refresh-hint"
+                  class="codicon codicon-info text-[10px] opacity-40 cursor-help hover:opacity-70"
+                  title="When on, this asset always runs in full-refresh mode — even when the run doesn't use --full-refresh. Useful for a periodic full load (e.g. to detect deleted source records)."
+                ></span>
+              </div>
+            </div>
+          </div>
         </div>
 
         <!-- Rendered View (Read-only, default) -->
@@ -246,6 +278,10 @@
             <div v-if="displayParams.incremental_key" class="flex items-center gap-2">
               <span class="text-2xs text-editor-fg opacity-70 min-w-[140px]">Incremental Key:</span>
               <span class="text-xs text-editor-fg">{{ displayParams.incremental_key }}</span>
+            </div>
+            <div v-if="displayParams.full_refresh" class="flex items-center gap-2">
+              <span class="text-2xs text-editor-fg opacity-70 min-w-[140px]">Full Refresh:</span>
+              <span class="text-xs text-editor-fg">Always</span>
             </div>
 
             <!-- Empty state -->
@@ -291,6 +327,7 @@ const localParameters = ref<IngestrParameters>({
   destination: props.parameters?.destination || '',
   incremental_strategy: props.parameters?.incremental_strategy || '',
   incremental_key: props.parameters?.incremental_key || '',
+  full_refresh: props.parameters?.full_refresh || false,
 });
 
 const editingField = ref<Record<string, boolean>>({});
@@ -315,6 +352,7 @@ const displayParams = computed(() => {
     destination: local.destination ? destinationDisplayName(local.destination) : '',
     incremental_strategy: local.incremental_strategy || '',
     incremental_key: local.incremental_key || '',
+    full_refresh: local.full_refresh || false,
   };
 });
 
@@ -509,7 +547,18 @@ const saveParameters = () => {
     }
   });
 
+  // full_refresh is only meaningful when true; drop it otherwise so the YAML stays clean.
+  if (!localParameters.value.full_refresh) {
+    delete updatedParameters.full_refresh;
+  }
+
   emit('save', updatedParameters as IngestrParameters);
+};
+
+const toggleFullRefresh = () => {
+  localParameters.value.full_refresh = !localParameters.value.full_refresh;
+  isInternalUpdate.value = true;
+  saveParameters();
 };
 
 onMounted(() => {
@@ -679,6 +728,7 @@ watch(
         destination: newParameters.destination || '',
         incremental_strategy: newParameters.incremental_strategy || '',
         incremental_key: newParameters.incremental_key || '',
+        full_refresh: newParameters.full_refresh || false,
       };
 
       if (!isInternalUpdate.value) {

--- a/webview-ui/src/test/ingestrFullRefresh.test.ts
+++ b/webview-ui/src/test/ingestrFullRefresh.test.ts
@@ -12,9 +12,7 @@ const baseParams = {
   destination: "postgres",
 };
 
-// The repo's test setup (setup.ts) creates a second JSDOM that breaks
-// querySelector on freshly-mounted components, so we drive the toggle through
-// the component's setup state rather than clicking the rendered checkbox.
+// Drive the toggle via setup state (DOM queries are unreliable in this harness).
 const setup = (wrapper: any) => (wrapper.vm as any).$.setupState;
 
 describe("IngestrAssetDisplay full_refresh", () => {
@@ -54,5 +52,13 @@ describe("IngestrAssetDisplay full_refresh", () => {
       props: { parameters: { ...baseParams, full_refresh: true }, columns: [] },
     });
     expect(on.text()).toContain("Full Refresh:");
+  });
+
+  it("does not show the empty state when full_refresh is the only parameter", () => {
+    const wrapper = mount(IngestrAssetDisplay, {
+      props: { parameters: { full_refresh: true }, columns: [] },
+    });
+    expect(wrapper.text()).toContain("Full Refresh:");
+    expect(wrapper.text()).not.toContain("No parameters configured");
   });
 });

--- a/webview-ui/src/test/ingestrFullRefresh.test.ts
+++ b/webview-ui/src/test/ingestrFullRefresh.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import IngestrAssetDisplay from "@/components/asset/IngestrAssetDisplay.vue";
+
+vi.mock("@/utilities/vscode", () => ({
+  vscode: { postMessage: vi.fn(), getState: vi.fn(), setState: vi.fn() },
+}));
+
+const baseParams = {
+  source_connection: "jira-conn",
+  source_table: "issues",
+  destination: "postgres",
+};
+
+// The repo's test setup (setup.ts) creates a second JSDOM that breaks
+// querySelector on freshly-mounted components, so we drive the toggle through
+// the component's setup state rather than clicking the rendered checkbox.
+const setup = (wrapper: any) => (wrapper.vm as any).$.setupState;
+
+describe("IngestrAssetDisplay full_refresh", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("toggling on emits save with full_refresh: true and preserves other params", () => {
+    const wrapper = mount(IngestrAssetDisplay, {
+      props: { parameters: { ...baseParams }, columns: [] },
+    });
+
+    setup(wrapper).toggleFullRefresh();
+
+    const payload = (wrapper.emitted("save") as any[])!.at(-1)![0];
+    expect(payload.full_refresh).toBe(true);
+    expect(payload.source_table).toBe("issues");
+    expect(payload.destination).toBe("postgres");
+  });
+
+  it("toggling off drops full_refresh from the saved parameters", () => {
+    const wrapper = mount(IngestrAssetDisplay, {
+      props: { parameters: { ...baseParams, full_refresh: true }, columns: [] },
+    });
+
+    setup(wrapper).toggleFullRefresh();
+
+    const payload = (wrapper.emitted("save") as any[])!.at(-1)![0];
+    expect("full_refresh" in payload).toBe(false);
+  });
+
+  it("shows the read-only full refresh row only when enabled", () => {
+    const off = mount(IngestrAssetDisplay, {
+      props: { parameters: { ...baseParams }, columns: [] },
+    });
+    expect(off.text()).not.toContain("Full Refresh:");
+
+    const on = mount(IngestrAssetDisplay, {
+      props: { parameters: { ...baseParams, full_refresh: true }, columns: [] },
+    });
+    expect(on.text()).toContain("Full Refresh:");
+  });
+});

--- a/webview-ui/src/types/index.ts
+++ b/webview-ui/src/types/index.ts
@@ -228,6 +228,7 @@ export interface IngestrParameters {
   destination: string;
   incremental_strategy?: string;
   incremental_key?: string;
+  full_refresh?: boolean;
 }
 
 export interface PipelineColumnInfo {


### PR DESCRIPTION
Adds a **Full Refresh** toggle to the ingestr asset panel. When enabled it writes `parameters.full_refresh: true`, so the asset always runs in full-refresh mode — even when the run doesn't use the `--full-refresh` flag. This is the declarative, per-asset counterpart to the run-time Full-Refresh checkbox, and covers use cases like a weekly full load to detect records deleted at the source (e.g. Jira issues that disappear from the API).

Backed by the CLI's `parameters.full_refresh` support (bruin-data/bruin#2586, shipped in CLI v0.11.732).

### Changes
- **Schema**: add `full_refresh` (boolean) under `parameters` so it gets autocomplete + docs in YAML editing.
- **Ingestr panel**: a slide toggle in edit mode (with an info tooltip) and a "Full Refresh: Always" row in the read-only view.
- **Save behavior**: writing `true` adds the param; toggling off removes the key entirely — matches CLI semantics, where an absent key and `false` are equivalent (no distinct meaning for explicit `false`).
- Types + unit tests.

### Notes
- No extension-host changes needed: parameters persist through the generic `patch-asset --body` path.
- The run command itself is unchanged — the CLI reads the param from the YAML and applies full-refresh internally.

### Not included (follow-ups)
- Version gate for users on a CLI older than v0.11.732 (the toggle writes the param regardless; an old CLI silently ignores it). Auto-update covers most users.
- A cross-reference near the run-time Full-Refresh checkbox so an unchecked box on an always-full-refresh asset isn't confusing.