### PR TITLE
fix: refresh asset panel immediately on editor switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [0.84.3]
-- Fixed the asset panel showing stale content when switching between open assets (most noticeable on Windows) — it now refreshes immediately instead of needing the Bruin tab closed and reopened.
+- Fixed the asset panel showing stale content when switching between open assets (most noticeable on Windows) — it now refreshes immediately instead of needing the Bruin tab closed and reopened, and switching between assets is faster (the asset is parsed once per switch instead of twice).
 
 ## [0.84.2] - [2026-08-28]
 - Added a "Full Refresh" toggle to ingestr assets that sets `parameters.full_refresh: true`, so the asset always runs in full-refresh mode (e.g. for a periodic full load to detect deleted source records), independent of the run-time full-refresh checkbox.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.84.3]
+- Fixed the asset panel showing stale content when switching between open assets (most noticeable on Windows) — it now refreshes immediately instead of needing the Bruin tab closed and reopened.
+
 ## [0.84.2] - [2026-08-28]
 - Added a "Full Refresh" toggle to ingestr assets that sets `parameters.full_refresh: true`, so the asset always runs in full-refresh mode (e.g. for a periodic full load to detect deleted source records), independent of the run-time full-refresh checkbox.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
+- **0.84.3**: Fixed the asset panel showing stale content when switching between open assets (most noticeable on Windows) — it now refreshes immediately instead of needing the Bruin tab closed and reopened.
 - **0.84.2**: Added a "Full Refresh" toggle to ingestr assets that sets `parameters.full_refresh: true`, so the asset always runs in full-refresh mode (e.g. for a periodic full load to detect deleted source records), independent of the run-time full-refresh checkbox.
 - **0.84.1**: Added a "+" button on databases in the Databases panel to open a new empty query connected to that database.
 - **0.84.0**: Configure Bruin MCP for any client using the standard `mcpServers` config (e.g. CoCo) via a custom config path, alongside the built-in one-click clients.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installing, run the **Bruin: Show Getting Started Walkthrough** command fr
 ## Release Notes
 
 ### Recent Update
-- **0.84.3**: Fixed the asset panel showing stale content when switching between open assets (most noticeable on Windows) — it now refreshes immediately instead of needing the Bruin tab closed and reopened.
+- **0.84.3**: Fixed the asset panel showing stale content when switching between open assets (most noticeable on Windows) — it now refreshes immediately instead of needing the Bruin tab closed and reopened, and switching between assets is faster (the asset is parsed once per switch instead of twice).
 - **0.84.2**: Added a "Full Refresh" toggle to ingestr assets that sets `parameters.full_refresh: true`, so the asset always runs in full-refresh mode (e.g. for a periodic full load to detect deleted source records), independent of the run-time full-refresh checkbox.
 - **0.84.1**: Added a "+" button on databases in the Databases panel to open a new empty query connected to that database.
 - **0.84.0**: Configure Bruin MCP for any client using the standard `mcpServers` config (e.g. CoCo) via a custom config path, alongside the built-in one-click clients.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bruin",
-  "version": "0.84.2",
+  "version": "0.84.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bruin",
-      "version": "0.84.2",
+      "version": "0.84.3",
       "dependencies": {
         "@rudderstack/analytics-js": "^3.11.15",
         "@rudderstack/rudder-sdk-node": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bruin",
   "displayName": "Bruin",
   "description": "Manage your Bruin data assets from within VS Code.",
-  "version": "0.84.2",
+  "version": "0.84.3",
   "dacFrontend": {
     "repo": "bruin-data/dac",
     "version": "v0.13.2",

--- a/src/bruin/bruinInternalParse.ts
+++ b/src/bruin/bruinInternalParse.ts
@@ -4,6 +4,10 @@ import { BruinPanel } from "../panels/BruinPanel";
 import { BruinLineageInternalParse } from "./bruinFlowLineage";
 
 export class BruinInternalParse extends BruinCommand {
+  // Result cached by checkIfAsset so a following parseAsset for the same file
+  // reuses it instead of spawning the CLI a second time (asset-switch latency).
+  private _prefetchedParse?: { filePath: string; raw: string };
+
   protected bruinCommand(): string {
     return "internal";
   }
@@ -37,6 +41,15 @@ export class BruinInternalParse extends BruinCommand {
       if (filePath.endsWith("bruin.yml") || filePath.endsWith("bruin.yaml")) {
         const result = JSON.stringify({ type: "bruinConfig", filePath });
         this.postMessageToPanels("success", result);
+        console.timeEnd("parseAsset");
+        return;
+      }
+
+      // Reuse a result already fetched by checkIfAsset for this same file.
+      if (this._prefetchedParse && this._prefetchedParse.filePath === filePath) {
+        const raw = this._prefetchedParse.raw;
+        this._prefetchedParse = undefined;
+        this.postMessageToPanels("success", raw);
         console.timeEnd("parseAsset");
         return;
       }
@@ -97,7 +110,9 @@ export class BruinInternalParse extends BruinCommand {
       }
 
       const parsed = JSON.parse(result);
-      console.log("checkIfAsset: CLI result parsed:", { 
+      // Cache the verified-JSON result so a following parseAsset can reuse it.
+      this._prefetchedParse = { filePath, raw: result };
+      console.log("checkIfAsset: CLI result parsed:", {
         hasAsset: parsed.asset !== null && parsed.asset !== undefined,
         assetValue: parsed.asset 
       });

--- a/src/bruin/bruinInternalParse.ts
+++ b/src/bruin/bruinInternalParse.ts
@@ -17,7 +17,18 @@ export class BruinInternalParse extends BruinCommand {
       if (filePath.endsWith("pipeline.yml") || filePath.endsWith("pipeline.yaml")) {
         const parser = new BruinLineageInternalParse(this.bruinExecutable, this.workingDirectory);
 
-        const pipelineMeta = await parser.parsePipelineConfig(filePath);
+        // Bound the parse so a hung CLI process still surfaces an error, but give
+        // real pipelines room to finish — the previous 300ms cap failed almost
+        // every non-trivial pipeline and left the panel showing stale content.
+        let timeout: NodeJS.Timeout | undefined;
+        const pipelineMeta = await Promise.race([
+          parser.parsePipelineConfig(filePath),
+          new Promise((_, reject) => {
+            timeout = setTimeout(() => reject(new Error("Parsing timeout")), 30000);
+          })
+        ]).finally(() => {
+          if (timeout) { clearTimeout(timeout); }
+        });
 
         const result = JSON.stringify({ type: "pipelineConfig", ...pipelineMeta, filePath });
         this.postMessageToPanels("success", result);

--- a/src/bruin/bruinInternalParse.ts
+++ b/src/bruin/bruinInternalParse.ts
@@ -17,9 +17,7 @@ export class BruinInternalParse extends BruinCommand {
       if (filePath.endsWith("pipeline.yml") || filePath.endsWith("pipeline.yaml")) {
         const parser = new BruinLineageInternalParse(this.bruinExecutable, this.workingDirectory);
 
-        // Bound the parse so a hung CLI process still surfaces an error, but give
-        // real pipelines room to finish — the previous 300ms cap failed almost
-        // every non-trivial pipeline and left the panel showing stale content.
+        // 30s deadline so a hung CLI surfaces an error without failing real pipelines.
         let timeout: NodeJS.Timeout | undefined;
         const pipelineMeta = await Promise.race([
           parser.parsePipelineConfig(filePath),

--- a/src/bruin/bruinInternalParse.ts
+++ b/src/bruin/bruinInternalParse.ts
@@ -16,13 +16,9 @@ export class BruinInternalParse extends BruinCommand {
     try {
       if (filePath.endsWith("pipeline.yml") || filePath.endsWith("pipeline.yaml")) {
         const parser = new BruinLineageInternalParse(this.bruinExecutable, this.workingDirectory);
-        
-        // Use Promise.race to limit parsing time
-        const pipelineMeta = await Promise.race([
-          parser.parsePipelineConfig(filePath),
-          new Promise((_, reject) => setTimeout(() => reject(new Error("Parsing timeout")), 300))
-        ]);
-        
+
+        const pipelineMeta = await parser.parsePipelineConfig(filePath);
+
         const result = JSON.stringify({ type: "pipelineConfig", ...pipelineMeta, filePath });
         this.postMessageToPanels("success", result);
         console.timeEnd("parseAsset");

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -1882,7 +1882,13 @@ export class BruinPanel {
         return;
       }
 
-      const isAsset = await this._isAssetFile(filePath);
+      // One parser shared between the asset check and the render, so parseAsset
+      // reuses checkIfAsset's result instead of spawning the CLI a second time.
+      const parser = new BruinInternalParse(
+        getBruinExecutablePath(),
+        vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || ""
+      );
+      const isAsset = await this._isAssetFile(filePath, parser);
       if (this._assetDetectionGeneration !== generation) { return; }
       console.log("_performAssetDetection: CLI determined file is an asset:", filePath, isAsset);
       if (isAsset) {
@@ -1893,7 +1899,7 @@ export class BruinPanel {
         });
         console.log("_performAssetDetection: Sending clear message to the UI for asset:", filePath);
         if (this._cliInstalled) {
-          parseAssetCommand(fileUri);
+          parser.parseAsset(filePath);
         }
         return;
       }
@@ -1918,7 +1924,7 @@ export class BruinPanel {
           filePath: filePath,
         });
         if (this._cliInstalled) {
-          parseAssetCommand(fileUri);
+          parser.parseAsset(filePath);
         }
       }
     } catch (error) {
@@ -1991,7 +1997,7 @@ export class BruinPanel {
     }
   }
 
-  private async _isAssetFile(filePath: string): Promise<boolean> {
+  private async _isAssetFile(filePath: string, parser?: BruinInternalParse): Promise<boolean> {
 
     try {
       // For YAML files, check if file already has .asset.yml or .asset.yaml extension first
@@ -2001,14 +2007,15 @@ export class BruinPanel {
         return true;
       }
 
-      // Primary method: Use CLI internal parse command
+      // Primary method: Use CLI internal parse command. Reuse the caller's parser
+      // so parseAsset can share checkIfAsset's result and skip a second CLI spawn.
       const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || "";
-      const parser = new BruinInternalParse(
+      const assetParser = parser ?? new BruinInternalParse(
         getBruinExecutablePath(),
         workspaceFolder
       );
-      
-      const isAsset = await parser.checkIfAsset(filePath);
+
+      const isAsset = await assetParser.checkIfAsset(filePath);
       console.log(`_isAssetFile: CLI asset check result for ${filePath}: ${isAsset}`);
       
       if (isAsset) {

--- a/src/panels/BruinPanel.ts
+++ b/src/panels/BruinPanel.ts
@@ -92,6 +92,7 @@ export class BruinPanel {
   private _flags: string = "";
   private _assetDetectionDebounceTimer: NodeJS.Timeout | undefined;
   private _assetDetectionGeneration: number = 0;
+  private _lastDetectedFilePath: string | undefined;
   private _renderDebounceTimer: NodeJS.Timeout | undefined;
   private _cliInstalled: boolean | null = null;
   private _initialSettingsOnlyMode: boolean = false;
@@ -1841,7 +1842,8 @@ export class BruinPanel {
     // Increment generation to invalidate any in-flight detection
     const generation = ++this._assetDetectionGeneration;
 
-    const isFileSwitch = this._lastRenderedDocumentUri?.fsPath !== filePath;
+    const isFileSwitch = this._lastDetectedFilePath !== filePath;
+    this._lastDetectedFilePath = filePath;
 
     if (isFileSwitch) {
       await this._performAssetDetection(filePath, fileUri, generation);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -2201,8 +2201,7 @@ suite("BruinPanel Tests", () => {
       await (panel as any)._handleAssetDetection(fileA);
       await (panel as any)._handleAssetDetection(fileB);
 
-      // Both are switches to a new file, so detection runs synchronously
-      // instead of taking the 500ms debounce path (the listener-ordering bug).
+      // A switch runs detection synchronously, not via the 500ms debounce.
       assert.strictEqual(performStub.callCount, 2, "each switch should run detection immediately");
       sinon.assert.calledWith(performStub.secondCall, fileB.fsPath, fileB);
     });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -4067,9 +4067,36 @@ suite(" Query export Tests", () => {
       sinon.assert.calledOnce(consoleTimeEndStub);
     });
 
+    test("parseAsset reuses checkIfAsset's result without a second CLI call", async () => {
+      const filePath = "path/to/assets/raw_orders.sql";
+      const raw = JSON.stringify({ asset: { name: "raw_orders" }, pipeline: { name: "p" } });
+      runStub.resolves(raw);
+
+      const isAsset = await bruinInternalParse.checkIfAsset(filePath);
+      assert.strictEqual(isAsset, true);
+      sinon.assert.calledOnce(runStub); // checkIfAsset ran the CLI once
+
+      await bruinInternalParse.parseAsset(filePath);
+
+      // parseAsset reused the cached result instead of spawning the CLI again
+      sinon.assert.calledOnce(runStub);
+      sinon.assert.calledWith(postMessageToPanelsStub, "success", raw);
+    });
+
+    test("parseAsset does a fresh CLI call when no result was prefetched", async () => {
+      const filePath = "path/to/assets/raw_orders.sql";
+      const raw = JSON.stringify({ asset: { name: "raw_orders" } });
+      runStub.resolves(raw);
+
+      await bruinInternalParse.parseAsset(filePath);
+
+      sinon.assert.calledOnce(runStub);
+      sinon.assert.calledWith(runStub, ["parse-asset", filePath], { ignoresErrors: false });
+    });
+
     test("should handle bruin.yml files", async () => {
       const filePath = "path/to/bruin.yml";
-      
+
       await bruinInternalParse.parseAsset(filePath);
       
       sinon.assert.calledOnce(postMessageToPanelsStub);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -4019,15 +4019,15 @@ suite(" Query export Tests", () => {
       sinon.assert.calledWith(parsePipelineConfigStub, filePath);
     });
 
-    test("should handle pipeline parsing timeout", async () => {
+    test("should surface pipeline parsing errors", async () => {
       const filePath = "path/to/pipeline.yml";
-      
-      parsePipelineConfigStub.rejects(new Error("Parsing timeout"));
-      
+
+      parsePipelineConfigStub.rejects(new Error("parse failed"));
+
       await bruinInternalParse.parseAsset(filePath);
-      
+
       sinon.assert.calledOnce(postMessageToPanelsStub);
-      sinon.assert.calledWith(postMessageToPanelsStub, "error", "Parsing timeout");
+      sinon.assert.calledWith(postMessageToPanelsStub, "error", "parse failed");
       sinon.assert.calledOnce(consoleTimeEndStub);
     });
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -2184,6 +2184,43 @@ suite("BruinPanel Tests", () => {
     });
   });
 
+  suite("Asset detection on editor switch", () => {
+    let panel: BruinPanel;
+    setup(() => {
+      BruinPanel.render(mockExtensionUri);
+      panel = BruinPanel.currentPanel!;
+    });
+
+    test("switching to a different file runs detection immediately", async () => {
+      const performStub = sinon
+        .stub(panel as any, "_performAssetDetection")
+        .resolves();
+      const fileA = vscode.Uri.file("/mock/assets/a.sql");
+      const fileB = vscode.Uri.file("/mock/assets/b.sql");
+
+      await (panel as any)._handleAssetDetection(fileA);
+      await (panel as any)._handleAssetDetection(fileB);
+
+      // Both are switches to a new file, so detection runs synchronously
+      // instead of taking the 500ms debounce path (the listener-ordering bug).
+      assert.strictEqual(performStub.callCount, 2, "each switch should run detection immediately");
+      sinon.assert.calledWith(performStub.secondCall, fileB.fsPath, fileB);
+    });
+
+    test("re-triggering the same file defers behind the debounce timer", async () => {
+      const performStub = sinon
+        .stub(panel as any, "_performAssetDetection")
+        .resolves();
+      const file = vscode.Uri.file("/mock/assets/a.sql");
+
+      await (panel as any)._handleAssetDetection(file); // switch → immediate
+      assert.strictEqual(performStub.callCount, 1, "first detection should run immediately");
+
+      await (panel as any)._handleAssetDetection(file); // same file → debounced, not immediate
+      assert.strictEqual(performStub.callCount, 1, "same-file re-trigger should not run synchronously");
+    });
+  });
+
   suite("Message Handling", () => {
     let panel: BruinPanel;
     let messageHandler: (message: any) => void;


### PR DESCRIPTION
Switching between open assets left the Bruin panel showing stale content — often for a minute or more on Windows — until the tab was closed and reopened. Two bugs caused it:

- **Pipeline parse raced a 300ms timeout.** Switching to a `pipeline.yml` raced the parse against a 300ms deadline; any real pipeline lost it, threw `Parsing timeout`, and the panel got an error instead of fresh data, so it kept showing the previous asset. The cap gave no benefit (the parse is fire-and-forget and never blocked the UI). Removed it.
- **`isFileSwitch` was always false.** It compared against `_lastRenderedDocumentUri`, but the editor-switch and save listeners overwrite that field *before* calling detection — so every switch took the 500ms debounce branch (with a focus-guard that could drop the update entirely) instead of the immediate path. Detection now tracks its own last file, so a genuine switch runs immediately.

Windows was the amplifier, not the root: both bugs are cross-platform, but slower process spawn plus AV scanning the CLI on cold start stretched the stall to a minute+.

Updated the one unit test that asserted the old timeout string; it now covers error propagation.

Follow-ups intentionally left out to keep this small: `BruinCommand.run` has no `execFile` timeout (a truly hung CLI still blocks), and each switch runs `parse-asset` twice.